### PR TITLE
Make transferring body a compulsory argument when fetching series

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/SeriesRepository.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/SeriesRepository.scala
@@ -9,13 +9,6 @@ class SeriesRepository(db: Database) {
 
   private val insertQuery = Series returning Series.map(_.seriesid) into ((series, seriesid) => series.copy(seriesid = Some(seriesid)))
 
-  def getSeries(): Future[Seq[SeriesRow]] = {
-    val query = for {
-      (series, _) <- Series.join(Body).on(_.bodyid === _.bodyid )
-    } yield series
-    db.run(query.result)
-  }
-
   def getSeries(bodyName: String): Future[Seq[SeriesRow]] = {
     val query = for {
       (series, _) <- Series.join(Body).on(_.bodyid === _.bodyid).filter(_._2.name === bodyName)

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/Tags.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/Tags.scala
@@ -22,20 +22,14 @@ object Tags {
     override def validate(ctx: Context[ConsignmentApiContext, _]): BeforeFieldResult[ConsignmentApiContext, Unit] = {
       val token = ctx.ctx.accessToken
 
-      val isAdmin: Boolean = token.roles.contains("tdr_admin")
-
       val bodyArg: String = ctx.arg("body")
+      val bodyFromToken: String = token.transferringBody.getOrElse("")
 
-      if(!isAdmin) {
-        val bodyFromToken: String = token.transferringBody.getOrElse("")
-        if(bodyFromToken != bodyArg) {
-          val msg = s"Body for user ${token.userId.getOrElse("")} was ${bodyArg} in the query and $bodyFromToken in the token"
-          throw AuthorisationException(msg)
-        }
-        continue
-      } else {
-        continue
+      if(bodyFromToken != bodyArg) {
+        val msg = s"Body for user ${token.userId.getOrElse("")} was ${bodyArg} in the query and $bodyFromToken in the token"
+        throw AuthorisationException(msg)
       }
+      continue
     }
   }
 

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/Tags.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/Tags.scala
@@ -24,12 +24,12 @@ object Tags {
 
       val isAdmin: Boolean = token.roles.contains("tdr_admin")
 
-      val bodyArg: Option[String] = ctx.argOpt("body")
+      val bodyArg: String = ctx.arg("body")
 
       if(!isAdmin) {
         val bodyFromToken: String = token.transferringBody.getOrElse("")
-        if(bodyFromToken != bodyArg.getOrElse("")) {
-          val msg = s"Body for user ${token.userId.getOrElse("")} was ${bodyArg.getOrElse("")} in the query and $bodyFromToken in the token"
+        if(bodyFromToken != bodyArg) {
+          val msg = s"Body for user ${token.userId.getOrElse("")} was ${bodyArg} in the query and $bodyFromToken in the token"
           throw AuthorisationException(msg)
         }
         continue

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/SeriesFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/SeriesFields.scala
@@ -14,7 +14,7 @@ object SeriesFields {
   implicit val SeriesType: ObjectType[Unit, Series] = deriveObjectType[Unit, Series]()
   implicit val AddSeriesInputType: InputObjectType[AddSeriesInput] = deriveInputObjectType[AddSeriesInput]()
 
-  val BodyArg = Argument("body", OptionInputType(StringType))
+  val BodyArg = Argument("body", StringType)
 
   private val SeriesInputArg = Argument("addSeriesInput", AddSeriesInputType)
 

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/SeriesService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/SeriesService.scala
@@ -8,16 +8,12 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class SeriesService(seriesRepository: SeriesRepository)(implicit val executionContext: ExecutionContext) {
 
-  def getSeries(bodyOption: Option[String]): Future[Seq[Series]] = {
-    val series = if(bodyOption.isDefined) {
-      seriesRepository.getSeries(bodyOption.get)
-    } else {
-      seriesRepository.getSeries()
-    }
+  def getSeries(body: String): Future[Seq[Series]] = {
+    val series = seriesRepository.getSeries(body)
     series.map(seriesRows =>
       seriesRows.map(s => Series(s.seriesid.get, s.bodyid, s.name, s.code, s.description)
       ))
-    }
+  }
 
   def addSeries(input: AddSeriesInput): Future[Series] = {
     val newSeries = SeriesRow(input.bodyid, input.code, input.name, input.description)

--- a/src/test/resources/json/getseries_data_error_no_body.json
+++ b/src/test/resources/json/getseries_data_error_no_body.json
@@ -1,1 +1,0 @@
-{"data":null,"errors":[{"message":"Body for user 4ab14990-ed63-4615-8336-56fbb9960300 was  in the query and Body in the token","path":["getSeries"],"locations":[{"column":2,"line":1}],"extensions":{"code":"NOT_AUTHORISED"}}]}

--- a/src/test/resources/json/getseries_data_multipleseries.json
+++ b/src/test/resources/json/getseries_data_multipleseries.json
@@ -1,1 +1,0 @@
-{"data":{"getSeries":[{"seriesid":1},{"seriesid":2}]}}

--- a/src/test/resources/json/getseries_query_admin.json
+++ b/src/test/resources/json/getseries_query_admin.json
@@ -1,1 +1,0 @@
-{"query":"{getSeries{seriesid}}"}

--- a/src/test/resources/json/getseries_query_no_body.json
+++ b/src/test/resources/json/getseries_query_no_body.json
@@ -1,1 +1,0 @@
-{"query":"{getSeries{seriesid}}"}

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/RouteAuthenticationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/RouteAuthenticationSpec.scala
@@ -31,7 +31,7 @@ class RouteAuthenticationSpec extends AnyFlatSpec with Matchers with ScalatestRo
   }
 
   "The api" should "return a valid response with a valid token" in {
-    val query: String = """{"query":"{getSeries{seriesid}}"}"""
+    val query: String = """{"query":"{getSeries(body:\"Body\"){seriesid}}"}"""
     Post("/graphql").withEntity(ContentTypes.`application/json`, query) ~> addCredentials(validUserToken()) ~> route ~> check {
       status shouldEqual StatusCodes.OK
     }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/SeriesRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/SeriesRouteSpec.scala
@@ -12,9 +12,6 @@ import uk.gov.nationalarchives.tdr.api.db.DbConnection
 import uk.gov.nationalarchives.tdr.api.utils.TestRequest
 import uk.gov.nationalarchives.tdr.api.utils.TestUtils._
 
-
-
-
 class SeriesRouteSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach with TestRequest {
 
   private val getSeriesJsonFilePrefix: String = "json/getseries_"
@@ -64,13 +61,6 @@ class SeriesRouteSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach 
     response.data should equal(expectedResponse.data)
   }
 
-  "The api" should "return an error if a user queries without a body argument" in {
-    val expectedResponse: GraphqlQueryData = expectedQueryResponse("data_error_no_body")
-    val response: GraphqlQueryData = runTestQuery("query_no_body", validUserToken())
-    response.errors.head.message should equal(expectedResponse.errors.head.message)
-    response.errors.head.extensions.get.code should equal(expectedResponse.errors.head.extensions.get.code)
-  }
-
   "The api" should "return an error if a user queries with a different body to their own" in {
     val expectedResponse: GraphqlQueryData = expectedQueryResponse("data_incorrect_body")
     val response: GraphqlQueryData = runTestQuery("query_incorrect_body", validUserToken())
@@ -83,16 +73,6 @@ class SeriesRouteSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach 
     val response: GraphqlQueryData = runTestQuery("query_incorrect_body", validUserTokenNoBody)
     response.data should equal(expectedResponse.data)
     response.errors.head.extensions.get.code should equal(expectedResponse.errors.head.extensions.get.code)
-  }
-
-  "The api" should "return all series if an admin user queries without a body argument" in {
-    val sql = "insert into consignmentapi.Series (SeriesId, BodyId) VALUES (1,1), (2, 2)"
-    val ps: PreparedStatement = DbConnection.db.source.createConnection().prepareStatement(sql)
-    ps.executeUpdate()
-
-    val expectedResponse: GraphqlQueryData = expectedQueryResponse("data_multipleseries")
-    val response: GraphqlQueryData = runTestQuery("query_admin", validAdminToken)
-    response.data should equal(expectedResponse.data)
   }
 
   "The api" should "return the correct series if an admin queries with a body argument" in {

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/SeriesServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/SeriesServiceSpec.scala
@@ -1,10 +1,9 @@
 package uk.gov.nationalarchives.tdr.api.service
 
-import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.{any, _}
 import org.mockito.MockitoSugar
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.mockito.ArgumentMatchers._
 import uk.gov.nationalarchives.Tables.SeriesRow
 import uk.gov.nationalarchives.tdr.api.db.repository.SeriesRepository
 import uk.gov.nationalarchives.tdr.api.graphql.fields.SeriesFields
@@ -16,25 +15,12 @@ import scala.concurrent.{ExecutionContext, Future}
 class SeriesServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers {
   implicit val executionContext: ExecutionContext = ExecutionContext.Implicits.global
 
-  "getSeries" should "return all series if no argument is provided" in {
-    val repoMock = setupSeriesResponses
-    val seriesService: SeriesService = new SeriesService(repoMock)
-    val seriesResponse: Seq[SeriesFields.Series] = seriesService.getSeries(Option.empty).await()
-
-    verify(repoMock, times(1)).getSeries()
-    verify(repoMock, times(0)).getSeries(anyString())
-    seriesResponse.length should equal(2)
-    checkFields(seriesResponse.head, SeriesCheck(1, 1, "name1", "code1", "description1"))
-    checkFields(seriesResponse.tail.head, SeriesCheck(2, 2, "name2", "code2", "description2"))
-  }
-
   "getSeries" should "return the specfic series for a body if one is provided" in {
     val repoMock = setupSeriesResponses
 
     val seriesService: SeriesService = new SeriesService(repoMock)
-    val seriesResponse: Seq[SeriesFields.Series] = seriesService.getSeries(Option("1")).await()
+    val seriesResponse: Seq[SeriesFields.Series] = seriesService.getSeries("1").await()
 
-    verify(repoMock, times(0)).getSeries()
     verify(repoMock, times(1)).getSeries(anyString())
     seriesResponse.length should equal(1)
     checkFields(seriesResponse.head, SeriesCheck(1, 1, "name1", "code1", "description1"))
@@ -79,12 +65,9 @@ class SeriesServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers {
 
   private def setupSeriesResponses = {
     val seriesOne = SeriesRow(1, Option.apply("name1"), Option.apply("code1"), Option.apply("description1"), Some(1))
-    val seriesTwo = SeriesRow(2, Option.apply("name2"), Option.apply("code2"), Option.apply("description2"), Some(2))
-    val mockResponseAll: Future[Seq[SeriesRow]] = Future.successful(Seq(seriesOne, seriesTwo))
     val mockResponseOne: Future[Seq[SeriesRow]] = Future.successful(Seq(seriesOne))
 
     val repoMock = mock[SeriesRepository]
-    when(repoMock.getSeries()).thenReturn(mockResponseAll)
     when(repoMock.getSeries(anyString())).thenReturn(mockResponseOne)
     repoMock
   }


### PR DESCRIPTION
This fixes an authorisation issue, where it was possible to fetch series for all departments by passing a null body parameter.

The only reason that body was an optional parameter was to support future admin functionality, but that does not exist yet so it's more secure to make the parameter compulsory are revisit this once we have requirements for the admin functions.

Also remove the admin token handling the same endpoint for the same reason.

Set as draft for now. The frontend needs to be updated to use https://github.com/nationalarchives/tdr-generated-graphql/pull/11 before this can be safely merged.