### PR TITLE
Parameterise database port

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -8,7 +8,7 @@ consignmentapi = {
     connectionPool = "HikariCP"
     driver = "com.mysql.cj.jdbc.Driver",
     url = "jdbc:mysql://localhost:3306/consignmentapi?useSSL=false",
-    url = "jdbc:mysql://"${?DB_ADDR}":3306/consignmentapi",
+    url = "jdbc:mysql://"${?DB_ADDR}":"${?DB_PORT}"/consignmentapi",
     user = "root",
     user = ${?DB_USER}
     password = "password",


### PR DESCRIPTION
Allow developers to override the default database port with an environment variable. Some developers are running MySQL natively for another project, so they might want to run MySQL in Docker on a non-default port.