### PR TITLE
Refactor saving parent folder

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepository.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepository.scala
@@ -67,8 +67,8 @@ class ConsignmentRepository(db: Database) {
     db.run(query.result)
   }
 
-  def addParentFolder(consignmentId: UUID, parentFolder: Option[String])(implicit executionContext: ExecutionContext): Future[Unit] = {
-    val updateAction = Consignment.filter(_.consignmentid === consignmentId).map(c => c.parentfolder).update(parentFolder)
+  def addParentFolder(consignmentId: UUID, parentFolder: String)(implicit executionContext: ExecutionContext): Future[Unit] = {
+    val updateAction = Consignment.filter(_.consignmentid === consignmentId).map(c => c.parentfolder).update(Option(parentFolder))
     db.run(updateAction).map(_ => ())
   }
 

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/FileFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/FileFields.scala
@@ -15,7 +15,7 @@ import uk.gov.nationalarchives.tdr.api.graphql.fields.FieldTypes._
 object FileFields {
   case class Files(fileIds: Seq[UUID])
 
-  case class AddFilesInput(consignmentId: UUID, numberOfFiles: Int, parentFolder: Option[String]) extends UserOwnsConsignment
+  case class AddFilesInput(consignmentId: UUID, numberOfFiles: Int, parentFolder: String) extends UserOwnsConsignment
   implicit val AddFilesInputType: InputObjectType[AddFilesInput] = deriveInputObjectType[AddFilesInput]()
   implicit val FileType: ObjectType[Unit, Files]  = deriveObjectType[Unit, Files]()
   private val FileInputArg = Argument("addFilesInput", AddFilesInputType)

--- a/src/test/resources/json/addfile_mutation_alldata.json
+++ b/src/test/resources/json/addfile_mutation_alldata.json
@@ -1,1 +1,1 @@
-{"query":"mutation {addFiles(addFilesInput: {consignmentId: \"6e3b76c4-1745-4467-8ac5-b4dd736e1b3e\", numberOfFiles: 3}) {fileIds}}"}
+{"query":"mutation {addFiles(addFilesInput: {consignmentId: \"6e3b76c4-1745-4467-8ac5-b4dd736e1b3e\", numberOfFiles: 3, parentFolder: \"PARENT FOLDER TEST\"}) {fileIds}}"}

--- a/src/test/resources/json/addfile_mutation_one_file.json
+++ b/src/test/resources/json/addfile_mutation_one_file.json
@@ -1,1 +1,1 @@
-{"query":"mutation {addFiles(addFilesInput:{consignmentId: \"6e3b76c4-1745-4467-8ac5-b4dd736e1b3e\", numberOfFiles: 1}) {fileIds}}"}
+{"query":"mutation {addFiles(addFilesInput:{consignmentId: \"6e3b76c4-1745-4467-8ac5-b4dd736e1b3e\", numberOfFiles: 1, parentFolder: \"PARENT FOLDER TEST\"}) {fileIds}}"}

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepositorySpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepositorySpec.scala
@@ -21,7 +21,7 @@ class ConsignmentRepositorySpec extends AnyFlatSpec with ScalaFutures with Match
 
     TestUtils.createConsignment(consignmentId, userId)
 
-    consignmentRepository.addParentFolder(consignmentId, Option("TEST ADD PARENT FOLDER NAME")).futureValue
+    consignmentRepository.addParentFolder(consignmentId, "TEST ADD PARENT FOLDER NAME").futureValue
 
     val parentFolderName = consignmentRepository.getConsignment(consignmentId).futureValue.map(consignment => consignment.parentfolder)
 
@@ -34,7 +34,7 @@ class ConsignmentRepositorySpec extends AnyFlatSpec with ScalaFutures with Match
     val consignmentId = UUID.fromString("b6da7577-3800-4ebc-821b-9d33e52def9e")
 
     TestUtils.createConsignment(consignmentId, userId)
-    consignmentRepository.addParentFolder(consignmentId, Option("TEST GET PARENT FOLDER NAME"))
+    consignmentRepository.addParentFolder(consignmentId, "TEST GET PARENT FOLDER NAME")
 
     val parentFolderName = consignmentRepository.getParentFolder(consignmentId).futureValue
 

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
@@ -31,10 +31,10 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val mockFileResponse = Future.successful(List(FileRow(fileId, consignmentId, uuid, Timestamp.from(Instant.now))))
     when(fileRepositoryMock.addFiles(any[List[FileRow]])).thenReturn(mockFileResponse)
     val mockConsignmentResponse = Future.successful(())
-    when(consignmentRepositoryMock.addParentFolder(consignmentId, Option("Parent folder name"))).thenReturn(mockConsignmentResponse)
+    when(consignmentRepositoryMock.addParentFolder(consignmentId, "Parent folder name")).thenReturn(mockConsignmentResponse)
 
     val fileService = new FileService(fileRepositoryMock, consignmentRepositoryMock, FixedTimeSource, fixedUuidSource)
-    val result: Files = fileService.addFile(AddFilesInput(consignmentId, 1, Option("Parent folder name")), uuid).futureValue
+    val result: Files = fileService.addFile(AddFilesInput(consignmentId, 1, "Parent folder name"), uuid).futureValue
 
     result.fileIds shouldBe List(fileId)
   }
@@ -59,10 +59,10 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val mockResponse = Future.successful(List(fileRowOne, fileRowTwo, fileRowThree))
     when(fileRepositoryMock.addFiles(captor.capture())).thenReturn(mockResponse)
     val mockConsignmentResponse = Future.successful(())
-    when(consignmentRepositoryMock.addParentFolder(consignmentUuid, Option("Parent folder name"))).thenReturn(mockConsignmentResponse)
+    when(consignmentRepositoryMock.addParentFolder(consignmentUuid, "Parent folder name")).thenReturn(mockConsignmentResponse)
 
     val fileService = new FileService(fileRepositoryMock, consignmentRepositoryMock, FixedTimeSource, fixedUuidSource)
-    val result: Files = fileService.addFile(AddFilesInput(consignmentUuid, 3, Option("Parent folder name")),userUuid).futureValue
+    val result: Files = fileService.addFile(AddFilesInput(consignmentUuid, 3, "Parent folder name"),userUuid).futureValue
 
     captor.getAllValues.size should equal(1)
     captor.getAllValues.get(0).length should equal(3)
@@ -86,9 +86,9 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val mockResponse = Future.successful(List(FileRow(fileUuid, consignmentUuid, userId, Timestamp.from(FixedTimeSource.now))))
     when(fileRepositoryMock.addFiles(captor.capture())).thenReturn(mockResponse)
     val mockConsignmentResponse = Future.successful(())
-    when(consignmentRepositoryMock.addParentFolder(consignmentUuid, Option("Parent folder name"))).thenReturn(mockConsignmentResponse)
+    when(consignmentRepositoryMock.addParentFolder(consignmentUuid, "Parent folder name")).thenReturn(mockConsignmentResponse)
 
-    fileService.addFile(AddFilesInput(consignmentUuid, 1, Option("Parent folder name")),userId).futureValue
+    fileService.addFile(AddFilesInput(consignmentUuid, 1, "Parent folder name"),userId).futureValue
 
     verify(fileRepositoryMock).addFiles(expectedRow)
     captor.getAllValues.size should equal(1)


### PR DESCRIPTION
These changes refactor the functions saving the parent folder name to the consignment table. Now that the front end is reliably saving the parent folder, it can be a `String` rather than `Option[String]`. I also amended some tests to reflect this change.