### PR TITLE
Changes to the type checking.

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/Tags.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/Tags.scala
@@ -51,12 +51,12 @@ object Tags {
     }
   }
 
-  case class ValidateUserOwnsConsignment[T](argName: String, argument: Argument[T]) extends ValidateTags {
+  case class ValidateUserOwnsConsignment[T](argument: Argument[T]) extends ValidateTags {
     override def validate(ctx: Context[ConsignmentApiContext, _]): BeforeFieldResult[ConsignmentApiContext, Unit] = {
       val token = ctx.ctx.accessToken
       val userId = token.userId.getOrElse("")
 
-      val arg: T = ctx.arg[T](argName)
+      val arg: T = ctx.arg[T](argument.name)
       val consignmentId: Long = arg match {
         case uoc: UserOwnsConsignment => uoc.consignmentId
         case id: Long => id

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/Tags.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/Tags.scala
@@ -1,11 +1,12 @@
 package uk.gov.nationalarchives.tdr.api.graphql
 
 import sangria.execution.{BeforeFieldResult, FieldTag}
-import sangria.schema.Context
+import sangria.schema.{Argument, Context}
 import uk.gov.nationalarchives.tdr.api.auth.ValidationAuthoriser.{AuthorisationException, continue}
 import uk.gov.nationalarchives.tdr.api.graphql.fields.ConsignmentFields.Consignment
 import uk.gov.nationalarchives.tdr.api.graphql.validation.UserOwnsConsignment
 
+import scala.Long
 import scala.concurrent._
 import scala.concurrent.duration._
 import scala.language.postfixOps
@@ -50,15 +51,15 @@ object Tags {
     }
   }
 
-  case class ValidateUserOwnsConsignment(argName: String) extends ValidateTags {
+  case class ValidateUserOwnsConsignment[T](argName: String, argument: Argument[T]) extends ValidateTags {
     override def validate(ctx: Context[ConsignmentApiContext, _]): BeforeFieldResult[ConsignmentApiContext, Unit] = {
       val token = ctx.ctx.accessToken
       val userId = token.userId.getOrElse("")
 
-      // Consignment id is either inside a case class extending UserOwnsConsignment or is a Long argument
-      val consignmentId: Long = Try(ctx.arg[UserOwnsConsignment](argName)) match {
-        case Success(value) => value.consignmentId
-        case Failure(_) => ctx.arg[Long](argName)
+      val arg: T = ctx.arg[T](argName)
+      val consignmentId: Long = arg match {
+        case uoc: UserOwnsConsignment => uoc.consignmentId
+        case id: Long => id
       }
 
       val result = ctx.ctx.consignmentService.getConsignment(consignmentId)

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/TransferAgreementFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/TransferAgreementFields.scala
@@ -38,13 +38,13 @@ object TransferAgreementFields {
     Field("addTransferAgreement", TransferAgreementType,
       arguments=TransferAgreementInputArg :: Nil,
       resolve = ctx => ctx.ctx.transferAgreementService.addTransferAgreement(ctx.arg(TransferAgreementInputArg)),
-      tags=List(ValidateUserOwnsConsignment("addTransferAgreementInput"))
+      tags=List(ValidateUserOwnsConsignment("addTransferAgreementInput", TransferAgreementInputArg))
     ))
 
   val queryFields: List[Field[ConsignmentApiContext, Unit]] = fields[ConsignmentApiContext, Unit](
     Field("getTransferAgreement", OptionType(TransferAgreementType),
       arguments=ConsignmentIdArg :: Nil,
       resolve = ctx => ctx.ctx.transferAgreementService.getTransferAgreement(ctx.arg(ConsignmentIdArg)),
-      tags=List(ValidateUserOwnsConsignment("consignmentid"))
+      tags=List(ValidateUserOwnsConsignment("consignmentid", ConsignmentIdArg))
     ))
 }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/TransferAgreementFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/TransferAgreementFields.scala
@@ -38,13 +38,13 @@ object TransferAgreementFields {
     Field("addTransferAgreement", TransferAgreementType,
       arguments=TransferAgreementInputArg :: Nil,
       resolve = ctx => ctx.ctx.transferAgreementService.addTransferAgreement(ctx.arg(TransferAgreementInputArg)),
-      tags=List(ValidateUserOwnsConsignment("addTransferAgreementInput", TransferAgreementInputArg))
+      tags=List(ValidateUserOwnsConsignment(TransferAgreementInputArg))
     ))
 
   val queryFields: List[Field[ConsignmentApiContext, Unit]] = fields[ConsignmentApiContext, Unit](
     Field("getTransferAgreement", OptionType(TransferAgreementType),
       arguments=ConsignmentIdArg :: Nil,
       resolve = ctx => ctx.ctx.transferAgreementService.getTransferAgreement(ctx.arg(ConsignmentIdArg)),
-      tags=List(ValidateUserOwnsConsignment("consignmentid", ConsignmentIdArg))
+      tags=List(ValidateUserOwnsConsignment(ConsignmentIdArg))
     ))
 }


### PR DESCRIPTION
I merged the changes to create the getTransferAgreement query on the api
and left the type checking using a Try and then assuming a Long value if
there was an exception.

It turns out that there is a better way and you can use the type on the
argument.