### PR TITLE
Ensure p11-kit version updated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM openjdk:16-jdk-alpine
 WORKDIR /api
 RUN addgroup --system apigroup && adduser --system apiuser -G apigroup && \
     apk update && \
+    apk upgrade p11-kit && \
     apk add ca-certificates && \
     chown -R apiuser /api && \
     wget https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem


### PR DESCRIPTION
Fix for a number of security vulnerabilities identified with an older version of the p11-kit: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-29363; https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-29362; https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-29361