### PR TITLE
Allow cross-origin requests from localhost to integration

### DIFF
--- a/src/main/resources/application.base.conf
+++ b/src/main/resources/application.base.conf
@@ -3,7 +3,9 @@ auth = {
 }
 
 frontend = {
-  url = ${FRONTEND_URL}
+  urls = [
+    ${FRONTEND_URL}
+  ]
 }
 
 source = {

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -5,7 +5,9 @@ auth = {
 }
 
 frontend = {
-  url = "http://localhost:9000"
+  urls = [
+    "http://localhost:9000"
+  ]
 }
 
 consignmentapi = {

--- a/src/main/resources/application.intg.conf
+++ b/src/main/resources/application.intg.conf
@@ -1,1 +1,10 @@
 include "application.base"
+
+frontend = {
+  // Allow cross-origin requests from the integration frontend and local dev environment, to make it easier to do
+  // frontend development without having to run the rest of the stack locally
+  urls = [
+    ${FRONTEND_URL},
+    "localhost:9000"
+  ]
+}

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/http/ApiServer.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/http/ApiServer.scala
@@ -3,8 +3,8 @@ package uk.gov.nationalarchives.tdr.api.http
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.stream.Materializer
+import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.Logger
-import uk.gov.nationalarchives.tdr.api.http.Routes.route
 
 import scala.concurrent.Await
 import scala.language.postfixOps
@@ -21,7 +21,9 @@ object ApiServer extends App {
 
   scala.sys.addShutdownHook(() -> shutdown())
 
-  Http().bindAndHandle(route, "0.0.0.0", PORT)
+  val routes = new Routes(ConfigFactory.load())
+
+  Http().bindAndHandle(routes.route, "0.0.0.0", PORT)
   logger.info(s"open a browser with URL: http://localhost:$PORT")
 
 

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/http/Cors.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/http/Cors.scala
@@ -7,26 +7,38 @@ import akka.http.scaladsl.server.Directives.{complete, options, respondWithHeade
 import akka.http.scaladsl.server.{Directive0, Route}
 import com.typesafe.config.Config
 
+import scala.jdk.CollectionConverters._
+
 trait Cors {
 
   def config: Config
 
-  val frontendUrl: String = config.getString("frontend.url")
+  val frontendUrls: Seq[String] = config.getStringList("frontend.urls").asScala.toSeq
 
-  private def addAccessControlHeaders: Directive0 = {
+  private def addAccessControlHeaders(originHeader: Option[Origin]): Directive0 = {
     respondWithHeaders(
-      `Access-Control-Allow-Origin`(HttpOrigin(frontendUrl)),
+      `Access-Control-Allow-Origin`(HttpOrigin(allowedOrigin(originHeader))),
       `Access-Control-Allow-Credentials`(true),
       `Access-Control-Allow-Headers`("Authorization", "Content-Type", "X-Requested-With"),
       `Access-Control-Allow-Methods`(OPTIONS, POST, GET)
     )
   }
 
+  private def allowedOrigin(originHeader: Option[Origin]): String = {
+    val domainsInHeader = originHeader.map(_.origins)
+      .getOrElse(Seq.empty)
+      .map(_.toString)
+    val overlappingDomains = domainsInHeader.intersect(frontendUrls)
+
+    val defaultAllowedOrigin = frontendUrls.head
+    overlappingDomains.headOption.getOrElse(defaultAllowedOrigin)
+  }
+
   private def preflightRequestHandler: Route = options {
     complete(HttpResponse(StatusCodes.OK))
   }
 
-  def corsHandler(r: Route): Route = addAccessControlHeaders {
+  def corsHandler(r: Route, originHeader: Option[Origin]): Route = addAccessControlHeaders(originHeader) {
     preflightRequestHandler ~ r
   }
 }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/http/Cors.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/http/Cors.scala
@@ -17,20 +17,16 @@ trait Cors {
     respondWithHeaders(
       `Access-Control-Allow-Origin`(HttpOrigin(frontendUrl)),
       `Access-Control-Allow-Credentials`(true),
-      `Access-Control-Allow-Headers`("Authorization", "Content-Type", "X-Requested-With")
+      `Access-Control-Allow-Headers`("Authorization", "Content-Type", "X-Requested-With"),
+      `Access-Control-Allow-Methods`(OPTIONS, POST, GET)
     )
   }
 
   private def preflightRequestHandler: Route = options {
-    complete(HttpResponse(StatusCodes.OK)
-      .withHeaders(
-        `Access-Control-Allow-Methods`(OPTIONS, POST, GET)
-      )
-    )
+    complete(HttpResponse(StatusCodes.OK))
   }
 
   def corsHandler(r: Route): Route = addAccessControlHeaders {
     preflightRequestHandler ~ r
   }
-
 }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/http/Cors.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/http/Cors.scala
@@ -1,17 +1,17 @@
 package uk.gov.nationalarchives.tdr.api.http
 
 import akka.http.scaladsl.model.HttpMethods.{GET, OPTIONS, POST}
-import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import akka.http.scaladsl.model.headers._
-import akka.http.scaladsl.server.Directives._
-
-import akka.http.scaladsl.server.Directives.{complete, options, respondWithHeaders}
+import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
+import akka.http.scaladsl.server.Directives.{complete, options, respondWithHeaders, _}
 import akka.http.scaladsl.server.{Directive0, Route}
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.Config
 
 trait Cors {
 
-  val frontendUrl: String = ConfigFactory.load().getString("frontend.url")
+  def config: Config
+
+  val frontendUrl: String = config.getString("frontend.url")
 
   private def addAccessControlHeaders: Directive0 = {
     respondWithHeaders(

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/http/Routes.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/http/Routes.scala
@@ -13,15 +13,14 @@ import uk.gov.nationalarchives.tdr.keycloak.{KeycloakUtils, Token}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-
-object Routes extends Cors {
+class Routes(val config: Config) extends Cors {
 
   implicit val system: ActorSystem = ActorSystem("consignmentApi")
   implicit val executionContext: ExecutionContext = system.dispatcher
 
   val logger = Logger("ApiServer")
   val ttlSeconds: Int = 10
-  val url: String = ConfigFactory.load().getString("auth.url")
+  val url: String = config.getString("auth.url")
 
 
   def tokenAuthenticator(credentials: Credentials): Future[Option[Token]] = {

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/http/Routes.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/http/Routes.scala
@@ -3,6 +3,7 @@ package uk.gov.nationalarchives.tdr.api.http
 import akka.actor.ActorSystem
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.Origin
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.server.directives.Credentials
@@ -33,13 +34,15 @@ class Routes(val config: Config) extends Cors {
   }
 
   val route: Route =
-    corsHandler((post & path("graphql")) {
-      authenticateOAuth2Async("tdr", tokenAuthenticator) { accessToken =>
-        entity(as[JsValue]) { requestJson =>
-          GraphQLServer.endpoint(requestJson, accessToken)
+    optionalHeaderValueByType[Origin](()) { originHeader =>
+      corsHandler((post & path("graphql")) {
+        authenticateOAuth2Async("tdr", tokenAuthenticator) { accessToken =>
+          entity(as[JsValue]) { requestJson =>
+            GraphQLServer.endpoint(requestJson, accessToken)
+          }
         }
-      }
+      }, originHeader)
     } ~ (get & path("healthcheck")) {
       complete(StatusCodes.OK)
-    })
+    }
 }

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -2,7 +2,7 @@ auth = {
   url = "http://localhost:8000/auth"
 }
 frontend = {
-  url = "https://tdr-frontend.example.com"
+  urls = ["https://tdr-frontend.example.com"]
 }
 akka = {
   test = {

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -2,7 +2,7 @@ auth = {
   url = "http://localhost:8000/auth"
 }
 frontend = {
-  url = "http://localhost:9000"
+  url = "https://tdr-frontend.example.com"
 }
 akka = {
   test = {

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/CorsSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/CorsSpec.scala
@@ -8,33 +8,97 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import uk.gov.nationalarchives.tdr.api.http.Routes
 
+import scala.jdk.CollectionConverters._
+
 class CorsSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest {
 
-  private val baseConfig = ConfigFactory.load()
+  private val defaultCrossOriginDomain = "https://some-frontend.example.com"
+  private val secondaryCrossOriginDomain = "https://other-frontend.example.com"
+  private val crossOriginUrls = List(defaultCrossOriginDomain, secondaryCrossOriginDomain).asJava
 
-  "the pre-flight request" should "allow requests from the frontend" in {
-    val frontendUrl = "https://some-frontend.example.com"
+  private val config = ConfigFactory.load()
+    .withValue("frontend.urls", ConfigValueFactory.fromIterable(crossOriginUrls))
+  private val route = new Routes(config).route
 
-    val testConfig = baseConfig.withValue("frontend.url", ConfigValueFactory.fromAnyRef(frontendUrl))
-    val route = new Routes(testConfig).route
-
+  "the pre-flight request" should "allow credentials, required headers and methods" in {
     Options("/graphql") ~> route ~> check {
-      header[`Access-Control-Allow-Origin`].map(_.value) should contain(frontendUrl)
       header[`Access-Control-Allow-Credentials`].map(_.value) should contain("true")
       header[`Access-Control-Allow-Headers`] should contain(`Access-Control-Allow-Headers`("Authorization", "Content-Type", "X-Requested-With"))
       header[`Access-Control-Allow-Methods`] should contain(`Access-Control-Allow-Methods`(OPTIONS, POST, GET))
     }
   }
 
-  "the pre-flight request" should "return the default origin if a different origin is given" in {
-    val frontendUrl = "https://some-frontend.example.com"
+  "the pre-flight request" should "allow requests from the default cross-origin URL" in {
+    val headers = List(Origin(defaultCrossOriginDomain))
 
-    val testConfig = baseConfig.withValue("frontend.url", ConfigValueFactory.fromAnyRef(frontendUrl))
-    val route = new Routes(testConfig).route
-
-    val headers = List(Origin("https://some-other-domain.example.com"))
     Options("/graphql").withHeaders(headers) ~> route ~> check {
-      header[`Access-Control-Allow-Origin`].map(_.value) should contain(frontendUrl)
+      header[`Access-Control-Allow-Origin`].map(_.value) should contain(defaultCrossOriginDomain)
+    }
+  }
+
+  "the pre-flight request" should "allow requests from other configured cross-origin URLs" in {
+    val headers = List(Origin(secondaryCrossOriginDomain))
+
+    Options("/graphql").withHeaders(headers) ~> route ~> check {
+      header[`Access-Control-Allow-Origin`].map(_.value) should contain(secondaryCrossOriginDomain )
+    }
+  }
+
+  "the pre-flight request" should "return the default origin if a different origin is given" in {
+    val headers = List(Origin("https://yet-another-domain.example.com"))
+
+    Options("/graphql").withHeaders(headers) ~> route ~> check {
+      header[`Access-Control-Allow-Origin`].map(_.value) should contain(defaultCrossOriginDomain)
+    }
+  }
+
+  "the pre-flight request" should "return the default origin if no origin is given" in {
+    Options("/graphql") ~> route ~> check {
+      header[`Access-Control-Allow-Origin`].map(_.value) should contain(defaultCrossOriginDomain)
+    }
+  }
+
+  "the pre-flight request" should "allow requests from an allowed port" in {
+    val allowedDomain = "http://localhost:1234"
+    val crossOriginUrls = List(allowedDomain).asJava
+
+    val testConfig = ConfigFactory.load()
+      .withValue("frontend.urls", ConfigValueFactory.fromIterable(crossOriginUrls))
+    val testRoute = new Routes(testConfig).route
+
+    val headers = List(Origin(allowedDomain))
+
+    Options("/graphql").withHeaders(headers) ~> testRoute ~> check {
+      header[`Access-Control-Allow-Origin`].map(_.value) should contain(allowedDomain)
+    }
+  }
+
+  "the pre-flight request" should "not allow requests from an allowed domain with a different port" in {
+    val allowedDomain = "http://localhost:1234"
+    val domainWithOtherPort = "http://localhost:5678"
+    val crossOriginUrls = List(allowedDomain).asJava
+
+    val testConfig = ConfigFactory.load()
+      .withValue("frontend.urls", ConfigValueFactory.fromIterable(crossOriginUrls))
+    val testRoute = new Routes(testConfig).route
+
+    val headers = List(Origin(domainWithOtherPort))
+
+    Options("/graphql").withHeaders(headers) ~> testRoute ~> check {
+      // Check that the response contains the only allowed port, NOT the requested port
+      header[`Access-Control-Allow-Origin`].map(_.value) should contain(allowedDomain)
+    }
+  }
+
+  "the pre-flight request" should "return an allowed domain if multiple origins are given" in {
+    val headers = List(Origin(
+      "https://yet-another-domain.example.com",
+      secondaryCrossOriginDomain,
+      "https://a-third-domain.example.com"
+    ))
+
+    Options("/graphql").withHeaders(headers) ~> route ~> check {
+      header[`Access-Control-Allow-Origin`].map(_.value) should contain(secondaryCrossOriginDomain)
     }
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/CorsSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/CorsSpec.scala
@@ -25,4 +25,16 @@ class CorsSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest {
       header[`Access-Control-Allow-Methods`] should contain(`Access-Control-Allow-Methods`(OPTIONS, POST, GET))
     }
   }
+
+  "the pre-flight request" should "return the default origin if a different origin is given" in {
+    val frontendUrl = "https://some-frontend.example.com"
+
+    val testConfig = baseConfig.withValue("frontend.url", ConfigValueFactory.fromAnyRef(frontendUrl))
+    val route = new Routes(testConfig).route
+
+    val headers = List(Origin("https://some-other-domain.example.com"))
+    Options("/graphql").withHeaders(headers) ~> route ~> check {
+      header[`Access-Control-Allow-Origin`].map(_.value) should contain(frontendUrl)
+    }
+  }
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/CorsSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/CorsSpec.scala
@@ -11,7 +11,7 @@ class CorsSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest {
 
   "the pre-flight request" should "allow requests from the frontend" in {
     Options("/graphql") ~> route ~> check {
-      header[`Access-Control-Allow-Origin`].map(_.value) should contain("http://localhost:9000")
+      header[`Access-Control-Allow-Origin`].map(_.value) should contain("https://tdr-frontend.example.com")
       header[`Access-Control-Allow-Credentials`].map(_.value) should contain("true")
       header[`Access-Control-Allow-Headers`] should contain(`Access-Control-Allow-Headers`("Authorization", "Content-Type", "X-Requested-With"))
       header[`Access-Control-Allow-Methods`] should contain(`Access-Control-Allow-Methods`(OPTIONS, POST, GET))

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/CorsSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/CorsSpec.scala
@@ -3,11 +3,14 @@ package uk.gov.nationalarchives.tdr.api.routes
 import akka.http.scaladsl.model.HttpMethods.{GET, OPTIONS, POST}
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import com.typesafe.config.ConfigFactory
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import uk.gov.nationalarchives.tdr.api.http.Routes.route
+import uk.gov.nationalarchives.tdr.api.http.Routes
 
 class CorsSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest {
+
+  val route = new Routes(ConfigFactory.load()).route
 
   "the pre-flight request" should "allow requests from the frontend" in {
     Options("/graphql") ~> route ~> check {

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/CorsSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/CorsSpec.scala
@@ -3,18 +3,23 @@ package uk.gov.nationalarchives.tdr.api.routes
 import akka.http.scaladsl.model.HttpMethods.{GET, OPTIONS, POST}
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import uk.gov.nationalarchives.tdr.api.http.Routes
 
 class CorsSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest {
 
-  val route = new Routes(ConfigFactory.load()).route
+  private val baseConfig = ConfigFactory.load()
 
   "the pre-flight request" should "allow requests from the frontend" in {
+    val frontendUrl = "https://some-frontend.example.com"
+
+    val testConfig = baseConfig.withValue("frontend.url", ConfigValueFactory.fromAnyRef(frontendUrl))
+    val route = new Routes(testConfig).route
+
     Options("/graphql") ~> route ~> check {
-      header[`Access-Control-Allow-Origin`].map(_.value) should contain("https://tdr-frontend.example.com")
+      header[`Access-Control-Allow-Origin`].map(_.value) should contain(frontendUrl)
       header[`Access-Control-Allow-Credentials`].map(_.value) should contain("true")
       header[`Access-Control-Allow-Headers`] should contain(`Access-Control-Allow-Headers`("Authorization", "Content-Type", "X-Requested-With"))
       header[`Access-Control-Allow-Methods`] should contain(`Access-Control-Allow-Methods`(OPTIONS, POST, GET))

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/CorsSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/CorsSpec.scala
@@ -1,0 +1,20 @@
+package uk.gov.nationalarchives.tdr.api.routes
+
+import akka.http.scaladsl.model.HttpMethods.{GET, OPTIONS, POST}
+import akka.http.scaladsl.model.headers._
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import uk.gov.nationalarchives.tdr.api.http.Routes.route
+
+class CorsSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest {
+
+  "the pre-flight request" should "allow requests from the frontend" in {
+    Options("/graphql") ~> route ~> check {
+      header[`Access-Control-Allow-Origin`].map(_.value) should contain("http://localhost:9000")
+      header[`Access-Control-Allow-Credentials`].map(_.value) should contain("true")
+      header[`Access-Control-Allow-Headers`] should contain(`Access-Control-Allow-Headers`("Authorization", "Content-Type", "X-Requested-With"))
+      header[`Access-Control-Allow-Methods`] should contain(`Access-Control-Allow-Methods`(OPTIONS, POST, GET))
+    }
+  }
+}

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/RouteAuthenticationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/RouteAuthenticationSpec.scala
@@ -5,12 +5,15 @@ import akka.http.scaladsl.model.{ContentTypes, StatusCodes}
 import akka.http.scaladsl.server.AuthenticationFailedRejection
 import akka.http.scaladsl.server.AuthenticationFailedRejection.{CredentialsMissing, CredentialsRejected}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import uk.gov.nationalarchives.tdr.api.http.Routes.route
+import com.typesafe.config.ConfigFactory
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import uk.gov.nationalarchives.tdr.api.utils.TestUtils.{validUserToken,invalidToken}
+import uk.gov.nationalarchives.tdr.api.http.Routes
+import uk.gov.nationalarchives.tdr.api.utils.TestUtils.{invalidToken, validUserToken}
 
 class RouteAuthenticationSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest {
+
+  val route = new Routes(ConfigFactory.load()).route
 
   "The api" should "return ok" in {
     Get("/healthcheck") ~> route ~> check {

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestRequest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestRequest.scala
@@ -4,16 +4,20 @@ import akka.http.scaladsl.model.ContentTypes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.http.scaladsl.unmarshalling.FromResponseUnmarshaller
+import com.typesafe.config.ConfigFactory
 import io.circe.Decoder
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import uk.gov.nationalarchives.tdr.api.http.Routes.route
+import uk.gov.nationalarchives.tdr.api.http.Routes
 import uk.gov.nationalarchives.tdr.api.utils.TestUtils.unmarshalResponse
 
 import scala.io.Source.fromResource
 import scala.reflect.ClassTag
 
 trait TestRequest extends AnyFlatSpec with ScalatestRouteTest with Matchers {
+
+  val route = new Routes(ConfigFactory.load()).route
+
   def runTestRequest[A](prefix: String)(queryFileName: String, token: OAuth2BearerToken)
                        (implicit decoder: Decoder[A], classTag: ClassTag[A])
   : A = {


### PR DESCRIPTION
Configure frontend domains as a list rather than as a single value.

Use this to allow cross-origin requests to the integration API from the integration frontend AND the local dev environment.

This makes it possible to do local frontend development without setting up the rest of the TDR stack.

I haven't fully tested this locally because of the [current issues with local dev](https://national-archives.atlassian.net/browse/TDR-111). I have checked that the MVC site can still make requests to the API. If there are any issues, they'll be with JavaScript requests, but that might be easier to spot when it's deployed to integration.