### PR TITLE
Change merge strategy to prevent duplicates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,9 +65,7 @@ assemblyJarName in assembly := "consignmentapi.jar"
 
 assemblyMergeStrategy in assembly := {
   case PathList("META-INF", xs @ _*) => MergeStrategy.discard
-  case x =>
-    val oldStrategy = (assemblyMergeStrategy in assembly).value
-    oldStrategy(x)
+  case _ => MergeStrategy.first
 }
 
 mainClass in assembly := Some("uk.gov.nationalarchives.tdr.api.http.ApiServer")


### PR DESCRIPTION
sbt assembly merge strategy changed to prevent duplicated dependencies which cause assembly to fail