### PR TITLE
Get consignment creator from token

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ cd tdr-consignment-api-data.git
 sbt flywayMigrate
 ```
 
-Run the api
+Run the api:
 
-`sbt run`
+* From IntelliJ, run the ApiServer app
+* Or from the command line, run `sbt run`
 
 #### Generate Graphql Schema Locally
 

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentFields.scala
@@ -11,7 +11,7 @@ import uk.gov.nationalarchives.tdr.api.graphql.fields.FieldTypes._
 
 object ConsignmentFields {
   case class Consignment(consignmentid: Option[Long] = None, userid: UUID, seriesid: Long)
-  case class AddConsignmentInput(seriesid: Long, userid: UUID)
+  case class AddConsignmentInput(seriesid: Long, userid: Option[UUID])
 
   implicit val ConsignmentType: ObjectType[Unit, Consignment] = deriveObjectType[Unit, Consignment]()
   implicit val AddConsignmentInputType: InputObjectType[AddConsignmentInput] = deriveInputObjectType[AddConsignmentInput]()

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentFields.scala
@@ -29,6 +29,10 @@ object ConsignmentFields {
   val mutationFields: List[Field[ConsignmentApiContext, Unit]] = fields[ConsignmentApiContext, Unit](
     Field("addConsignment", ConsignmentType,
       arguments=ConsignmentInputArg :: Nil,
-      resolve = ctx => ctx.ctx.consignmentService.addConsignment(ctx.arg(ConsignmentInputArg)))
+      resolve = ctx => ctx.ctx.consignmentService.addConsignment(
+        ctx.arg(ConsignmentInputArg),
+        ctx.ctx.accessToken.userId.map(id => UUID.fromString(id))
+      )
+    )
   )
 }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/http/GraphQLServer.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/http/GraphQLServer.scala
@@ -5,18 +5,17 @@ import akka.http.scaladsl.model.StatusCode
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
-import org.keycloak.representations.AccessToken
-import uk.gov.nationalarchives.tdr.api.db.DbConnection
-import uk.gov.nationalarchives.tdr.api.db.repository.{ClientFileMetadataRepository, ConsignmentRepository, SeriesRepository, TransferAgreementRepository}
-import uk.gov.nationalarchives.tdr.api.graphql.{ConsignmentApiContext, GraphQlTypes}
 import sangria.ast.Document
 import sangria.execution._
 import sangria.marshalling.sprayJson._
 import sangria.parser.QueryParser
-import uk.gov.nationalarchives.tdr.api.service.{ClientFileMetadataService, ConsignmentService, SeriesService, TransferAgreementService}
 import spray.json.{JsObject, JsString, JsValue}
-import uk.gov.nationalarchives.tdr.api.auth.ValidationAuthoriser.AuthorisationException
 import uk.gov.nationalarchives.tdr.api.auth.ValidationAuthoriser
+import uk.gov.nationalarchives.tdr.api.auth.ValidationAuthoriser.AuthorisationException
+import uk.gov.nationalarchives.tdr.api.db.DbConnection
+import uk.gov.nationalarchives.tdr.api.db.repository.{ClientFileMetadataRepository, ConsignmentRepository, SeriesRepository, TransferAgreementRepository}
+import uk.gov.nationalarchives.tdr.api.graphql.{ConsignmentApiContext, GraphQlTypes}
+import uk.gov.nationalarchives.tdr.api.service._
 import uk.gov.nationalarchives.tdr.keycloak.Token
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -55,7 +54,7 @@ object GraphQLServer {
                                  (implicit ec: ExecutionContext): Future[(StatusCode with Serializable, JsValue)] = {
     val db = DbConnection.db
     val seriesService = new SeriesService(new SeriesRepository(db))
-    val consignmentService = new ConsignmentService(new ConsignmentRepository(db))
+    val consignmentService = new ConsignmentService(new ConsignmentRepository(db), new CurrentTimeSource)
     val transferAgreementService = new TransferAgreementService(new TransferAgreementRepository(db))
     val clientFileMetadataService = new ClientFileMetadataService(new ClientFileMetadataRepository(db))
     val context = ConsignmentApiContext(

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentService.scala
@@ -10,9 +10,10 @@ import uk.gov.nationalarchives.tdr.api.graphql.fields.ConsignmentFields.{AddCons
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class ConsignmentService(consignmentRepository: ConsignmentRepository)(implicit val executionContext: ExecutionContext) {
-    def addConsignment(addConsignmentInput: AddConsignmentInput): Future[Consignment] = {
-      val consignmentRow = ConsignmentRow(addConsignmentInput.seriesid, addConsignmentInput.userid.get.toString, Timestamp.from(Instant.now()))
+class ConsignmentService(consignmentRepository: ConsignmentRepository, timeSource: TimeSource)
+                        (implicit val executionContext: ExecutionContext) {
+    def addConsignment(addConsignmentInput: AddConsignmentInput, userId: Option[UUID]): Future[Consignment] = {
+      val consignmentRow = ConsignmentRow(addConsignmentInput.seriesid, userId.get.toString, Timestamp.from(timeSource.now))
       consignmentRepository.addConsignment(consignmentRow).map(row => Consignment(row.consignmentid, UUID.fromString(row.userid), row.seriesid))
     }
 

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentService.scala
@@ -12,7 +12,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class ConsignmentService(consignmentRepository: ConsignmentRepository)(implicit val executionContext: ExecutionContext) {
     def addConsignment(addConsignmentInput: AddConsignmentInput): Future[Consignment] = {
-      val consignmentRow = ConsignmentRow(addConsignmentInput.seriesid, addConsignmentInput.userid.toString, Timestamp.from(Instant.now()))
+      val consignmentRow = ConsignmentRow(addConsignmentInput.seriesid, addConsignmentInput.userid.get.toString, Timestamp.from(Instant.now()))
       consignmentRepository.addConsignment(consignmentRow).map(row => Consignment(row.consignmentid, UUID.fromString(row.userid), row.seriesid))
     }
 

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/TimeSource.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/TimeSource.scala
@@ -1,0 +1,14 @@
+package uk.gov.nationalarchives.tdr.api.service
+
+import java.time.Instant
+
+/**
+  * A clock that can be queried for the time. This is mainly useful so that a fixed time can be injected by tests.
+  */
+trait TimeSource {
+  def now: Instant
+}
+
+class CurrentTimeSource extends TimeSource {
+  override def now: Instant = Instant.now()
+}

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentRouteSpec.scala
@@ -51,12 +51,6 @@ class ConsignmentRouteSpec extends AnyFlatSpec with Matchers with TestRequest wi
     response.errors.head.message should equal (expectedResponse.errors.head.message)
   }
 
-  "The api" should "throw an error if the user id field isn't provided" in {
-    val expectedResponse: GraphqlMutationData = expectedMutationResponse("data_userid_missing")
-    val response: GraphqlMutationData = runTestMutation("mutation_missinguserid", validUserToken())
-    response.errors.head.message should equal (expectedResponse.errors.head.message)
-  }
-
   "The api" should "allow a tdr_user user to create a consignment" in {
     val expectedResponse: GraphqlMutationData = expectedMutationResponse("data_all")
     val response: GraphqlMutationData = runTestMutation("mutation_alldata", validUserToken())

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentRouteSpec.scala
@@ -39,7 +39,7 @@ class ConsignmentRouteSpec extends AnyFlatSpec with Matchers with TestRequest wi
 
   "The api" should "create a consignment if the correct information is provided" in {
     val expectedResponse: GraphqlMutationData = expectedMutationResponse("data_all")
-    val response: GraphqlMutationData = runTestMutation("mutation_alldata", validAdminToken)
+    val response: GraphqlMutationData = runTestMutation("mutation_alldata", validUserToken())
     response.data.get.addConsignment should equal(expectedResponse.data.get.addConsignment)
 
     checkConsignmentExists(response.data.get.addConsignment.consignmentid.get)
@@ -47,22 +47,14 @@ class ConsignmentRouteSpec extends AnyFlatSpec with Matchers with TestRequest wi
 
   "The api" should "throw an error if the series id field isn't provided" in {
     val expectedResponse: GraphqlMutationData = expectedMutationResponse("data_seriesid_missing")
-    val response: GraphqlMutationData = runTestMutation("mutation_missingseriesid", validAdminToken)
+    val response: GraphqlMutationData = runTestMutation("mutation_missingseriesid", validUserToken())
     response.errors.head.message should equal (expectedResponse.errors.head.message)
   }
 
   "The api" should "throw an error if the user id field isn't provided" in {
     val expectedResponse: GraphqlMutationData = expectedMutationResponse("data_userid_missing")
-    val response: GraphqlMutationData = runTestMutation("mutation_missinguserid", validAdminToken)
+    val response: GraphqlMutationData = runTestMutation("mutation_missinguserid", validUserToken())
     response.errors.head.message should equal (expectedResponse.errors.head.message)
-  }
-
-  "The api" should "allow a tdr_admin user to create a consignment" in {
-    val expectedResponse: GraphqlMutationData = expectedMutationResponse("data_all")
-    val response: GraphqlMutationData = runTestMutation("mutation_alldata", validAdminToken)
-    response.data.get.addConsignment should equal(expectedResponse.data.get.addConsignment)
-
-    checkConsignmentExists(response.data.get.addConsignment.consignmentid.get)
   }
 
   "The api" should "allow a tdr_user user to create a consignment" in {

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentRouteSpec.scala
@@ -65,6 +65,14 @@ class ConsignmentRouteSpec extends AnyFlatSpec with Matchers with TestRequest wi
     checkConsignmentExists(response.data.get.addConsignment.consignmentid.get)
   }
 
+  "The api" should "link a new consignment to the creating user" in {
+    val expectedResponse: GraphqlMutationData = expectedMutationResponse("data_all")
+    val response: GraphqlMutationData = runTestMutation("mutation_alldata", validUserToken())
+    response.data.get.addConsignment should equal(expectedResponse.data.get.addConsignment)
+
+    response.data.get.addConsignment.userid should contain(userId)
+  }
+
   "The api" should "return all requested fields" in {
     val sql = "insert into consignmentapi.Consignment (SeriesId, UserId) VALUES (1,'4ab14990-ed63-4615-8336-56fbb9960300')"
     val ps: PreparedStatement = DbConnection.db.source.createConnection().prepareStatement(sql)

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentServiceSpec.scala
@@ -4,15 +4,16 @@ import java.sql.Timestamp
 import java.time.Instant
 import java.util.UUID
 
+import org.mockito.ArgumentMatchers._
 import org.mockito.MockitoSugar
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import uk.gov.nationalarchives.Tables.ConsignmentRow
 import uk.gov.nationalarchives.tdr.api.db.repository.ConsignmentRepository
-import uk.gov.nationalarchives.tdr.api.graphql.fields.ConsignmentFields.{AddConsignmentInput, Consignment}
-import uk.gov.nationalarchives.tdr.api.utils.TestUtils._
-import org.mockito.ArgumentMatchers._
 import uk.gov.nationalarchives.tdr.api.graphql.fields.ConsignmentFields
+import uk.gov.nationalarchives.tdr.api.graphql.fields.ConsignmentFields.{AddConsignmentInput, Consignment}
+import uk.gov.nationalarchives.tdr.api.utils.FixedTimeSource
+import uk.gov.nationalarchives.tdr.api.utils.TestUtils._
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -24,12 +25,27 @@ class ConsignmentServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers
     val consignmentRepositoryMock = mock[ConsignmentRepository]
     val mockResponse = Future.successful(ConsignmentRow(1L, uuid.toString, Timestamp.from(Instant.now), Some(1)))
     when(consignmentRepositoryMock.addConsignment(any[ConsignmentRow])).thenReturn(mockResponse)
-    val consignmentService = new ConsignmentService(consignmentRepositoryMock)
-    val result: Consignment = consignmentService.addConsignment(AddConsignmentInput(1, Some(uuid))).await()
+    val consignmentService = new ConsignmentService(consignmentRepositoryMock, FixedTimeSource)
+    val result: Consignment = consignmentService.addConsignment(AddConsignmentInput(1, Some(uuid)), Some(uuid)).await()
     result.seriesid shouldBe 1
     result.userid shouldBe uuid
     result.consignmentid shouldBe defined
     result.consignmentid.get shouldBe 1
+  }
+
+  "createConsignment" should "link a consignment to the user's ID" in {
+    val userId = UUID.randomUUID()
+    val seriesId = 123
+    val consignmentRepositoryMock = mock[ConsignmentRepository]
+    val consignmentService = new ConsignmentService(consignmentRepositoryMock, FixedTimeSource)
+
+    val expectedRow = ConsignmentRow(seriesId, userId.toString, Timestamp.from(FixedTimeSource.now), None)
+    val mockResponse = Future.successful(ConsignmentRow(seriesId, userId.toString, Timestamp.from(Instant.now), Some(1)))
+    when(consignmentRepositoryMock.addConsignment(any[ConsignmentRow])).thenReturn(mockResponse)
+
+    consignmentService.addConsignment(AddConsignmentInput(seriesId, None), Some(userId)).await()
+
+    verify(consignmentRepositoryMock).addConsignment(expectedRow)
   }
 
   "getConsignment" should "return the specfic Consignment for the requested consignment id" in {
@@ -39,7 +55,7 @@ class ConsignmentServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers
     val consignmentRepoMock = mock[ConsignmentRepository]
     when(consignmentRepoMock.getConsignment(anyLong())).thenReturn(mockResponse)
 
-    val consignmentService: ConsignmentService = new ConsignmentService(consignmentRepoMock)
+    val consignmentService: ConsignmentService = new ConsignmentService(consignmentRepoMock, FixedTimeSource)
     val response: Option[ConsignmentFields.Consignment] = consignmentService.getConsignment(1).await()
 
     verify(consignmentRepoMock, times(1)).getConsignment(anyLong())
@@ -54,7 +70,7 @@ class ConsignmentServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers
     val consignmentRepoMock = mock[ConsignmentRepository]
     when(consignmentRepoMock.getConsignment(anyLong())).thenReturn(mockResponse)
 
-    val consignmentService: ConsignmentService = new ConsignmentService(consignmentRepoMock)
+    val consignmentService: ConsignmentService = new ConsignmentService(consignmentRepoMock, FixedTimeSource)
     val response: Option[ConsignmentFields.Consignment] = consignmentService.getConsignment(1).await()
     verify(consignmentRepoMock, times(1)).getConsignment(anyLong())
 

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentServiceSpec.scala
@@ -25,7 +25,7 @@ class ConsignmentServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers
     val mockResponse = Future.successful(ConsignmentRow(1L, uuid.toString, Timestamp.from(Instant.now), Some(1)))
     when(consignmentRepositoryMock.addConsignment(any[ConsignmentRow])).thenReturn(mockResponse)
     val consignmentService = new ConsignmentService(consignmentRepositoryMock)
-    val result: Consignment = consignmentService.addConsignment(AddConsignmentInput(1 ,uuid)).await()
+    val result: Consignment = consignmentService.addConsignment(AddConsignmentInput(1, Some(uuid))).await()
     result.seriesid shouldBe 1
     result.userid shouldBe uuid
     result.consignmentid shouldBe defined

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/FixedTimeSource.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/FixedTimeSource.scala
@@ -1,0 +1,9 @@
+package uk.gov.nationalarchives.tdr.api.utils
+
+import java.time.Instant
+
+import uk.gov.nationalarchives.tdr.api.service.TimeSource
+
+object FixedTimeSource extends TimeSource {
+  override def now: Instant = Instant.parse("2020-01-01T09:00:00Z")
+}

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestUtils.scala
@@ -1,5 +1,7 @@
 package uk.gov.nationalarchives.tdr.api.utils
 
+import java.util.UUID
+
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.unmarshalling.{FromResponseUnmarshaller, Unmarshaller}
 import akka.stream.Materializer
@@ -30,7 +32,7 @@ object TestUtils  {
     mock
   }
 
-  val userId = "4ab14990-ed63-4615-8336-56fbb9960300"
+  val userId = UUID.fromString("4ab14990-ed63-4615-8336-56fbb9960300")
 
   def validUserToken(body: String = "Body"): OAuth2BearerToken = OAuth2BearerToken(tdrMock.getAccessToken(
     aTokenConfig()


### PR DESCRIPTION
The user's ID is used for auditing purposes, so we should read it from the user's authentication token rather than trusting the UUID sent by the client.

For now, make the user ID parameter in the GraphQL request optional, so that this change is backwards-compatible with the frontend client. The frontend will be updated to remove the parameter, and then the parameter can be removed from the API.