### PR TITLE
Delete references to ClientFileMetadata table from tests

### DIFF
--- a/src/test/resources/scripts/init.sql
+++ b/src/test/resources/scripts/init.sql
@@ -45,18 +45,6 @@ CREATE TABLE IF NOT EXISTS ConsignmentMetadata (
     PRIMARY KEY (MetadataId)
 );
 
-CREATE TABLE IF NOT EXISTS ClientFileMetadata (
-   FileId uuid NOT NULL DEFAULT '6e3b76c4-1745-4467-8ac5-b4dd736e1b3e',
-   OriginalPath varchar(255) DEFAULT NULL,
-   Checksum varchar(255) DEFAULT NULL,
-   ChecksumType varchar(255) DEFAULT NULL,
-   LastModified timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-   Filesize bigint DEFAULT NULL,
-   Datetime timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-   ClientFileMetadataId uuid NOT NULL DEFAULT '6e3b76c4-1745-4467-8ac5-b4dd736e1b3e',
-   PRIMARY KEY (ClientFileMetadataId)
-);
-
 CREATE TABLE IF NOT EXISTS File (
    FileId uuid NOT NULL DEFAULT '6e3b76c4-1745-4467-8ac5-b4dd736e1b3e',
    ConsignmentId uuid NOT NULL,

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ClientFileMetadataRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ClientFileMetadataRouteSpec.scala
@@ -168,7 +168,6 @@ class ClientFileMetadataRouteSpec extends AnyFlatSpec with Matchers with TestReq
   private def resetDatabase(): Unit = {
     DbConnection.db.source.createConnection().prepareStatement("DELETE FROM FileMetadata").executeUpdate()
     DbConnection.db.source.createConnection().prepareStatement("DELETE FROM FileProperty").executeUpdate()
-    DbConnection.db.source.createConnection().prepareStatement("DELETE FROM ClientFileMetadata").executeUpdate()
     DbConnection.db.source.createConnection().prepareStatement("DELETE FROM File").executeUpdate()
     DbConnection.db.source.createConnection().prepareStatement("DELETE FROM Consignment").executeUpdate()
   }


### PR DESCRIPTION
This table no longer exists in the real DB, and the code does not depend on it, so it's safe to remove from the test database setup.