### PR TITLE
Remove user from consignment creation query

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentFields.scala
@@ -11,7 +11,7 @@ import uk.gov.nationalarchives.tdr.api.graphql.fields.FieldTypes._
 
 object ConsignmentFields {
   case class Consignment(consignmentid: Option[Long] = None, userid: UUID, seriesid: Long)
-  case class AddConsignmentInput(seriesid: Long, userid: Option[UUID])
+  case class AddConsignmentInput(seriesid: Long)
 
   implicit val ConsignmentType: ObjectType[Unit, Consignment] = deriveObjectType[Unit, Consignment]()
   implicit val AddConsignmentInputType: InputObjectType[AddConsignmentInput] = deriveInputObjectType[AddConsignmentInput]()

--- a/src/test/resources/json/addconsignment_mutation_alldata.json
+++ b/src/test/resources/json/addconsignment_mutation_alldata.json
@@ -1,1 +1,1 @@
-{"query":"mutation {addConsignment(addConsignmentInput: {seriesid: 1, userid: \"4ab14990-ed63-4615-8336-56fbb9960300\"}) {consignmentid, seriesid, userid}}"}
+{"query":"mutation {addConsignment(addConsignmentInput: {seriesid: 1}) {consignmentid, seriesid, userid}}"}

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentServiceSpec.scala
@@ -26,7 +26,7 @@ class ConsignmentServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers
     val mockResponse = Future.successful(ConsignmentRow(1L, uuid.toString, Timestamp.from(Instant.now), Some(1)))
     when(consignmentRepositoryMock.addConsignment(any[ConsignmentRow])).thenReturn(mockResponse)
     val consignmentService = new ConsignmentService(consignmentRepositoryMock, FixedTimeSource)
-    val result: Consignment = consignmentService.addConsignment(AddConsignmentInput(1, Some(uuid)), Some(uuid)).await()
+    val result: Consignment = consignmentService.addConsignment(AddConsignmentInput(1), Some(uuid)).await()
     result.seriesid shouldBe 1
     result.userid shouldBe uuid
     result.consignmentid shouldBe defined
@@ -43,7 +43,7 @@ class ConsignmentServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers
     val mockResponse = Future.successful(ConsignmentRow(seriesId, userId.toString, Timestamp.from(Instant.now), Some(1)))
     when(consignmentRepositoryMock.addConsignment(any[ConsignmentRow])).thenReturn(mockResponse)
 
-    consignmentService.addConsignment(AddConsignmentInput(seriesId, None), Some(userId)).await()
+    consignmentService.addConsignment(AddConsignmentInput(seriesId), Some(userId)).await()
 
     verify(consignmentRepositoryMock).addConsignment(expectedRow)
   }


### PR DESCRIPTION
In a previous commit, we switched to getting the user ID from the auth token, so it is no longer needed in the GraphQL query.

PR marked as draft until https://github.com/nationalarchives/tdr-transfer-frontend/pull/58 is merged.

Edit: I found an issue in the graphql client that needs to be fixed first too: https://github.com/nationalarchives/tdr-graphql-client/pull/2