### PR TITLE
Fix cross-origin domain in integration

### DIFF
--- a/src/main/resources/application.intg.conf
+++ b/src/main/resources/application.intg.conf
@@ -5,6 +5,6 @@ frontend = {
   // frontend development without having to run the rest of the stack locally
   urls = [
     ${FRONTEND_URL},
-    "localhost:9000"
+    "http://localhost:9000"
   ]
 }


### PR DESCRIPTION
Add missing "http" scheme to localhost cross-origin domain.