### PR TITLE
Make antivirus metadata fields non-optional

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-optics" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-generic-extras" % circeVersion,
-  "uk.gov.nationalarchives" %% "consignment-api-db" % "0.0.27",
+  "uk.gov.nationalarchives" %% "consignment-api-db" % "0.0.28",
   "org.postgresql" % "postgresql" % "42.2.11",
   "com.typesafe.slick" %% "slick" % "3.3.2",
   "com.typesafe.slick" %% "slick-hikaricp" % "3.3.2",

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/AntivirusMetadataFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/AntivirusMetadataFields.scala
@@ -12,19 +12,19 @@ import uk.gov.nationalarchives.tdr.api.graphql.fields.FieldTypes._
 
 object AntivirusMetadataFields {
   case class AntivirusMetadata(fileId: UUID,
-                               software: Option[String] = None,
+                               software: String,
                                value: Option[String] = None,
-                               softwareVersion: Option[String] = None,
-                               databaseVersion: Option[String] = None,
-                               result: Option[String] = None,
+                               softwareVersion: String,
+                               databaseVersion: String,
+                               result: String,
                                datetime: Long)
 
   case class AddAntivirusMetadataInput(fileId: UUID,
-                                       software: Option[String] = None,
+                                       software: String,
                                        value: Option[String] = None,
-                                       softwareVersion: Option[String] = None,
-                                       databaseVersion: Option[String] = None,
-                                       result: Option[String] = None,
+                                       softwareVersion: String,
+                                       databaseVersion: String,
+                                       result: String,
                                        datetime: Long)
 
   implicit val AntivirusMetadataType: ObjectType[Unit, AntivirusMetadata] = deriveObjectType[Unit, AntivirusMetadata]()

--- a/src/test/resources/json/addavmetadata_data_datetime_missing.json
+++ b/src/test/resources/json/addavmetadata_data_datetime_missing.json
@@ -1,1 +1,0 @@
-{"data":null,"errors":[{"message":  "Field 'AddAntivirusMetadataInput.datetime' of required type 'Long!' was not provided. (line 1, column 59):\nmutation {addAntivirusMetadata(addAntivirusMetadataInput: {fileId: \"07a3a4bd-0281-4a6d-a4c1-8fa3239e1313\", softwareVersion: \"0.1\"}) {fileId, softwareVersion}}\n                                                          ^"}]}

--- a/src/test/resources/json/addavmetadata_mutation_missingdatetime.json
+++ b/src/test/resources/json/addavmetadata_mutation_missingdatetime.json
@@ -1,1 +1,0 @@
-{"query":"mutation {addAntivirusMetadata(addAntivirusMetadataInput: {fileId: \"07a3a4bd-0281-4a6d-a4c1-8fa3239e1313\", softwareVersion: \"0.1\"}) {fileId, softwareVersion}}"}

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/AntivirusMetadataRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/AntivirusMetadataRouteSpec.scala
@@ -78,14 +78,6 @@ class AntivirusMetadataRouteSpec extends AnyFlatSpec with Matchers with TestRequ
     checkNoAntivirusMetadataAdded()
   }
 
-  "addAntivirusMetadata" should "throw an error if the field datetime is not provided" in {
-    val expectedResponse: GraphqlMutationData = expectedMutationResponse("data_datetime_missing")
-    val response: GraphqlMutationData = runTestMutation("mutation_missingdatetime", validBackendChecksToken("antivirus"))
-
-    response.errors.head.message should equal (expectedResponse.errors.head.message)
-    checkNoAntivirusMetadataAdded()
-  }
-
   private def checkAntivirusMetadataExists(fileId: UUID): Unit = {
     val sql = "select * from AVMetadata where FileId = ?;"
     val ps: PreparedStatement = DbConnection.db.source.createConnection().prepareStatement(sql)

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/AntivirusMetadataServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/AntivirusMetadataServiceSpec.scala
@@ -27,11 +27,11 @@ class AntivirusMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Ma
     val fileRepositoryMock = mock[FileRepository]
     val mockResponse = Future.successful(AvmetadataRow(
       fixedFileUuid,
-      Some("software"),
+      "software",
       Some("value"),
-      Some("software version"),
-      Some("database version"),
-      Some("result"),
+      "software version",
+      "database version",
+      "result",
       dummyTimestamp
     ))
 
@@ -40,20 +40,20 @@ class AntivirusMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Ma
     val service: AntivirusMetadataService = new AntivirusMetadataService(avRepositoryMock, fileRepositoryMock)
     val result = service.addAntivirusMetadata(AddAntivirusMetadataInput(
       fixedFileUuid,
-      Some("software"),
+      "software",
       Some("value"),
-      Some("software version"),
-      Some("database version"),
-      Some("result"),
+      "software version",
+      "database version",
+      "result",
       dummyInstant.toEpochMilli
     )).futureValue
 
     result.fileId shouldBe fixedFileUuid
-    result.software.get shouldBe "software"
+    result.software shouldBe "software"
     result.value.get shouldBe "value"
-    result.softwareVersion.get shouldBe "software version"
-    result.databaseVersion.get shouldBe "database version"
-    result.result.get shouldBe "result"
+    result.softwareVersion shouldBe "software version"
+    result.databaseVersion shouldBe "database version"
+    result.result shouldBe "result"
     result.datetime shouldBe dummyInstant.toEpochMilli
   }
 }


### PR DESCRIPTION
The antivirus scan generates data for all of these fields, so they shouldn't be optional. Upgrade to the latest version of the generated database classes, which makes the fields mandatory in the database, and also make them mandatory in the GraphQL schema.

The only exception to this is the 'value' field, which is not used and will be deleted in a later commit.