### PR TITLE
Convert sql timestamp to ZonedDateTime

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentFields.scala
@@ -1,6 +1,6 @@
 package uk.gov.nationalarchives.tdr.api.graphql.fields
 
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 import java.util.UUID
 
 import io.circe.generic.auto._
@@ -16,9 +16,9 @@ object ConsignmentFields {
   case class Consignment(consignmentid: UUID,
                          userid: UUID,
                          seriesid: UUID,
-                         createdDateTime: LocalDateTime,
-                         transferInitiatedDatetime: Option[LocalDateTime],
-                         exportDatetime: Option[LocalDateTime]
+                         createdDateTime: ZonedDateTime,
+                         transferInitiatedDatetime: Option[ZonedDateTime],
+                         exportDatetime: Option[ZonedDateTime]
                         )
 
   case class AddConsignmentInput(seriesid: UUID)
@@ -51,9 +51,9 @@ object ConsignmentFields {
       Field("consignmentid", OptionType(UuidType), resolve = _.value.consignmentid),
       Field("userid", UuidType, resolve = _.value.userid),
       Field("seriesid", UuidType, resolve = _.value.seriesid),
-      Field("createdDatetime", OptionType(LocalDateTimeType), resolve = _.value.createdDateTime),
-      Field("transferInitiatedDatetime", OptionType(LocalDateTimeType), resolve = _.value.transferInitiatedDatetime),
-      Field("exportDatetime", OptionType(LocalDateTimeType), resolve = _.value.exportDatetime),
+      Field("createdDatetime", OptionType(ZonedDateTimeType), resolve = _.value.createdDateTime),
+      Field("transferInitiatedDatetime", OptionType(ZonedDateTimeType), resolve = _.value.transferInitiatedDatetime),
+      Field("exportDatetime", OptionType(ZonedDateTimeType), resolve = _.value.exportDatetime),
       Field(
         "totalFiles",
         IntType,

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/FieldTypes.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/FieldTypes.scala
@@ -20,7 +20,6 @@ object FieldTypes {
     def toSecondsPrecisionString: String = value.truncatedTo(ChronoUnit.SECONDS).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
   }
 
-
   private def parseUuid(s: String): Either[ValueCoercionViolation, UUID] = Try(UUID.fromString(s)) match {
     case Success(uuid) => Right(uuid)
     case Failure(_) => Left(UuidCoercionViolation)

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/FieldTypes.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/FieldTypes.scala
@@ -17,7 +17,7 @@ object FieldTypes {
 
   implicit class ZonedDateTimeUtils(value: ZonedDateTime) {
     //Zoned Date Time truncated to 'seconds' precision to ensure consistent date format irrespective of input precision
-    def toSecondsPrecisionString = value.truncatedTo(ChronoUnit.SECONDS).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+    def toSecondsPrecisionString: String = value.truncatedTo(ChronoUnit.SECONDS).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
   }
 
 

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentService.scala
@@ -1,6 +1,7 @@
 package uk.gov.nationalarchives.tdr.api.service
 
 import java.sql.Timestamp
+import java.time.{ZoneId, ZonedDateTime}
 import java.util.UUID
 
 import uk.gov.nationalarchives.Tables.{BodyRow, ConsignmentRow, SeriesRow}
@@ -18,6 +19,12 @@ class ConsignmentService(
                           timeSource: TimeSource,
                           uuidSource: UUIDSource
                         )(implicit val executionContext: ExecutionContext) {
+
+  implicit class TimestampUtils(value: Timestamp)  {
+    private val zoneId = "UTC"
+
+    def toZonedDateTime: ZonedDateTime = ZonedDateTime.ofInstant(value.toInstant, ZoneId.of(zoneId))
+  }
 
   def updateTransferInitiated(consignmentId: UUID, userId: UUID): Future[Int] = {
     consignmentRepository.updateTransferInitiated(consignmentId, userId, Timestamp.from(timeSource.now))
@@ -72,8 +79,8 @@ class ConsignmentService(
       row.consignmentid,
       row.userid,
       row.seriesid,
-      row.datetime.toLocalDateTime,
-      row.transferinitiateddatetime.map(_.toLocalDateTime),
-      row.exportdatetime.map(_.toLocalDateTime))
+      row.datetime.toZonedDateTime,
+      row.transferinitiateddatetime.map(ts => ts.toZonedDateTime),
+      row.exportdatetime.map(ts => ts.toZonedDateTime))
   }
 }

--- a/src/test/resources/json/getconsignment_data_all.json
+++ b/src/test/resources/json/getconsignment_data_all.json
@@ -4,9 +4,9 @@
       "consignmentid":"b130e097-2edc-4e67-a7e9-5364a09ae9cb",
       "seriesid": "fde450c9-09aa-4ba8-b0df-13f9bac1e587",
       "userid":"4ab14990-ed63-4615-8336-56fbb9960300",
-      "createdDatetime": "2020-01-01 09:00:00 UTC",
-      "transferInitiatedDatetime": "2020-01-01 09:00:00 UTC",
-      "exportDatetime": "2020-01-01 09:00:00 UTC",
+      "createdDatetime": "2020-01-01T09:00:00Z",
+      "transferInitiatedDatetime": "2020-01-01T09:00:00Z",
+      "exportDatetime": "2020-01-01T09:00:00Z",
       "totalFiles":  3,
       "fileChecks": {
         "antivirusProgress": {

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentRouteSpec.scala
@@ -1,6 +1,7 @@
 package uk.gov.nationalarchives.tdr.api.routes
 
 import java.sql.{PreparedStatement, Timestamp}
+import java.time.ZonedDateTime
 import java.util.UUID
 
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
@@ -28,9 +29,9 @@ class ConsignmentRouteSpec extends AnyFlatSpec with Matchers with TestRequest wi
   case class Consignment(consignmentid: Option[UUID] = None,
                          userid: Option[UUID] = None,
                          seriesid: Option[UUID] = None,
-                         createdDatetime: Option[String] = None,
-                         transferInitiatedDatetime: Option[String] = None,
-                         exportDatetime: Option[String] = None,
+                         createdDatetime: Option[ZonedDateTime] = None,
+                         transferInitiatedDatetime: Option[ZonedDateTime] = None,
+                         exportDatetime: Option[ZonedDateTime] = None,
                          totalFiles: Option[Int],
                          fileChecks: Option[FileChecks],
                          parentFolder: Option[String],


### PR DESCRIPTION
To ensure clients can decode date times from API without custom decoders use ZonedDateTime for output

ZonedDateTime make the UTC timezone explicit to clients that need to use date times