### PR TITLE
Fix flaky tests

### DIFF
--- a/src/test/resources/scripts/init.sql
+++ b/src/test/resources/scripts/init.sql
@@ -78,17 +78,11 @@ CREATE TABLE IF NOT EXISTS FileMetadata (
     Value varchar(255) not null,
     Datetime timestamp not null DEFAULT CURRENT_TIMESTAMP,
     UserId uuid NOT NULL,
-    PRIMARY KEY (MetadataId)
+    PRIMARY KEY (MetadataId),
+    FOREIGN KEY (FileId) REFERENCES File(FileId),
+    FOREIGN KEY (PropertyName) REFERENCES FileProperty(Name)
 );
 
- ALTER TABLE FileMetadata
-    ADD FOREIGN KEY (FileId)
-    REFERENCES File(FileId);
-
-ALTER TABLE FileMetadata
-    ADD FOREIGN KEY (PropertyName)
-    REFERENCES FileProperty(Name);
-    
 CREATE TABLE IF NOT EXISTS FFIDMetadata (
     FFIDMetadataId uuid not null,
     FileId uuid NOT NULL,
@@ -98,20 +92,14 @@ CREATE TABLE IF NOT EXISTS FFIDMetadata (
     ContainerSignatureFileVersion varchar(255) not null,
     Method varchar(255) not null,
     Datetime timestamp not null,
-    PRIMARY KEY(FFIDMetadataId)
+    PRIMARY KEY(FFIDMetadataId),
+    FOREIGN KEY (FileId) REFERENCES File(FileId)
 );
 
 CREATE TABLE IF NOT EXISTS FFIDMetadataMatches (
     FFIDMetadataId uuid not null,
     Extension varchar(255),
     IdentificationBasis varchar(255) not null,
-    PUID varchar(255) not null
+    PUID varchar(255) not null,
+    FOREIGN KEY (FFIDMetadataId) REFERENCES FFIDMetadata(FFIDMetadataId)
 );
-
- ALTER TABLE FFIDMetadataMatches
-     ADD FOREIGN KEY (FFIDMetadataId)
-     REFERENCES FFIDMetadata(FFIDMetadataId);
-
- ALTER TABLE FFIDMetadata
-    ADD FOREIGN KEY (FileId)
-    REFERENCES File(FileId);

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepositorySpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepositorySpec.scala
@@ -34,7 +34,7 @@ class ConsignmentRepositorySpec extends AnyFlatSpec with TestDatabase with Scala
     val consignmentId = UUID.fromString("b6da7577-3800-4ebc-821b-9d33e52def9e")
 
     TestUtils.createConsignment(consignmentId, userId)
-    consignmentRepository.addParentFolder(consignmentId, "TEST GET PARENT FOLDER NAME")
+    consignmentRepository.addParentFolder(consignmentId, "TEST GET PARENT FOLDER NAME").futureValue
 
     val parentFolderName = consignmentRepository.getParentFolder(consignmentId).futureValue
 


### PR DESCRIPTION
### Create foreign keys at same time as table in test database 

Merge the `ALTER TABLE` statements with the `CREATE TABLE` statements rather than keeping them separate. This means the foreign keys are only added if the tables don't already exist.

This solves a `ConcurrentModificationException` problem that was causing the tests to fail intermittently. init.sql is run every time a new database connection is opened, because it's specified as an init script in the H2 configuration in the tests' application.conf. If multiple connections were opened in parallel, for example because Sangria was resolving deferred resolvers in parallel, this sometimes meant that data was being read by one thread while another thread ran `ALTER TABLE` on the same table.

This change should mean that init.sql never modifies existing tables, which should fix the concurrency error.

### Fix flaky test by waiting for Future to finish

This test was failing intermittently because it was calling the repository method before waiting for the test setup to finish.

