### PR TITLE
Remove allDigital field from agreement complete check

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/TransferAgreementService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/TransferAgreementService.scala
@@ -31,7 +31,7 @@ class TransferAgreementService(transferAgreementRepository: TransferAgreementRep
   private def agreed(field: Option[Boolean]) = field.isDefined && field.get
 
   private def isAgreementComplete(ta: TransferagreementRow): Boolean = {
-    val fields = List(ta.allcrowncopyright, ta.alldigital, ta.allenglish, ta.allpublicrecords, ta.appraisalselectionsignedoff, ta.sensitivityreviewsignedoff)
+    val fields = List(ta.allcrowncopyright, ta.allenglish, ta.allpublicrecords, ta.appraisalselectionsignedoff, ta.sensitivityreviewsignedoff)
     fields.forall(agreed)
   }
 


### PR DESCRIPTION
Before removing the allDigital field from the API safely need to remove it from Transfer Agreement complete check

If not removed when allDigital field not passed in check fails and user is not redirected to the upload page