### PR TITLE
Remove Jenkins post-build agent to fix Jenkins deadlocks

### DIFF
--- a/Jenkinsfile-testing
+++ b/Jenkinsfile-testing
@@ -83,17 +83,13 @@ pipeline {
   }
   post {
     failure {
-        node('master') {
-            script {
-                tdr.reportFailedBuildToGitHub(repo, env.GIT_COMMIT)
-            }
-        }
+      script {
+        tdr.reportFailedBuildToGitHub(repo, env.GIT_COMMIT)
+      }
     }
     success {
-      node('master') {
-            script {
-                tdr.reportSuccessfulBuildToGitHub(repo, env.GIT_COMMIT)
-            }
+      script {
+        tdr.reportSuccessfulBuildToGitHub(repo, env.GIT_COMMIT)
       }
     }
   }


### PR DESCRIPTION
There is no need to specify an agent for the post-build steps because it is the same as the pipeline's default agent. Re-specifying the agent only leads to deadlocks because the build tries to wait for another node to become available. If two builds are running at the same time, they are using all the available nodes already, so they get stuck.