### PR TITLE
Tag versions and releases in git, and use them for Docker deployments

### DIFF
--- a/Jenkinsfile-deploy
+++ b/Jenkinsfile-deploy
@@ -4,34 +4,24 @@ pipeline {
   }
   parameters {
     choice(name: "STAGE", choices: ["intg", "staging", "prod"], description: "The stage you are building the api for")
+    string(name: "TO_DEPLOY", description: "The git tag, branch or commit reference to deploy, e.g. 'v123'")
   }
   stages {
-    stage("Build") {
-        agent {
-            ecs {
-                inheritFrom "transfer-frontend"
-            }
-        }
-        steps {
-            sh 'sbt -no-colors test scalastyle assembly'
-            stash includes: "Dockerfile", name: "Dockerfile"
-            stash includes: "target/scala-2.13/consignmentapi.jar", name: "tdr-consignment-api"
-        }
-    }
     stage("Docker") {
-        agent {
-            label "master"
+      agent {
+        label "master"
+      }
+      steps {
+        script {
+          docker.withRegistry('', 'docker') {
+            sh "docker pull nationalarchives/consignment-api:${params.TO_DEPLOY}"
+            sh "docker tag nationalarchives/consignment-api:${params.TO_DEPLOY} nationalarchives/consignment-api:${params.STAGE}"
+            sh "docker push nationalarchives/consignment-api:${params.STAGE}"
+
+            slackSend color: "good", message: "The Consignment API ${params.STAGE} tag has been upated to the ${params.TO_DEPLOY} version in Docker Hub", channel: "#tdr"
+          }
         }
-        steps {
-            unstash "tdr-consignment-api"
-            unstash "Dockerfile"
-            script {
-                docker.withRegistry('', 'docker') {
-                    docker.build("nationalarchives/consignment-api:${params.STAGE}").push()
-                    slackSend color: "good", message: "The api has been pushed to docker hub", channel: "#tdr"
-                }
-            }
-        }
+      }
     }
     stage("Update ECS container") {
         agent {

--- a/Jenkinsfile-deploy
+++ b/Jenkinsfile-deploy
@@ -13,14 +13,9 @@ pipeline {
             }
         }
         steps {
-            sh 'sbt -no-colors graphqlSchemaGen scalastyle assembly'
+            sh 'sbt -no-colors test scalastyle assembly'
             stash includes: "Dockerfile", name: "Dockerfile"
             stash includes: "target/scala-2.13/consignmentapi.jar", name: "tdr-consignment-api"
-            script {
-                schema = sh(script: "cat target/sbt-graphql/schema.graphql", returnStdout: true).trim()
-                build job: 'TDR Graphql Code Generation', parameters: [[$class: 'StringParameterValue', name: 'STAGE', value: params.STAGE], [$class: 'StringParameterValue', name: 'SCHEMA', value: schema]]
-            }
-
         }
     }
     stage("Docker") {

--- a/Jenkinsfile-testing
+++ b/Jenkinsfile-testing
@@ -13,5 +13,61 @@ pipeline {
             sh 'sbt -no-colors test scalastyle test:scalastyle'
         }
     }
+    stage('Post-build') {
+      agent {
+        label "master"
+      }
+      when {
+        expression { env.BRANCH_NAME == "master"}
+      }
+      stages {
+        stage('Tag Release') {
+          steps {
+            sh "git tag ${versionTag}"
+            sshagent(['github-jenkins']) {
+              sh("git push origin ${versionTag}")
+            }
+          }
+        }
+        stage("Build Docker image") {
+          agent {
+            ecs {
+              inheritFrom "transfer-frontend"
+            }
+          }
+          steps {
+            sh 'sbt -no-colors test scalastyle assembly'
+            stash includes: "Dockerfile", name: "Dockerfile"
+            stash includes: "target/scala-2.13/consignmentapi.jar", name: "tdr-consignment-api"
+          }
+        }
+        stage("Push Docker image") {
+          agent {
+            label "master"
+          }
+          steps {
+            unstash "tdr-consignment-api"
+            unstash "Dockerfile"
+            script {
+              docker.withRegistry('', 'docker') {
+                docker.build("nationalarchives/consignment-api:${versionTag}").push()
+                slackSend color: "good", message: "Pushed version ${versionTag} of the Consignment API to Docker Hub", channel: "#tdr"
+              }
+            }
+          }
+        }
+        stage('Deploy to integration') {
+          steps {
+            build(
+                job: "TDR Consignment API Deploy",
+                parameters: [
+                    string(name: "STAGE", value: "intg"),
+                    string(name: "TO_DEPLOY", value: versionTag)
+                ],
+                wait: false)
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Update the Jenkinsfiles to handle deployments in the same way as the frontend app:

- When code is merged to master, the Jenkins test build tags the current commit with a version tag, builds the Docker image and pushes it to Docker hub with the same version tag
- When a deployment build is run, Jenkins re-tags the Docker image with the environment name, deploys it to ECS and updates the release branch tag
- The master branch build triggers a deployment to integration if the build succeeds