### PR TITLE
Clean up test data after every test

### DIFF
--- a/src/test/resources/json/getconsignment_data_all.json
+++ b/src/test/resources/json/getconsignment_data_all.json
@@ -21,7 +21,7 @@
         "code": "Mock series"
       },
       "transferringBody": {
-        "name": "Body"
+        "name": "Some department name"
       }
     }
   }

--- a/src/test/resources/json/getseries_data_all.json
+++ b/src/test/resources/json/getseries_data_all.json
@@ -1,1 +1,1 @@
-{"data":{"getSeries":[{"name":"Name","description":"Description","seriesid":"6e3b76c4-1745-4467-8ac5-b4dd736e1b3e","code":"Code","bodyid":"6e3b76c4-1745-4467-8ac5-b4dd736e1b3e"}]}}
+{"data":{"getSeries":[{"name":"some-series-name","description":"some-series-description","seriesid":"a9f96d9b-ca53-41c3-937d-88c5cb1241da","code":"some-series-code","bodyid":"283b28bf-a0cc-475a-9ce9-1ba60631afa7"}]}}

--- a/src/test/resources/json/getseries_data_some.json
+++ b/src/test/resources/json/getseries_data_some.json
@@ -1,1 +1,12 @@
-{"data":{"getSeries":[{"seriesid":"6e3b76c4-1745-4467-8ac5-b4dd736e1b3e"}]}}
+{
+  "data": {
+    "getSeries": [
+      {
+        "seriesid": "d737dc4a-cd9b-4ac3-8b33-ab30ee8d3241"
+      },
+      {
+        "seriesid":"769d319f-4faa-4ab2-ab52-46bc7e6e1e3d"
+      }
+    ]
+  }
+}

--- a/src/test/resources/json/getseries_query_alldata.json
+++ b/src/test/resources/json/getseries_query_alldata.json
@@ -1,1 +1,1 @@
-{"query":"{getSeries(body: \"Code\"){seriesid, bodyid, name, code, description}}"}
+{"query":"{getSeries(body: \"body-code-xyz\"){seriesid, bodyid, name, code, description}}"}

--- a/src/test/resources/json/getseries_query_somedata.json
+++ b/src/test/resources/json/getseries_query_somedata.json
@@ -1,1 +1,1 @@
-{"query":"{getSeries(body: \"Code\"){seriesid}}"}
+{"query":"{getSeries(body: \"body-code-abcde\"){seriesid}}"}

--- a/src/test/resources/scripts/init.sql
+++ b/src/test/resources/scripts/init.sql
@@ -115,7 +115,3 @@ CREATE TABLE IF NOT EXISTS FFIDMetadataMatches (
  ALTER TABLE FFIDMetadata
     ADD FOREIGN KEY (FileId)
     REFERENCES File(FileId);
-
-
-DELETE from Body;
-INSERT INTO Body (BodyId, Name, Code, Description) VALUES ('6e3b76c4-1745-4467-8ac5-b4dd736e1b3e', 'Body', 'Code', 'Description'), ('645bee46-d738-439b-8007-2083bc983154', 'Body2', 'Code2', 'Description');

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentMetadataRepositorySpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentMetadataRepositorySpec.scala
@@ -11,10 +11,11 @@ import uk.gov.nationalarchives.tdr.api.db.DbConnection
 import uk.gov.nationalarchives.tdr.api.utils.TestUtils._
 import uk.gov.nationalarchives.Tables._
 import uk.gov.nationalarchives.tdr.api.service.TransferAgreementService.transferAgreementProperties
+import uk.gov.nationalarchives.tdr.api.utils.TestDatabase
 
 import scala.concurrent.ExecutionContext
 
-class ConsignmentMetadataRepositorySpec extends AnyFlatSpec with ScalaFutures with Matchers {
+class ConsignmentMetadataRepositorySpec extends AnyFlatSpec with TestDatabase with ScalaFutures with Matchers {
   implicit val executionContext: ExecutionContext = ExecutionContext.Implicits.global
 
   private val consignmentMetadataProperty = "AllEnglishConfirmed"

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepositorySpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepositorySpec.scala
@@ -6,12 +6,12 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import uk.gov.nationalarchives.tdr.api.db.DbConnection
-import uk.gov.nationalarchives.tdr.api.utils.TestUtils
+import uk.gov.nationalarchives.tdr.api.utils.{TestDatabase, TestUtils}
 import uk.gov.nationalarchives.tdr.api.utils.TestUtils._
 
 import scala.concurrent.ExecutionContext
 
-class ConsignmentRepositorySpec extends AnyFlatSpec with ScalaFutures with Matchers {
+class ConsignmentRepositorySpec extends AnyFlatSpec with TestDatabase with ScalaFutures with Matchers {
   implicit val executionContext: ExecutionContext = ExecutionContext.Implicits.global
 
   "addParentFolder" should "add parent folder name to an existing consignment row" in {
@@ -74,12 +74,13 @@ class ConsignmentRepositorySpec extends AnyFlatSpec with ScalaFutures with Match
     val consignmentRepository = new ConsignmentRepository(db)
     val consignmentId = UUID.fromString("a3088f8a-59a3-4ab3-9e50-1677648e8186")
     val seriesId = UUID.fromString("845a4589-d412-49d7-80c6-63969112728a")
-    val bodyId = UUID.fromString("6e3b76c4-1745-4467-8ac5-b4dd736e1b3e")
+    val bodyId = UUID.fromString("edb31587-4357-4e63-b40c-75368c9d9cc9")
+    val bodyName = "Some transferring body name"
     val seriesCode = "Mock series"
-    val bodyName = "Body"
 
+    TestUtils.addTransferringBody(bodyId, bodyName, "some-body-code")
     TestUtils.addSeries(seriesId, bodyId, seriesCode)
-    TestUtils.createConsignment(consignmentId, userId)
+    TestUtils.createConsignment(consignmentId, userId, seriesId)
 
     val consignmentBody = consignmentRepository.getTransferringBodyOfConsignment(consignmentId).futureValue.head
 

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/FFIDMetadataRepositorySpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/FFIDMetadataRepositorySpec.scala
@@ -6,11 +6,11 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import uk.gov.nationalarchives.tdr.api.db.DbConnection
-import uk.gov.nationalarchives.tdr.api.utils.TestUtils
+import uk.gov.nationalarchives.tdr.api.utils.{TestDatabase, TestUtils}
 import uk.gov.nationalarchives.tdr.api.utils.TestUtils._
 
 
-class FFIDMetadataRepositorySpec extends AnyFlatSpec with ScalaFutures with Matchers {
+class FFIDMetadataRepositorySpec extends AnyFlatSpec with TestDatabase with ScalaFutures with Matchers {
 
   "countProcessedFfidMetadata" should "return 0 if consignment has no files" in {
     val db = DbConnection.db

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileMetadataRepositorySpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileMetadataRepositorySpec.scala
@@ -136,7 +136,7 @@ class FileMetadataRepositorySpec extends AnyFlatSpec with ScalaFutures with Matc
   "addFileMetadata" should "add metadata with the correct values" in {
     val db = DbConnection.db
     val fileMetadataRepository = new FileMetadataRepository(db)
-    val consignmentId = UUID.fromString("d4c053c5-f83a-4547-aefe-878d496bc5d2")
+    val consignmentId = UUID.fromString("306c526b-d099-470b-87c8-df7bd0aa225a")
     val fileId = UUID.fromString("ba176f90-f0fd-42ef-bb28-81ba3ffb6f05")
     addFileProperty("FileProperty")
     createConsignment(consignmentId, userId)
@@ -165,7 +165,7 @@ class FileMetadataRepositorySpec extends AnyFlatSpec with ScalaFutures with Matc
   "getFileMetadata" should "return the correct metadata" in {
     val db = DbConnection.db
     val fileMetadataRepository = new FileMetadataRepository(db)
-    val consignmentId = UUID.fromString("d511ecee-89ac-4643-b62d-76a41984a92b")
+    val consignmentId = UUID.fromString("4c935c42-502c-4b89-abce-2272584655e1")
     val fileId = UUID.fromString("4d5a5a00-77b4-4a97-aa3f-a75f7b13f284")
     createFile(fileId, consignmentId)
     addFileProperty("FileProperty")

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileMetadataRepositorySpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileMetadataRepositorySpec.scala
@@ -4,26 +4,18 @@ import java.sql.{PreparedStatement, Timestamp}
 import java.time.Instant
 import java.util.UUID
 
-import org.scalatest.{Assertion, BeforeAndAfterEach}
+import org.scalatest.Assertion
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Seconds, Span}
+import uk.gov.nationalarchives.Tables.FilemetadataRow
 import uk.gov.nationalarchives.tdr.api.db.DbConnection
 import uk.gov.nationalarchives.tdr.api.graphql.fields.FileMetadataFields.SHA256ServerSideChecksum
-import uk.gov.nationalarchives.tdr.api.utils.TestUtils
 import uk.gov.nationalarchives.tdr.api.utils.TestUtils._
-import uk.gov.nationalarchives.Tables.FilemetadataRow
+import uk.gov.nationalarchives.tdr.api.utils.{TestDatabase, TestUtils}
 
-class FileMetadataRepositorySpec extends AnyFlatSpec with ScalaFutures with Matchers with BeforeAndAfterEach {
-
-  override def beforeEach(): Unit = {
-    val connection = DbConnection.db.source.createConnection()
-    val psFileMetadata = connection.prepareStatement("delete from FileMetadata")
-    val psFileProperty = connection.prepareStatement("delete from FileProperty")
-    psFileMetadata.execute()
-    psFileProperty.execute()
-  }
+class FileMetadataRepositorySpec extends AnyFlatSpec with TestDatabase with ScalaFutures with Matchers {
 
   implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = Span(2, Seconds))
@@ -98,8 +90,6 @@ class FileMetadataRepositorySpec extends AnyFlatSpec with ScalaFutures with Matc
     TestUtils.createFile(UUID.fromString(fileTwoId), consignmentOne)
     TestUtils.createFile(UUID.fromString(fileThreeId), consignmentTwo)
 
-    TestUtils.addFileProperty(SHA256ServerSideChecksum)
-
 //  Then need to add data to the FileMetadata repository for these files
     TestUtils.addFileMetadata(metadataOneId, fileOneId, SHA256ServerSideChecksum)
     TestUtils.addFileMetadata(metadataTwoId, fileTwoId, SHA256ServerSideChecksum)
@@ -123,7 +113,6 @@ class FileMetadataRepositorySpec extends AnyFlatSpec with ScalaFutures with Matc
     TestUtils.createConsignment(consignmentId, userId)
     TestUtils.createFile(UUID.fromString(fileOneId), consignmentId)
     TestUtils.createFile(UUID.fromString(fileTwoId), consignmentId)
-    TestUtils.addFileProperty(SHA256ServerSideChecksum)
 
     (1 to 7).foreach { _ => TestUtils.addFileMetadata(UUID.randomUUID().toString, fileOneId, SHA256ServerSideChecksum)}
 

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileRepositorySpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileRepositorySpec.scala
@@ -6,11 +6,11 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import uk.gov.nationalarchives.tdr.api.db.DbConnection
-import uk.gov.nationalarchives.tdr.api.utils.TestUtils
+import uk.gov.nationalarchives.tdr.api.utils.{TestDatabase, TestUtils}
 import uk.gov.nationalarchives.tdr.api.utils.TestUtils._
 
 
-class FileRepositorySpec extends AnyFlatSpec with ScalaFutures with Matchers {
+class FileRepositorySpec extends AnyFlatSpec with TestDatabase with ScalaFutures with Matchers {
 
   "countFilesInConsignment" should "return 0 if a consignment has no files" in {
     val db = DbConnection.db

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/AntivirusMetadataRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/AntivirusMetadataRouteSpec.scala
@@ -6,14 +6,13 @@ import java.util.UUID
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.auto._
-import org.scalatest.BeforeAndAfterEach
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import uk.gov.nationalarchives.tdr.api.db.DbConnection
-import uk.gov.nationalarchives.tdr.api.utils.TestRequest
 import uk.gov.nationalarchives.tdr.api.utils.TestUtils._
+import uk.gov.nationalarchives.tdr.api.utils.{TestDatabase, TestRequest}
 
-class AntivirusMetadataRouteSpec extends AnyFlatSpec with Matchers with TestRequest with BeforeAndAfterEach  {
+class AntivirusMetadataRouteSpec extends AnyFlatSpec with Matchers with TestRequest with TestDatabase  {
 
   private val addAVMetadataJsonFilePrefix: String = "json/addavmetadata_"
 
@@ -31,7 +30,7 @@ class AntivirusMetadataRouteSpec extends AnyFlatSpec with Matchers with TestRequ
   case class AddAntivirusMetadata(addAntivirusMetadata: AntivirusMetadata) extends TestRequest
 
   override def beforeEach(): Unit = {
-    resetDatabase()
+    super.beforeEach()
     seedDatabaseWithDefaultEntries()
   }
 
@@ -87,14 +86,5 @@ class AntivirusMetadataRouteSpec extends AnyFlatSpec with Matchers with TestRequ
     val rs: ResultSet = ps.executeQuery()
     rs.last()
     rs.getRow should equal(0)
-  }
-
-  private def resetDatabase(): Unit = {
-    DbConnection.db.source.createConnection().prepareStatement("delete from AVMetadata").executeUpdate()
-    DbConnection.db.source.createConnection().prepareStatement("delete from FFIDMetadata").executeUpdate()
-    DbConnection.db.source.createConnection().prepareStatement("delete from FileMetadata").executeUpdate()
-    DbConnection.db.source.createConnection().prepareStatement("delete from FileProperty").executeUpdate()
-    DbConnection.db.source.createConnection().prepareStatement("delete from File").executeUpdate()
-    DbConnection.db.source.createConnection().prepareStatement("delete from Consignment").executeUpdate()
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ClientFileMetadataRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ClientFileMetadataRouteSpec.scala
@@ -6,15 +6,14 @@ import java.util.UUID
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.auto._
-import org.scalatest.BeforeAndAfterEach
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import uk.gov.nationalarchives.tdr.api.db.DbConnection
 import uk.gov.nationalarchives.tdr.api.service.FileMetadataService._
-import uk.gov.nationalarchives.tdr.api.utils.TestRequest
 import uk.gov.nationalarchives.tdr.api.utils.TestUtils._
+import uk.gov.nationalarchives.tdr.api.utils.{TestDatabase, TestRequest}
 
-class ClientFileMetadataRouteSpec extends AnyFlatSpec with Matchers with TestRequest with BeforeAndAfterEach  {
+class ClientFileMetadataRouteSpec extends AnyFlatSpec with Matchers with TestRequest with TestDatabase  {
 
   private val addClientFileMetadataJsonFilePrefix: String = "json/addclientfilemetadata_"
   private val getClientFileMetadataJsonFilePrefix: String = "json/getclientfilemetadata_"
@@ -36,10 +35,6 @@ class ClientFileMetadataRouteSpec extends AnyFlatSpec with Matchers with TestReq
   case class AddClientFileMetadata(addClientFileMetadata: List[ClientFileMetadata]) extends TestRequest
   case class GetClientFileMetadata(getClientFileMetadata: ClientFileMetadata) extends TestRequest
 
-  override def beforeEach(): Unit = {
-    resetDatabase()
-  }
-
   val runTestMutation: (String, OAuth2BearerToken) => GraphqlMutationData =
     runTestRequest[GraphqlMutationData](addClientFileMetadataJsonFilePrefix)
   val expectedMutationResponse: String => GraphqlMutationData =
@@ -50,7 +45,6 @@ class ClientFileMetadataRouteSpec extends AnyFlatSpec with Matchers with TestReq
     getDataFromFile[GraphqlQueryData](getClientFileMetadataJsonFilePrefix)
 
   "addClientFileMetadata" should "return all requested fields from inserted Client File metadata object" in {
-    addClientSideProperties()
     val consignmentId = UUID.fromString("eb197bfb-43f7-40ca-9104-8f6cbda88506")
     createConsignment(consignmentId, userId)
     createFile(defaultFileId, consignmentId)
@@ -63,7 +57,6 @@ class ClientFileMetadataRouteSpec extends AnyFlatSpec with Matchers with TestReq
   }
 
   "addClientFileMetadata" should "return the expected data from inserted Client File metadata object" in {
-    addClientSideProperties()
     val consignmentId = UUID.fromString("eb197bfb-43f7-40ca-9104-8f6cbda88506")
     createConsignment(consignmentId, userId)
     createFile(defaultFileId, consignmentId)
@@ -163,12 +156,5 @@ class ClientFileMetadataRouteSpec extends AnyFlatSpec with Matchers with TestReq
     val rs: ResultSet = ps.executeQuery()
     rs.next()
     rs.getString("FileId") should equal(fileId.toString)
-  }
-
-  private def resetDatabase(): Unit = {
-    DbConnection.db.source.createConnection().prepareStatement("DELETE FROM FileMetadata").executeUpdate()
-    DbConnection.db.source.createConnection().prepareStatement("DELETE FROM FileProperty").executeUpdate()
-    DbConnection.db.source.createConnection().prepareStatement("DELETE FROM File").executeUpdate()
-    DbConnection.db.source.createConnection().prepareStatement("DELETE FROM Consignment").executeUpdate()
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentRouteSpec.scala
@@ -1,28 +1,25 @@
 package uk.gov.nationalarchives.tdr.api.routes
 
-import java.sql.{Connection, PreparedStatement}
+import java.sql.PreparedStatement
 import java.util.UUID
 
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.auto._
-import org.scalatest.BeforeAndAfterEach
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import uk.gov.nationalarchives.tdr.api.db.DbConnection
 import uk.gov.nationalarchives.tdr.api.graphql.fields.FileMetadataFields.SHA256ServerSideChecksum
 import uk.gov.nationalarchives.tdr.api.utils.TestUtils._
-import uk.gov.nationalarchives.tdr.api.utils.{FixedUUIDSource, TestRequest}
+import uk.gov.nationalarchives.tdr.api.utils.{FixedUUIDSource, TestDatabase, TestRequest}
 
-class ConsignmentRouteSpec extends AnyFlatSpec with Matchers with TestRequest with BeforeAndAfterEach {
+class ConsignmentRouteSpec extends AnyFlatSpec with Matchers with TestRequest with TestDatabase {
   private val addConsignmentJsonFilePrefix: String = "json/addconsignment_"
   private val getConsignmentJsonFilePrefix: String = "json/getconsignment_"
 
   implicit val customConfig: Configuration = Configuration.default.withDefaults
 
-  override def beforeEach(): Unit = {
-    resetDatabase()
-  }
+  private val transferringBodyId = UUID.fromString("830f0315-e683-440e-90d0-5f4aa60388c6")
+  private val transferringBodyCode = "default-transferring-body-code"
 
   case class GraphqlQueryData(data: Option[GetConsignment], errors: List[GraphqlError] = Nil)
   case class GraphqlMutationData(data: Option[AddConsignment], errors: List[GraphqlError] = Nil)
@@ -53,11 +50,17 @@ class ConsignmentRouteSpec extends AnyFlatSpec with Matchers with TestRequest wi
   val expectedQueryResponse: String => GraphqlQueryData = getDataFromFile[GraphqlQueryData](getConsignmentJsonFilePrefix)
   val expectedMutationResponse: String => GraphqlMutationData = getDataFromFile[GraphqlMutationData](addConsignmentJsonFilePrefix)
 
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+
+    addTransferringBody(transferringBodyId, "Default transferring body name", transferringBodyCode)
+  }
+
   "addConsignment" should "create a consignment if the correct information is provided" in {
-    createSeries(UUID.fromString("6e3b76c4-1745-4467-8ac5-b4dd736e1b3e"))
+    createSeries(transferringBodyId)
 
     val expectedResponse: GraphqlMutationData = expectedMutationResponse("data_all")
-    val response: GraphqlMutationData = runTestMutation("mutation_alldata", validUserToken())
+    val response: GraphqlMutationData = runTestMutation("mutation_alldata", validUserToken(transferringBodyCode))
     response.data.get.addConsignment should equal(expectedResponse.data.get.addConsignment)
 
     checkConsignmentExists(response.data.get.addConsignment.consignmentid.get)
@@ -70,17 +73,17 @@ class ConsignmentRouteSpec extends AnyFlatSpec with Matchers with TestRequest wi
   }
 
   "addConsignment" should "link a new consignment to the creating user" in {
-    createSeries(UUID.fromString("6e3b76c4-1745-4467-8ac5-b4dd736e1b3e"))
+    createSeries(transferringBodyId)
 
     val expectedResponse: GraphqlMutationData = expectedMutationResponse("data_all")
-    val response: GraphqlMutationData = runTestMutation("mutation_alldata", validUserToken())
+    val response: GraphqlMutationData = runTestMutation("mutation_alldata", validUserToken(transferringBodyCode))
     response.data.get.addConsignment should equal(expectedResponse.data.get.addConsignment)
 
     response.data.get.addConsignment.userid should contain(userId)
   }
 
   "addConsignment" should "not allow a user to link a consignment to a series from another transferring body" in {
-    createSeries(UUID.fromString("6e3b76c4-1745-4467-8ac5-b4dd736e1b3e"))
+    createSeries(transferringBodyId)
 
     val response: GraphqlMutationData = runTestMutation("mutation_alldata", validUserToken(body = "some-other-transferring-body"))
 
@@ -90,7 +93,9 @@ class ConsignmentRouteSpec extends AnyFlatSpec with Matchers with TestRequest wi
 
   "getConsignment" should "return all requested fields" in {
     val sql = "insert into Consignment (ConsignmentId, SeriesId, UserId) VALUES (?, ?, ?)"
-    val ps: PreparedStatement = DbConnection.db.source.createConnection().prepareStatement(sql)
+    val ps: PreparedStatement = databaseConnection.prepareStatement(sql)
+    val bodyId = UUID.fromString("5c761efa-ae1a-4ec8-bb08-dc609fce51f8")
+    val bodyCode = "consignment-body-code"
     val consignmentId = "b130e097-2edc-4e67-a7e9-5364a09ae9cb"
     val seriesId = "fde450c9-09aa-4ba8-b0df-13f9bac1e587"
     ps.setString(1, consignmentId)
@@ -107,7 +112,6 @@ class ConsignmentRouteSpec extends AnyFlatSpec with Matchers with TestRequest wi
 
     addAntivirusMetadata(fileOneId)
 
-    addFileProperty(SHA256ServerSideChecksum)
     addFileMetadata("06209e0d-95d0-4f13-8933-e5b9d00eb435", fileOneId, SHA256ServerSideChecksum)
     addFileMetadata("c4759aae-dc68-45ec-aee1-5a562c7b42cc", fileTwoId, SHA256ServerSideChecksum)
 
@@ -117,12 +121,13 @@ class ConsignmentRouteSpec extends AnyFlatSpec with Matchers with TestRequest wi
 
     addParentFolderName(UUID.fromString(consignmentId), "ALL CONSIGNMENT DATA PARENT FOLDER")
 
-    val bodyId = UUID.fromString("6e3b76c4-1745-4467-8ac5-b4dd736e1b3e")
+    addTransferringBody(bodyId, "Some department name", bodyCode)
+
     val seriesName = "Mock series"
     addSeries(UUID.fromString(seriesId), bodyId, seriesName)
 
     val expectedResponse: GraphqlQueryData = expectedQueryResponse("data_all")
-    val response: GraphqlQueryData = runTestQuery("query_alldata", validUserToken())
+    val response: GraphqlQueryData = runTestQuery("query_alldata", validUserToken(bodyCode))
 
     response should equal(expectedResponse)
   }
@@ -130,7 +135,7 @@ class ConsignmentRouteSpec extends AnyFlatSpec with Matchers with TestRequest wi
   "getConsignment" should "return the expected data" in {
     val fixedUuidSource = new FixedUUIDSource()
     val sql = "insert into Consignment (ConsignmentId, SeriesId, UserId) VALUES (?,?,?)"
-    val ps: PreparedStatement = DbConnection.db.source.createConnection().prepareStatement(sql)
+    val ps: PreparedStatement = databaseConnection.prepareStatement(sql)
     val uuid = fixedUuidSource.uuid.toString
     ps.setString(1, uuid)
     ps.setString(2, uuid)
@@ -145,7 +150,7 @@ class ConsignmentRouteSpec extends AnyFlatSpec with Matchers with TestRequest wi
   "getConsignment" should "not allow a user to get a consignment that they did not create" in {
     val otherUserId = "73abd1dc-294d-4068-b60d-c1cd4782d08d"
     val sql = s"insert into Consignment (SeriesId, UserId) VALUES (1, '$otherUserId')"
-    val ps: PreparedStatement = DbConnection.db.source.createConnection().prepareStatement(sql)
+    val ps: PreparedStatement = databaseConnection.prepareStatement(sql)
     ps.executeUpdate()
 
     val response: GraphqlQueryData = runTestQuery("query_somedata", validUserToken())
@@ -183,7 +188,7 @@ class ConsignmentRouteSpec extends AnyFlatSpec with Matchers with TestRequest wi
 
   private def getConsignment(consignmentId: UUID) = {
     val sql = s"select * from Consignment where ConsignmentId = ?"
-    val ps: PreparedStatement = DbConnection.db.source.createConnection().prepareStatement(sql)
+    val ps: PreparedStatement = databaseConnection.prepareStatement(sql)
     ps.setString(1, consignmentId.toString)
     val result = ps.executeQuery()
     result.next()
@@ -202,14 +207,9 @@ class ConsignmentRouteSpec extends AnyFlatSpec with Matchers with TestRequest wi
 
   private def createSeries(bodyId: UUID): Unit = {
     val sql = "insert into Series (SeriesId, BodyId) VALUES (?,?)"
-    val ps: PreparedStatement = DbConnection.db.source.createConnection().prepareStatement(sql)
+    val ps: PreparedStatement = databaseConnection.prepareStatement(sql)
     ps.setString(1, "6e3b76c4-1745-4467-8ac5-b4dd736e1b3e")
     ps.setString(2, bodyId.toString)
     ps.executeUpdate()
-  }
-
-  private def resetDatabase(): Unit = {
-    DbConnection.db.source.createConnection().prepareStatement("delete from Consignment").executeUpdate()
-    DbConnection.db.source.createConnection().prepareStatement("delete from Series").executeUpdate()
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FFIDMetadataRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FFIDMetadataRouteSpec.scala
@@ -6,15 +6,14 @@ import java.util.UUID
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.auto._
-import org.scalatest.BeforeAndAfterEach
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import uk.gov.nationalarchives.tdr.api.db.DbConnection
 import uk.gov.nationalarchives.tdr.api.graphql.fields.FFIDMetadataFields.FFIDMetadata
-import uk.gov.nationalarchives.tdr.api.utils.TestRequest
 import uk.gov.nationalarchives.tdr.api.utils.TestUtils._
+import uk.gov.nationalarchives.tdr.api.utils.{TestDatabase, TestRequest}
 
-class FFIDMetadataRouteSpec extends AnyFlatSpec with Matchers with TestRequest with BeforeAndAfterEach {
+class FFIDMetadataRouteSpec extends AnyFlatSpec with Matchers with TestRequest with TestDatabase {
 
   private val addFfidMetadataJsonFilePrefix: String = "json/addffidmetadata_"
 
@@ -30,7 +29,8 @@ class FFIDMetadataRouteSpec extends AnyFlatSpec with Matchers with TestRequest w
     getDataFromFile[GraphqlMutationData](addFfidMetadataJsonFilePrefix)
 
   override def beforeEach(): Unit = {
-    resetDatabase()
+    super.beforeEach()
+
     seedDatabaseWithDefaultEntries()
   }
 

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
@@ -6,32 +6,19 @@ import java.util.UUID
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.auto._
-import org.scalatest.{Assertion, BeforeAndAfterEach}
+import org.scalatest.Assertion
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import uk.gov.nationalarchives.tdr.api.db.DbConnection
 import uk.gov.nationalarchives.tdr.api.service.FileMetadataService.staticMetadataProperties
 import uk.gov.nationalarchives.tdr.api.utils.TestUtils._
-import uk.gov.nationalarchives.tdr.api.utils.{FixedUUIDSource, TestRequest}
+import uk.gov.nationalarchives.tdr.api.utils.{FixedUUIDSource, TestDatabase, TestRequest}
 
-class FileRouteSpec extends AnyFlatSpec with Matchers with TestRequest with BeforeAndAfterEach  {
+class FileRouteSpec extends AnyFlatSpec with Matchers with TestRequest with TestDatabase  {
   private val addFileJsonFilePrefix: String = "json/addfile_"
   private val getFilesJsonFilePrefix: String = "json/getfiles_"
 
   implicit val customConfig: Configuration = Configuration.default.withDefaults
-
-  override def beforeEach(): Unit = {
-    val connection = DbConnection.db.source.createConnection()
-    connection.prepareStatement("delete from FileMetadata").executeUpdate()
-    connection.prepareStatement("delete from FFIDMetadata").executeUpdate()
-    connection.prepareStatement("delete from File").executeUpdate()
-    connection.prepareStatement("delete from Consignment").executeUpdate()
-    val deleteSql = "delete from FileProperty where Name in ('RightsCopyright','LegalStatus','HeldBy','Language','FoiExemptionCode')"
-    val insertSql = "insert into FileProperty (Name) values ('RightsCopyright'), ('LegalStatus'), ('HeldBy'), ('Language'), ('FoiExemptionCode')"
-    connection.prepareStatement(deleteSql).executeUpdate()
-    connection.prepareStatement(insertSql).executeUpdate()
-    connection.close()
-  }
 
   case class GraphqlMutationData(data: Option[AddFiles], errors: List[GraphqlError] = Nil)
   case class GraphqlQueryData(data: Option[GetFiles], errors: List[GraphqlError] = Nil)

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/SeriesRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/SeriesRouteSpec.scala
@@ -1,19 +1,16 @@
 package uk.gov.nationalarchives.tdr.api.routes
 
-import java.sql.PreparedStatement
 import java.util.UUID
 
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.auto._
-import org.scalatest.BeforeAndAfterEach
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import uk.gov.nationalarchives.tdr.api.db.DbConnection
-import uk.gov.nationalarchives.tdr.api.utils.TestRequest
 import uk.gov.nationalarchives.tdr.api.utils.TestUtils._
+import uk.gov.nationalarchives.tdr.api.utils.{TestDatabase, TestRequest, TestUtils}
 
-class SeriesRouteSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach with TestRequest {
+class SeriesRouteSpec extends AnyFlatSpec with Matchers with TestDatabase with TestRequest {
 
   private val getSeriesJsonFilePrefix: String = "json/getseries_"
   private val addSeriesJsonFilePrefix: String = "json/addseries_"
@@ -22,47 +19,60 @@ class SeriesRouteSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach 
 
   case class GraphqlQueryData(data: Option[GetSeries], errors: List[GraphqlError] = Nil)
   case class GraphqlMutationData(data: Option[AddSeries], errors: List[GraphqlError] = Nil)
-  case class Series(bodyid: Option[UUID], name: Option[String] = None, code: Option[String] = None, description: Option[String] = None)
+  case class Series(
+                     bodyid: Option[UUID],
+                     seriesid: Option[UUID],
+                     name: Option[String] = None,
+                     code: Option[String] = None,
+                     description: Option[String] = None
+                   )
   case class GetSeries(getSeries: List[Series])
   case class AddSeries(addSeries: Series)
+
+  private val bodyCode = "body-code-abcde"
 
   val runTestQuery: (String, OAuth2BearerToken) => GraphqlQueryData = runTestRequest[GraphqlQueryData](getSeriesJsonFilePrefix)
   val runTestMutation: (String, OAuth2BearerToken) => GraphqlMutationData = runTestRequest[GraphqlMutationData](addSeriesJsonFilePrefix)
   val expectedQueryResponse: String => GraphqlQueryData = getDataFromFile[GraphqlQueryData](getSeriesJsonFilePrefix)
   val expectedMutationResponse: String => GraphqlMutationData = getDataFromFile[GraphqlMutationData](addSeriesJsonFilePrefix)
 
-  override def beforeEach(): Unit = {
-    DbConnection.db.source.createConnection().prepareStatement("delete from Series").executeUpdate()
-  }
+  "The api" should "return an empty series list if the body has no series" in {
+    val bodyId = UUID.fromString("90cb9602-9794-4945-bedf-f01632b266c3")
+    TestUtils.addTransferringBody(bodyId, "Some body name", bodyCode)
 
-
-  "The api" should "return an empty series list" in {
     val expectedResponse: GraphqlQueryData = expectedQueryResponse("data_empty")
-    val response: GraphqlQueryData = runTestQuery("query_somedata", validUserToken())
+    val response: GraphqlQueryData = runTestQuery("query_somedata", validUserToken(bodyCode))
     response.data should equal(expectedResponse.data)
   }
 
-  "The api" should "return the expected data" in {
-    val ps: PreparedStatement = DbConnection.db.source.createConnection()
-      .prepareStatement("""insert into Series (SeriesId, BodyId) VALUES (?, ?)""")
-    ps.setString(1, "6e3b76c4-1745-4467-8ac5-b4dd736e1b3e")
-    ps.setString(2, "6e3b76c4-1745-4467-8ac5-b4dd736e1b3e")
-    ps.executeUpdate()
+  "The api" should "return all series belonging to the user's transferring body" in {
+    val bodyId = UUID.fromString("260f90b1-9648-46c0-b8c5-e5a725fbc667")
+    val otherBodyId = UUID.fromString("534845ee-dd2a-4566-a348-d91e4a74a998")
+
+    TestUtils.addTransferringBody(bodyId, "Some body name", bodyCode)
+    TestUtils.addTransferringBody(otherBodyId, "Some body name", "other-body-code")
+    TestUtils.addSeries(UUID.fromString("d737dc4a-cd9b-4ac3-8b33-ab30ee8d3241"), bodyId, "series-code-1")
+    TestUtils.addSeries(UUID.fromString("769d319f-4faa-4ab2-ab52-46bc7e6e1e3d"), bodyId, "series-code-2")
+    TestUtils.addSeries(UUID.fromString("01d2eb57-9d35-43e8-9eff-63e539ada1f9"), otherBodyId, "series-code-3")
 
     val expectedResponse: GraphqlQueryData = expectedQueryResponse("data_some")
-    val response: GraphqlQueryData = runTestQuery("query_somedata", validUserToken())
+    val response: GraphqlQueryData = runTestQuery("query_somedata", validUserToken(bodyCode))
     response.data should equal(expectedResponse.data)
   }
 
   "The api" should "return all requested fields" in {
-    val sql = "insert into Series (SeriesId, BodyId, Name, Code, Description) VALUES (?,?,'Name','Code','Description')"
-    val ps: PreparedStatement = DbConnection.db.source.createConnection().prepareStatement(sql)
-    ps.setString(1, "6e3b76c4-1745-4467-8ac5-b4dd736e1b3e")
-    ps.setString(2, "6e3b76c4-1745-4467-8ac5-b4dd736e1b3e")
-    ps.executeUpdate()
+    val bodyId = UUID.fromString("283b28bf-a0cc-475a-9ce9-1ba60631afa7")
+
+    val bodyCode = "body-code-xyz"
+    TestUtils.addSeries(
+      UUID.fromString("a9f96d9b-ca53-41c3-937d-88c5cb1241da"),
+      bodyId,
+      "some-series-code"
+    )
+    TestUtils.addTransferringBody(bodyId, "Some body name", bodyCode)
 
     val expectedResponse: GraphqlQueryData = expectedQueryResponse("data_all")
-    val response: GraphqlQueryData = runTestQuery("query_alldata", validUserToken())
+    val response: GraphqlQueryData = runTestQuery("query_alldata", validUserToken(bodyCode))
     response.data should equal(expectedResponse.data)
   }
 
@@ -78,19 +88,5 @@ class SeriesRouteSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach 
     val response: GraphqlQueryData = runTestQuery("query_incorrect_body", validUserTokenNoBody)
     response.data should equal(expectedResponse.data)
     response.errors.head.extensions.get.code should equal(expectedResponse.errors.head.extensions.get.code)
-  }
-
-  "The api" should "return the correct series if an admin queries with a body argument" in {
-    val sql = "insert into Series (SeriesId, BodyId) VALUES (?,?), (?, ?)"
-    val ps: PreparedStatement = DbConnection.db.source.createConnection().prepareStatement(sql)
-    ps.setString(1, "6e3b76c4-1745-4467-8ac5-b4dd736e1b3e")
-    ps.setString(2, "6e3b76c4-1745-4467-8ac5-b4dd736e1b3e")
-    ps.setString(3, "f67d1337-cbd0-4fd1-9eac-611489e7113f")
-    ps.setString(4, "645bee46-d738-439b-8007-2083bc983154")
-    ps.executeUpdate()
-
-    val expectedResponse: GraphqlQueryData = expectedQueryResponse("data_some")
-    val response: GraphqlQueryData = runTestQuery("query_somedata", validUserToken())
-    response.data should equal(expectedResponse.data)
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/SeriesRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/SeriesRouteSpec.scala
@@ -23,7 +23,7 @@ class SeriesRouteSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach 
   case class GraphqlQueryData(data: Option[GetSeries], errors: List[GraphqlError] = Nil)
   case class GraphqlMutationData(data: Option[AddSeries], errors: List[GraphqlError] = Nil)
   case class Series(bodyid: Option[UUID], name: Option[String] = None, code: Option[String] = None, description: Option[String] = None)
-  case class GetSeries(getSeries: List[Series]) extends TestRequest
+  case class GetSeries(getSeries: List[Series])
   case class AddSeries(addSeries: Series)
 
   val runTestQuery: (String, OAuth2BearerToken) => GraphqlQueryData = runTestRequest[GraphqlQueryData](getSeriesJsonFilePrefix)

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/TransfersAgreementRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/TransfersAgreementRouteSpec.scala
@@ -6,15 +6,14 @@ import java.util.UUID
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.auto._
-import org.scalatest.BeforeAndAfterEach
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import uk.gov.nationalarchives.tdr.api.db.DbConnection
 import uk.gov.nationalarchives.tdr.api.service.TransferAgreementService.transferAgreementProperties
 import uk.gov.nationalarchives.tdr.api.utils.TestUtils._
-import uk.gov.nationalarchives.tdr.api.utils.{FixedUUIDSource, TestRequest}
+import uk.gov.nationalarchives.tdr.api.utils.{TestDatabase, FixedUUIDSource, TestRequest}
 
-class TransfersAgreementRouteSpec extends AnyFlatSpec with Matchers with TestRequest with BeforeAndAfterEach  {
+class TransfersAgreementRouteSpec extends AnyFlatSpec with Matchers with TestRequest with TestDatabase  {
 
   private val addTransferAgreementJsonFilePrefix: String = "json/addtransferagreement_"
   private val getTransferAgreementJsonFilePrefix: String = "json/gettransferagreement_"
@@ -33,11 +32,6 @@ class TransfersAgreementRouteSpec extends AnyFlatSpec with Matchers with TestReq
                                 sensitivityReviewSignedOff: Option[Boolean] = None
                               )
   case class AddTransferAgreement(addTransferAgreement: TransferAgreement) extends TestRequest
-
-  override def beforeEach(): Unit = {
-    resetDatabase()
-    addTransferAgreementProperties()
-  }
 
   val runTestMutation: (String, OAuth2BearerToken) => GraphqlMutationData =
     runTestRequest[GraphqlMutationData](addTransferAgreementJsonFilePrefix)
@@ -175,11 +169,5 @@ class TransfersAgreementRouteSpec extends AnyFlatSpec with Matchers with TestReq
     val rs: ResultSet = ps.executeQuery()
     rs.next()
     rs.getString("ConsignmentId") should equal(consignmentId.toString)
-  }
-
-  private def resetDatabase(): Unit = {
-    DbConnection.db.source.createConnection().prepareStatement("DELETE FROM ConsignmentMetadata").execute()
-    DbConnection.db.source.createConnection().prepareStatement("DELETE FROM ConsignmentProperty").execute()
-    DbConnection.db.source.createConnection().prepareStatement("DELETE FROM Consignment").executeUpdate()
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestDatabase.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestDatabase.scala
@@ -1,0 +1,60 @@
+package uk.gov.nationalarchives.tdr.api.utils
+
+import java.sql.Connection
+
+import org.scalatest.{BeforeAndAfterEach, Suite}
+import uk.gov.nationalarchives.tdr.api.db.DbConnection
+import uk.gov.nationalarchives.tdr.api.service.FileMetadataService.{clientSideProperties, staticMetadataProperties}
+import uk.gov.nationalarchives.tdr.api.service.TransferAgreementService.transferAgreementProperties
+import uk.gov.nationalarchives.tdr.api.utils.TestUtils.{addConsignmentProperty, addFileProperty}
+
+/**
+ * This trait should be mixed into specs which access the test database.
+ *
+ * It provides a test database connection and cleans up all of the test data after every test.
+ */
+trait TestDatabase extends BeforeAndAfterEach {
+  this: Suite =>
+
+  val databaseConnection: Connection = DbConnection.db.source.createConnection()
+
+  override def beforeEach(): Unit = {
+    databaseConnection.prepareStatement("DELETE FROM FileMetadata").execute()
+    databaseConnection.prepareStatement("DELETE FROM FileProperty").execute()
+    databaseConnection.prepareStatement("DELETE FROM FFIDMetadataMatches").execute()
+    databaseConnection.prepareStatement("DELETE FROM FFIDMetadata").execute()
+    databaseConnection.prepareStatement("DELETE FROM AVMetadata").execute()
+    databaseConnection.prepareStatement("DELETE FROM File").execute()
+    databaseConnection.prepareStatement("DELETE FROM ConsignmentMetadata").execute()
+    databaseConnection.prepareStatement("DELETE FROM ConsignmentProperty").execute()
+    databaseConnection.prepareStatement("DELETE FROM Consignment").execute()
+    databaseConnection.prepareStatement("DELETE FROM Series").execute()
+    databaseConnection.prepareStatement("DELETE FROM Body").execute()
+
+    databaseConnection.prepareStatement("INSERT INTO FileProperty (Name, Description, Shortname) " +
+      "VALUES ('SHA256ServerSideChecksum', 'The checksum calculated after upload', 'Checksum')")
+      .execute()
+
+    addTransferAgreementConsignmentProperties()
+    addTransferAgreementFileProperties()
+    addClientSideProperties()
+  }
+
+  private def addTransferAgreementConsignmentProperties(): Unit = {
+    transferAgreementProperties.foreach(propertyName => {
+      addConsignmentProperty(propertyName)
+    })
+  }
+
+  private def addTransferAgreementFileProperties(): Unit = {
+    staticMetadataProperties.foreach(propertyName => {
+      addFileProperty(propertyName.name)
+    })
+  }
+
+  private def addClientSideProperties(): Unit = {
+    clientSideProperties.foreach(propertyName => {
+      addFileProperty(propertyName)
+    })
+  }
+}

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestUtils.scala
@@ -95,9 +95,7 @@ object TestUtils {
     val seriesId = UUID.fromString("1436ad43-73a2-4489-a774-85fa95daff32")
     createConsignment(consignmentId, userId, seriesId)
     createFile(defaultFileId, consignmentId)
-    addClientSideProperties()
     createClientFileMetadata(defaultFileId)
-    addTransferAgreementProperties()
     addTransferAgreementMetadata(consignmentId)
   }
 
@@ -198,21 +196,35 @@ object TestUtils {
     ps.executeUpdate()
   }
 
-  def addSeries(seriesId: UUID, bodyId: UUID, code: String): Unit = {
-    val sql = s"INSERT INTO Series (SeriesId, BodyId, Code) VALUES (?, ?, ?)"
+  def addTransferringBody(id: UUID, name: String, code: String): Unit = {
+    val sql = s"INSERT INTO Body (BodyId, Name, Code) VALUES (?, ?, ?)"
     val ps: PreparedStatement = DbConnection.db.source.createConnection().prepareStatement(sql)
-    ps.setString(1, seriesId.toString)
-    ps.setString(2, bodyId.toString)
+    ps.setString(1, id.toString)
+    ps.setString(2, name)
     ps.setString(3, code)
 
     ps.executeUpdate()
   }
 
-  def addClientSideProperties(): Unit = {
-    clientSideProperties.foreach(propertyName => {
-      addFileProperty(propertyName)
-    })
+  // scalastyle:off magic.number
+  def addSeries(
+                 seriesId: UUID,
+                 bodyId: UUID,
+                 code: String,
+                 name: String = "some-series-name",
+                 description: String = "some-series-description"
+               ): Unit = {
+    val sql = s"INSERT INTO Series (SeriesId, BodyId, Code, Name, Description) VALUES (?, ?, ?, ?, ?)"
+    val ps: PreparedStatement = DbConnection.db.source.createConnection().prepareStatement(sql)
+    ps.setString(1, seriesId.toString)
+    ps.setString(2, bodyId.toString)
+    ps.setString(3, code)
+    ps.setString(4, name)
+    ps.setString(5, description)
+
+    ps.executeUpdate()
   }
+  // scalastyle:on magic.number
 
   def addConsignmentProperty(name: String): Unit = {
     // name is primary key check exists before attempting insert to table
@@ -259,12 +271,5 @@ object TestUtils {
       ps.executeUpdate()
     })
   }
-
   //scalastyle:on magic.number
-
-  def addTransferAgreementProperties(): Unit = {
-    transferAgreementProperties.foreach(propertyName => {
-      addConsignmentProperty(propertyName)
-    })
-  }
 }


### PR DESCRIPTION
This fixes an issue where some tests would fail if only a subset of the tests were run, because of inter-dependencies. Now you can run all of the tests, or just one folder, or just one individual test.

This is quite a large change because every time I fixed a test, a different one would fail. It took a while to unpick all of the interdependencies.

Part of the problem was that init.sql gets run at unexpected times. It looks like it just gets executed at the start of the test suite, but it actually gets run every time the code creates a new database connection! Hopefully that will be a moot point once we can [move to a more realistic test database](https://national-archives.atlassian.net/browse/TDR-150), but I've mitigated the problems in the meantime by moving all the static data creation to a new trait called `TestDatabase`.

Some tests still use quite a lot of shared test data, but they no longer rely on the database being left in a particular state by  a previous test, so this is hopefully quite a big improvement.

Any new RepoSpecs or RouteSpecs should inherit from the new `TestDatabase` trait.

I timed the full test suite before and after the change. It still takes around 2 minutes, so the extra database teardown doesn't significantly affect the performance.