### PR TITLE
Upgrade generated DB classes to remove 'value' from antivirus metadata

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-optics" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-generic-extras" % circeVersion,
-  "uk.gov.nationalarchives" %% "consignment-api-db" % "0.0.28",
+  "uk.gov.nationalarchives" %% "consignment-api-db" % "0.0.29",
   "org.postgresql" % "postgresql" % "42.2.11",
   "com.typesafe.slick" %% "slick" % "3.3.2",
   "com.typesafe.slick" %% "slick-hikaricp" % "3.3.2",

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/AntivirusMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/AntivirusMetadataService.scala
@@ -17,7 +17,6 @@ class AntivirusMetadataService(antivirusMetadataRepository: AntivirusMetadataRep
     val inputRow = AvmetadataRow(
       input.fileId,
       input.software,
-      None,
       input.softwareVersion,
       input.databaseVersion,
       input.result,

--- a/src/test/resources/scripts/init.sql
+++ b/src/test/resources/scripts/init.sql
@@ -59,7 +59,6 @@ CREATE TABLE IF NOT EXISTS File (
 CREATE TABLE IF NOT EXISTS AVMetadata (
     FileId uuid DEFAULT NULL,
     Software varchar(255) NOT NULL,
-    Value varchar(255) DEFAULT NULL,
     SoftwareVersion varchar(255) NOT NULL,
     DatabaseVersion varchar(255) NOT NULL,
     Result varchar(255) NOT NULL,

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/AntivirusMetadataServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/AntivirusMetadataServiceSpec.scala
@@ -26,7 +26,6 @@ class AntivirusMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Ma
     val mockResponse = Future.successful(AvmetadataRow(
       fixedFileUuid,
       "software",
-      Some("value"),
       "software version",
       "database version",
       "result",


### PR DESCRIPTION
This column is [about to be removed from the database](https://github.com/nationalarchives/tdr-consignment-api-data/pull/32), so update the consignment-api-db dependency, which removes it from the database classes.

Also remove the column from the test database. The tests pass before and after this change.