### PR TITLE
Add error code to GraphQL errors

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/ErrorCodes.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/ErrorCodes.scala
@@ -1,0 +1,11 @@
+package uk.gov.nationalarchives.tdr.api.graphql
+
+/**
+  * GraphQL supports arbitrary error codes to provide extra error information to client applications. These error codes
+  * are added to the error object under `extensions.code`.
+  *
+  * See the GraphQL spec for more information: https://github.com/graphql/graphql-spec/blob/master/spec/Section%207%20--%20Response.md#errors
+  */
+object ErrorCodes {
+  val notAuthorised = "NOT_AUTHORISED"
+}

--- a/src/test/resources/json/addfile_data_error_not_owner.json
+++ b/src/test/resources/json/addfile_data_error_not_owner.json
@@ -1,1 +1,1 @@
-{"data":null,"errors":[{"message":"User does not own consignment"}]}
+{"data":null,"errors":[{"message":"User does not own consignment","extensions":{"code":"NOT_AUTHORISED"}}]}

--- a/src/test/resources/json/addseries_data_error_incorrect_role.json
+++ b/src/test/resources/json/addseries_data_error_incorrect_role.json
@@ -1,1 +1,1 @@
-{"data":null,"errors":[{"message":"Admin permissions required to call addSeries","path":["addSeries"],"locations":[{"column":11,"line":1}]}]}
+{"data":null,"errors":[{"message":"Admin permissions required to call addSeries","path":["addSeries"],"locations":[{"column":11,"line":1}],"extensions":{"code":"NOT_AUTHORISED"}}]}

--- a/src/test/resources/json/addtransferagreement_data_error_not_owner.json
+++ b/src/test/resources/json/addtransferagreement_data_error_not_owner.json
@@ -1,1 +1,1 @@
-{"data":null,"errors":[{"message":"User does not own consignment"}]}
+{"data":null,"errors":[{"message":"User does not own consignment","extensions":{"code":"NOT_AUTHORISED"}}]}

--- a/src/test/resources/json/getseries_data_error_incorrect_user.json
+++ b/src/test/resources/json/getseries_data_error_incorrect_user.json
@@ -1,1 +1,1 @@
-{"data":null,"errors":[{"message":"Body for user 4ab14990-ed63-4615-8336-56fbb9960300 was Body2 in the query and null in the token","path":["getSeries"],"locations":[{"column":2,"line":1}]}]}
+{"data":null,"errors":[{"message":"Body for user 4ab14990-ed63-4615-8336-56fbb9960300 was Body2 in the query and null in the token","path":["getSeries"],"locations":[{"column":2,"line":1}],"extensions":{"code":"NOT_AUTHORISED"}}]}

--- a/src/test/resources/json/getseries_data_error_no_body.json
+++ b/src/test/resources/json/getseries_data_error_no_body.json
@@ -1,1 +1,1 @@
-{"data":null,"errors":[{"message":"Body for user 4ab14990-ed63-4615-8336-56fbb9960300 was  in the query and Body in the token","path":["getSeries"],"locations":[{"column":2,"line":1}]}]}
+{"data":null,"errors":[{"message":"Body for user 4ab14990-ed63-4615-8336-56fbb9960300 was  in the query and Body in the token","path":["getSeries"],"locations":[{"column":2,"line":1}],"extensions":{"code":"NOT_AUTHORISED"}}]}

--- a/src/test/resources/json/getseries_data_incorrect_body.json
+++ b/src/test/resources/json/getseries_data_incorrect_body.json
@@ -1,1 +1,1 @@
-{"data":null,"errors":[{"message":"Body for user 4ab14990-ed63-4615-8336-56fbb9960300 was Body2 in the query and Body in the token","path":["getSeries"],"locations":[{"column":2,"line":1}]}]}
+{"data":null,"errors":[{"message":"Body for user 4ab14990-ed63-4615-8336-56fbb9960300 was Body2 in the query and Body in the token","path":["getSeries"],"locations":[{"column":2,"line":1}],"extensions":{"code":"NOT_AUTHORISED"}}]}

--- a/src/test/resources/json/gettransferagreement_data_notowner.json
+++ b/src/test/resources/json/gettransferagreement_data_notowner.json
@@ -1,1 +1,1 @@
-{"data":null,"errors":[{"message":"User does not own consignment","path":["getSeries"],"locations":[{"column":2,"line":1}]}]}
+{"data":null,"errors":[{"message":"User does not own consignment","path":["getSeries"],"locations":[{"column":2,"line":1}],"extensions":{"code":"NOT_AUTHORISED"}}]}

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
@@ -82,7 +82,7 @@ class FileRouteSpec extends AnyFlatSpec with Matchers with TestRequest with Befo
     val expectedResponse: GraphqlMutationData = expectedMutationResponse("data_error_not_owner")
     val response: GraphqlMutationData = runTestMutation("mutation_alldata", validUserToken())
     response.errors.head.message should equal(expectedResponse.errors.head.message)
-
+    response.errors.head.extensions.get.code should equal(expectedResponse.errors.head.extensions.get.code)
   }
 
   private def checkFileExists(fileId: Long) = {

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/SeriesRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/SeriesRouteSpec.scala
@@ -68,18 +68,21 @@ class SeriesRouteSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach 
     val expectedResponse: GraphqlQueryData = expectedQueryResponse("data_error_no_body")
     val response: GraphqlQueryData = runTestQuery("query_no_body", validUserToken())
     response.errors.head.message should equal(expectedResponse.errors.head.message)
+    response.errors.head.extensions.get.code should equal(expectedResponse.errors.head.extensions.get.code)
   }
 
   "The api" should "return an error if a user queries with a different body to their own" in {
     val expectedResponse: GraphqlQueryData = expectedQueryResponse("data_incorrect_body")
     val response: GraphqlQueryData = runTestQuery("query_incorrect_body", validUserToken())
     response.errors.head.message should equal(expectedResponse.errors.head.message)
+    response.errors.head.extensions.get.code should equal(expectedResponse.errors.head.extensions.get.code)
   }
 
   "The api" should "return an error if a user queries with the correct body but it is not set on their user" in {
     val expectedResponse: GraphqlQueryData = expectedQueryResponse("data_error_incorrect_user")
     val response: GraphqlQueryData = runTestQuery("query_incorrect_body", validUserTokenNoBody)
     response.data should equal(expectedResponse.data)
+    response.errors.head.extensions.get.code should equal(expectedResponse.errors.head.extensions.get.code)
   }
 
   "The api" should "return all series if an admin user queries without a body argument" in {
@@ -118,5 +121,6 @@ class SeriesRouteSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach 
     val expectedResponse: GraphqlMutationData = expectedMutationResponse("data_error_incorrect_role")
     val response: GraphqlMutationData = runTestMutation("mutation_alldata", validUserToken())
     response.data should equal(expectedResponse.data)
+    response.errors.head.extensions.get.code should equal(expectedResponse.errors.head.extensions.get.code)
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/TransfersAgreementRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/TransfersAgreementRouteSpec.scala
@@ -85,6 +85,7 @@ class TransfersAgreementRouteSpec extends AnyFlatSpec with Matchers with TestReq
     val expectedResponse: GraphqlMutationData = expectedMutationResponse("data_error_not_owner")
     val response: GraphqlMutationData = runTestMutation("mutation_alldata", validUserToken())
     response.errors.head.message should equal(expectedResponse.errors.head.message)
+    response.errors.head.extensions.get.code should equal(expectedResponse.errors.head.extensions.get.code)
   }
 
   "The api" should "return an error if an invalid consignment id is provided" in {
@@ -146,6 +147,7 @@ class TransfersAgreementRouteSpec extends AnyFlatSpec with Matchers with TestReq
     val response: GraphqlQueryData = runTestQuery("query_alldata", validUserToken())
     response.errors.length should equal(1)
     response.errors.head.message should equal(expectedResponse.errors.head.message)
+    response.errors.head.extensions.get.code should equal(expectedResponse.errors.head.extensions.get.code)
   }
 
   private def checkTransferAgreementExists(transferAgreementId: Long): Unit = {

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestUtils.scala
@@ -54,7 +54,9 @@ object TestUtils  {
   )
   def invalidToken: OAuth2BearerToken = OAuth2BearerToken(testMock.getAccessToken(aTokenConfig().build))
 
-  case class GraphqlError(message: String)
+  case class GraphqlError(message: String, extensions: Option[GraphqlErrorExtensions])
+
+  case class GraphqlErrorExtensions(code: String)
 
   case class Locations(column: Int, line: Int)
 


### PR DESCRIPTION
GraphQL supports error codes to provide more information to the client applications. We can look for these code Strings in the GraphQL clients to provide better errors to the user.

For now, the only specialised error is NOT_AUTHORISED, which indicates that the request tried to do something which the user does not have permission for.