### PR TITLE
Pass keycloak deployment to auth utils

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-testkit" % "2.6.3" % Test,
   "com.tngtech.keycloakmock" % "mock" % "0.2.0" % Test,
   "com.h2database" % "h2" % "1.4.200" % Test,
-  "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.21",
+  "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.23",
   "io.github.hakky54" % "logcaptor" % "2.1.0" % Test
 )
 

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/http/Routes.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/http/Routes.scala
@@ -30,7 +30,6 @@ class Routes(val config: Config) extends Cors {
 
   val ttlSeconds: Int = 10
 
-
   // We return None rather than a failed future because we're following the async authenticator docs
   // https://doc.akka.io/docs/akka-http/10.0/routing-dsl/directives/security-directives/authenticateOAuth2Async.html
   def tokenAuthenticator(credentials: Credentials): Future[Option[Token]] = {

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/http/Routes.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/http/Routes.scala
@@ -26,9 +26,8 @@ class Routes(val config: Config) extends Cors {
   implicit val materializer: Materializer = Materializer(system)
   implicit val executionContext: ExecutionContext = system.dispatcher
   val url: String = config.getString("auth.url")
-  implicit val keycloakDeployment: TdrKeycloakDeployment = TdrKeycloakDeployment(url, "tdr", 3600)
-
-  val ttlSeconds: Int = 10
+  val ttlSeconds: Int = 3600
+  implicit val keycloakDeployment: TdrKeycloakDeployment = TdrKeycloakDeployment(url, "tdr", ttlSeconds)
 
   // We return None rather than a failed future because we're following the async authenticator docs
   // https://doc.akka.io/docs/akka-http/10.0/routing-dsl/directives/security-directives/authenticateOAuth2Async.html


### PR DESCRIPTION
Each time we were getting a token, we were creating a keycloak
deployment which contacts the keycloak server to get the oidc
configuration. This is a waste so the auth utils library has been
changed to take an implicit KeycloakConfiguration object. This means
that the config it only got once.
