### PR TITLE
Split up endpoints into graphql and admin

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/GraphQlTypes.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/GraphQlTypes.scala
@@ -5,15 +5,26 @@ import uk.gov.nationalarchives.tdr.api.graphql.fields._
 
 object GraphQlTypes {
 
-  private val QueryType = ObjectType("Query", SeriesFields.queryFields ++ ConsignmentFields.queryFields ++ TransferAgreementFields.queryFields)
-  private val MutationType = ObjectType("Mutation",
+  private val UserQueryType = ObjectType("Query", SeriesFields.queryFields ++ ConsignmentFields.queryFields ++ TransferAgreementFields.queryFields)
+  private val UserMutationType: ObjectType[ConsignmentApiContext, Unit] = ObjectType("Mutation",
     ConsignmentFields.mutationFields ++
     TransferAgreementFields.mutationFields ++
     ClientFileMetadataFields.mutationFields ++
-    FileFields.mutationFields ++
-    AntivirusMetadataFields.mutationFields ++
-    FileMetadataFields.mutationFields
+    FileFields.mutationFields
   )
 
-  val schema: Schema[ConsignmentApiContext, Unit] = Schema(QueryType, Some(MutationType))
+  private val AdminMutationType: ObjectType[ConsignmentApiContext, Unit] = ObjectType("Mutation",
+    AntivirusMetadataFields.mutationFields ++
+      FileMetadataFields.mutationFields
+  )
+
+  private val AllMutationType = ObjectType("Mutation",AdminMutationType.fieldsFn() ++ UserMutationType.fieldsFn())
+
+  val userSchema: Schema[ConsignmentApiContext, Unit] = Schema(UserQueryType, Some(UserMutationType))
+
+  //You can't have a query object without fields and the argument is mandatory so I'll put the user queries in.
+  val adminSchema: Schema[ConsignmentApiContext, Unit] = Schema(UserQueryType, Some(AdminMutationType))
+
+  //Needed for the schema gen. You can only have one schema set
+  val schema = Schema(UserQueryType, Some(AllMutationType))
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/AntivirusMetadataRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/AntivirusMetadataRouteSpec.scala
@@ -36,7 +36,7 @@ class AntivirusMetadataRouteSpec extends AnyFlatSpec with Matchers with TestRequ
   }
 
   val runTestMutation: (String, OAuth2BearerToken) => GraphqlMutationData =
-    runTestRequest[GraphqlMutationData](addAVMetadataJsonFilePrefix)
+    runTestRequest[GraphqlMutationData](addAVMetadataJsonFilePrefix, "/admin")
   val expectedMutationResponse: String => GraphqlMutationData =
     getDataFromFile[GraphqlMutationData](addAVMetadataJsonFilePrefix)
 

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileMetadataRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileMetadataRouteSpec.scala
@@ -26,7 +26,7 @@ class FileMetadataRouteSpec extends AnyFlatSpec with Matchers with TestRequest w
   case class AddFileMetadata(addFileMetadata: FileMetadata)
 
   val runTestMutation: (String, OAuth2BearerToken) => GraphqlMutationData =
-    runTestRequest[GraphqlMutationData](addFileMetadataJsonFilePrefix)
+    runTestRequest[GraphqlMutationData](addFileMetadataJsonFilePrefix, "/admin")
 
   val expectedMutationResponse: String => GraphqlMutationData =
     getDataFromFile[GraphqlMutationData](addFileMetadataJsonFilePrefix)

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestRequest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestRequest.scala
@@ -18,12 +18,12 @@ trait TestRequest extends AnyFlatSpec with ScalatestRouteTest with Matchers {
 
   val route = new Routes(ConfigFactory.load()).route
 
-  def runTestRequest[A](prefix: String)(queryFileName: String, token: OAuth2BearerToken)
+  def runTestRequest[A](prefix: String, urlPath: String = "/graphql")(queryFileName: String, token: OAuth2BearerToken)
                        (implicit decoder: Decoder[A], classTag: ClassTag[A])
   : A = {
     implicit val unmarshaller: FromResponseUnmarshaller[A] = unmarshalResponse[A]()
     val query: String = fromResource(prefix + s"$queryFileName.json").mkString
-    Post("/graphql").withEntity(ContentTypes.`application/json`, query) ~> addCredentials(token) ~> route ~> check {
+    Post(urlPath).withEntity(ContentTypes.`application/json`, query) ~> addCredentials(token) ~> route ~> check {
       responseAs[A]
     }
   }


### PR DESCRIPTION
This isn't going to be merged but I've raised this so people can see the diff a bit easier. 
It's part of the spike to see about splitting the graphql server into two separate endpoints.