### PR TITLE
Downgrade the JDK from version 16 to 15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:16-jdk-alpine
+FROM openjdk:15-jdk-alpine
 #For alpine versions need to create a group before adding a user to the image
 WORKDIR /api
 RUN addgroup --system apigroup && adduser --system apiuser -G apigroup && \


### PR DESCRIPTION
Version 15 is the latest stable release. Version 16 seems to work on this project, but has been causing errors in tdr-transfer-frontend: https://github.com/nationalarchives/tdr-transfer-frontend/pull/393