### PR TITLE
Make ID non-optional in the Consignment domain model

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/DeferredResolver.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/DeferredResolver.scala
@@ -12,21 +12,16 @@ class DeferredResolver extends sangria.execution.deferred.DeferredResolver[Consi
   // We may at some point need to do authorisation in this method. There is a ensurePermissions method which needs to be called before returning data.
   override def resolve(deferred: Vector[Deferred[Any]], context: ConsignmentApiContext, queryState: Any)(implicit ec: ExecutionContext): Vector[Future[Any]] = {
     deferred.map {
-      case DeferTotalFiles(consignmentId) => consignmentId.map(id => context.fileService.fileCount(id)).getOrElse(Future.successful(0))
+      case DeferTotalFiles(consignmentId) => context.fileService.fileCount(consignmentId)
       case DeferFileChecksProgress(consignmentId) =>
-        consignmentId.map(
-          id => context.consignmentService.getConsignmentFileProgress(id)
-        ).getOrElse(Future.successful(0))
+        context.consignmentService.getConsignmentFileProgress(consignmentId)
       case DeferParentFolder(consignmentId) =>
-        consignmentId match {
-          case Some(id) => context.consignmentService.getConsignmentParentFolder(id)
-          case None => Future.successful(None)
-        }
+        context.consignmentService.getConsignmentParentFolder(consignmentId)
       case other => throw UnsupportedDeferError(other)
     }
   }
 }
 
-case class DeferTotalFiles(consignmentId: Option[UUID]) extends Deferred[Int]
-case class DeferFileChecksProgress(consignmentId: Option[UUID]) extends Deferred[FileChecks]
-case class DeferParentFolder(consignmentId: Option[UUID]) extends Deferred[Option[String]]
+case class DeferTotalFiles(consignmentId: UUID) extends Deferred[Int]
+case class DeferFileChecksProgress(consignmentId: UUID) extends Deferred[FileChecks]
+case class DeferParentFolder(consignmentId: UUID) extends Deferred[Option[String]]

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentFields.scala
@@ -11,7 +11,7 @@ import uk.gov.nationalarchives.tdr.api.graphql.fields.FieldTypes._
 import uk.gov.nationalarchives.tdr.api.graphql.{ConsignmentApiContext, DeferFileChecksProgress, DeferParentFolder, DeferTotalFiles}
 
 object ConsignmentFields {
-  case class Consignment(consignmentid: Option[UUID] = None, userid: UUID, seriesid: UUID)
+  case class Consignment(consignmentid: UUID, userid: UUID, seriesid: UUID)
   case class AddConsignmentInput(seriesid: UUID)
   case class AntivirusProgress(filesProcessed: Int)
   case class ChecksumProgress(filesProcessed: Int)

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentService.scala
@@ -21,12 +21,12 @@ class ConsignmentService(
 
   def addConsignment(addConsignmentInput: AddConsignmentInput, userId: Option[UUID]): Future[Consignment] = {
       val consignmentRow = ConsignmentRow(uuidSource.uuid, addConsignmentInput.seriesid, userId.get, Timestamp.from(timeSource.now))
-      consignmentRepository.addConsignment(consignmentRow).map(row => Consignment(Some(row.consignmentid), row.userid, row.seriesid))
+      consignmentRepository.addConsignment(consignmentRow).map(row => Consignment(row.consignmentid, row.userid, row.seriesid))
     }
 
   def getConsignment(consignmentId: UUID): Future[Option[Consignment]] = {
     val consignments = consignmentRepository.getConsignment(consignmentId)
-    consignments.map(rows => rows.headOption.map(row => Consignment(Some(row.consignmentid), row.userid, row.seriesid)))
+    consignments.map(rows => rows.headOption.map(row => Consignment(row.consignmentid, row.userid, row.seriesid)))
   }
 
   def consignmentHasFiles(consignmentId: UUID): Future[Boolean] = {

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentServiceSpec.scala
@@ -39,11 +39,10 @@ class ConsignmentServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers
       FixedTimeSource,
       fixedUuidSource)
     val result: Consignment = consignmentService.addConsignment(AddConsignmentInput(seriesUuid), Some(userUuid)).futureValue
-    result.consignmentid shouldBe Some(consignmentUuid)
+    result.consignmentid shouldBe consignmentUuid
     result.seriesid shouldBe seriesUuid
     result.userid shouldBe userUuid
-    result.consignmentid shouldBe defined
-    result.consignmentid.get shouldBe consignmentUuid
+    result.consignmentid shouldBe consignmentUuid
   }
 
   "createConsignment" should "link a consignment to the user's ID" in {
@@ -94,7 +93,7 @@ class ConsignmentServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers
 
     verify(consignmentRepoMock, times(1)).getConsignment(any[UUID])
     val consignment: ConsignmentFields.Consignment = response.get
-    consignment.consignmentid should equal(Some(consignmentUuid))
+    consignment.consignmentid should equal(consignmentUuid)
     consignment.seriesid should equal(seriesUuid)
     consignment.userid should equal(userUuid)
   }


### PR DESCRIPTION
Refactor the Consignment model so that the ID is compulsory. It's not clear why this was an Option in the first place, but removing it makes the code simpler because the deferred resolvers don't need to decide what to do if the value is None.