### PR TITLE
Upgrade Scala and SBT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ version := "0.1.0-SNAPSHOT"
 
 description := "The consignment API for TDR"
 
-scalaVersion := "2.13.0"
+scalaVersion := "2.13.3"
 scalacOptions ++= Seq("-deprecation", "-feature")
 
 resolvers ++= Seq[Resolver](

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.3.13


### PR DESCRIPTION
Upgrade to the latest versions of Scala and SBT.

This fixes a compiler error on my dev machine that I can't work out the cause of:

```
java.io.IOError: java.lang.RuntimeException: /packages cannot be represented as URI
```