### PR TITLE
Pass in export datetime instead of generating value

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepository.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepository.scala
@@ -13,7 +13,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class ConsignmentRepository(db: Database) {
 
   implicit class ZonedDateTimeUtils(value: ZonedDateTime) {
-    def toTimestamp = {
+    def toTimestamp: Timestamp = {
       Timestamp.valueOf(value.toLocalDateTime)
     }
   }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepository.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepository.scala
@@ -1,6 +1,7 @@
 package uk.gov.nationalarchives.tdr.api.db.repository
 
 import java.sql.Timestamp
+import java.time.ZonedDateTime
 import java.util.UUID
 
 import slick.jdbc.PostgresProfile.api._
@@ -11,6 +12,12 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class ConsignmentRepository(db: Database) {
 
+  implicit class ZonedDateTimeUtils(value: ZonedDateTime) {
+    def toTimestamp = {
+      Timestamp.valueOf(value.toLocalDateTime)
+    }
+  }
+
   private val insertQuery = Consignment returning Consignment.map(_.consignmentid) into
     ((consignment, consignmentid) => consignment.copy(consignmentid = consignmentid))
 
@@ -18,10 +25,10 @@ class ConsignmentRepository(db: Database) {
     db.run(insertQuery += consignmentRow)
   }
 
-  def updateExportLocation(exportLocationInput: ConsignmentFields.UpdateExportLocationInput, timestamp: Timestamp): Future[Int] = {
+  def updateExportLocation(exportLocationInput: ConsignmentFields.UpdateExportLocationInput): Future[Int] = {
     val update = Consignment.filter(_.consignmentid === exportLocationInput.consignmentId)
       .map(c => (c.exportlocation, c.exportdatetime))
-      .update((Option(exportLocationInput.exportLocation), Option(timestamp)))
+      .update((Option(exportLocationInput.exportLocation), Option(exportLocationInput.exportDatetime.toTimestamp)))
     db.run(update)
   }
 

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepository.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepository.scala
@@ -1,22 +1,16 @@
 package uk.gov.nationalarchives.tdr.api.db.repository
 
 import java.sql.Timestamp
-import java.time.ZonedDateTime
 import java.util.UUID
 
 import slick.jdbc.PostgresProfile.api._
 import uk.gov.nationalarchives.Tables.{Body, BodyRow, Consignment, ConsignmentRow, File, Series, SeriesRow}
 import uk.gov.nationalarchives.tdr.api.graphql.fields.ConsignmentFields
+import uk.gov.nationalarchives.tdr.api.utils.TimeUtils.ZonedDateTimeUtils
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class ConsignmentRepository(db: Database) {
-
-  implicit class ZonedDateTimeUtils(value: ZonedDateTime) {
-    def toTimestamp: Timestamp = {
-      Timestamp.valueOf(value.toLocalDateTime)
-    }
-  }
 
   private val insertQuery = Consignment returning Consignment.map(_.consignmentid) into
     ((consignment, consignmentid) => consignment.copy(consignmentid = consignmentid))

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentFields.scala
@@ -32,7 +32,7 @@ object ConsignmentFields {
   case class FileChecks(antivirusProgress: AntivirusProgress, checksumProgress: ChecksumProgress, ffidProgress: FFIDProgress)
   case class TransferringBody(name: Option[String], code: Option[String])
 
-  case class UpdateExportLocationInput(consignmentId: UUID, exportLocation: String)
+  case class UpdateExportLocationInput(consignmentId: UUID, exportLocation: String, exportDatetime: ZonedDateTime)
 
   implicit val FileChecksType: ObjectType[Unit, FileChecks] =
     deriveObjectType[Unit, FileChecks]()

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentFields.scala
@@ -32,7 +32,7 @@ object ConsignmentFields {
   case class FileChecks(antivirusProgress: AntivirusProgress, checksumProgress: ChecksumProgress, ffidProgress: FFIDProgress)
   case class TransferringBody(name: Option[String], code: Option[String])
 
-  case class UpdateExportLocationInput(consignmentId: UUID, exportLocation: String, exportDatetime: ZonedDateTime)
+  case class UpdateExportLocationInput(consignmentId: UUID, exportLocation: String, exportDatetime: Option[ZonedDateTime])
 
   implicit val FileChecksType: ObjectType[Unit, FileChecks] =
     deriveObjectType[Unit, FileChecks]()

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/FieldTypes.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/FieldTypes.scala
@@ -1,24 +1,18 @@
 package uk.gov.nationalarchives.tdr.api.graphql.fields
 
 import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
-import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 import sangria.ast.StringValue
 import sangria.schema.ScalarType
 import sangria.validation.ValueCoercionViolation
+import uk.gov.nationalarchives.tdr.api.utils.TimeUtils.ZonedDateTimeUtils
 
 import scala.util.{Failure, Success, Try}
 
 object FieldTypes {
   private case object UuidCoercionViolation extends ValueCoercionViolation("Valid UUID expected")
   private case object ZonedDateTimeCoercionViolation extends ValueCoercionViolation("Valid Zoned Date Time expected")
-
-  implicit class ZonedDateTimeUtils(value: ZonedDateTime) {
-    //Zoned Date Time truncated to 'seconds' precision to ensure consistent date format irrespective of input precision
-    def toSecondsPrecisionString: String = value.truncatedTo(ChronoUnit.SECONDS).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
-  }
 
   private def parseUuid(s: String): Either[ValueCoercionViolation, UUID] = Try(UUID.fromString(s)) match {
     case Success(uuid) => Right(uuid)

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/http/GraphQLServer.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/http/GraphQLServer.scala
@@ -73,12 +73,12 @@ object GraphQLServer {
                                  (implicit ec: ExecutionContext): Future[(StatusCode with Serializable, JsValue)] = {
     val uuidSourceClass: Class[_] = Class.forName(ConfigFactory.load().getString("source.uuid"))
     val uuidSource: UUIDSource = uuidSourceClass.getDeclaredConstructor().newInstance().asInstanceOf[UUIDSource]
+    val timeSource = new CurrentTimeSource
     val db = DbConnection.db
-    val consignmentRepository = new ConsignmentRepository(db)
+    val consignmentRepository = new ConsignmentRepository(db, timeSource)
     val fileMetadataRepository = new FileMetadataRepository(db)
     val fileRepository = new FileRepository(db)
     val ffidMetadataRepository = new FFIDMetadataRepository(db)
-    val timeSource = new CurrentTimeSource
 
     val consignmentService = new ConsignmentService(consignmentRepository, fileMetadataRepository, fileRepository,
       ffidMetadataRepository, timeSource, uuidSource)

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentService.scala
@@ -8,6 +8,7 @@ import uk.gov.nationalarchives.Tables.{BodyRow, ConsignmentRow, SeriesRow}
 import uk.gov.nationalarchives.tdr.api.db.repository._
 import uk.gov.nationalarchives.tdr.api.graphql.fields.ConsignmentFields._
 import uk.gov.nationalarchives.tdr.api.graphql.fields.SeriesFields.Series
+import uk.gov.nationalarchives.tdr.api.utils.TimeUtils.TimestampUtils
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -19,12 +20,6 @@ class ConsignmentService(
                           timeSource: TimeSource,
                           uuidSource: UUIDSource
                         )(implicit val executionContext: ExecutionContext) {
-
-  implicit class TimestampUtils(value: Timestamp)  {
-    private val zoneId = "UTC"
-
-    def toZonedDateTime: ZonedDateTime = ZonedDateTime.ofInstant(value.toInstant, ZoneId.of(zoneId))
-  }
 
   def updateTransferInitiated(consignmentId: UUID, userId: UUID): Future[Int] = {
     consignmentRepository.updateTransferInitiated(consignmentId, userId, Timestamp.from(timeSource.now))

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentService.scala
@@ -31,7 +31,7 @@ class ConsignmentService(
   }
 
   def updateExportLocation(exportLocationInput: UpdateExportLocationInput): Future[Int] = {
-    consignmentRepository.updateExportLocation(exportLocationInput, Timestamp.from(timeSource.now))
+    consignmentRepository.updateExportLocation(exportLocationInput)
   }
 
   def addConsignment(addConsignmentInput: AddConsignmentInput, userId: UUID): Future[Consignment] = {

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/utils/TimeUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/utils/TimeUtils.scala
@@ -1,7 +1,7 @@
 package uk.gov.nationalarchives.tdr.api.utils
 
 import java.sql.Timestamp
-import java.time.ZonedDateTime
+import java.time.{ZoneId, ZonedDateTime}
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 
@@ -11,5 +11,11 @@ object TimeUtils {
     def toSecondsPrecisionString: String = value.truncatedTo(ChronoUnit.SECONDS).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
 
     def toTimestamp: Timestamp = Timestamp.valueOf(value.toLocalDateTime)
+  }
+
+  implicit class TimestampUtils(value: Timestamp)  {
+    private val zoneId = "UTC"
+
+    def toZonedDateTime: ZonedDateTime = ZonedDateTime.ofInstant(value.toInstant, ZoneId.of(zoneId))
   }
 }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/utils/TimeUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/utils/TimeUtils.scala
@@ -1,0 +1,15 @@
+package uk.gov.nationalarchives.tdr.api.utils
+
+import java.sql.Timestamp
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+
+object TimeUtils {
+  implicit class ZonedDateTimeUtils(value: ZonedDateTime) {
+    //Zoned Date Time truncated to 'seconds' precision to ensure consistent date format irrespective of input precision
+    def toSecondsPrecisionString: String = value.truncatedTo(ChronoUnit.SECONDS).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+
+    def toTimestamp: Timestamp = Timestamp.valueOf(value.toLocalDateTime)
+  }
+}

--- a/src/test/resources/json/updateexportlocation_mutation_all.json
+++ b/src/test/resources/json/updateexportlocation_mutation_all.json
@@ -3,7 +3,8 @@
   "variables": {
     "updateExportLocationInput": {
       "consignmentId": "6e3b76c4-1745-4467-8ac5-b4dd736e1b3e",
-      "exportLocation": "6e3b76c4-1745-4467-8ac5-b4dd736e1b3e.tar.gz"
+      "exportLocation": "6e3b76c4-1745-4467-8ac5-b4dd736e1b3e.tar.gz",
+      "exportDatetime": "2020-01-01T09:00:00Z"
     }
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepositorySpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepositorySpec.scala
@@ -6,6 +6,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import uk.gov.nationalarchives.tdr.api.db.DbConnection
+import uk.gov.nationalarchives.tdr.api.service.CurrentTimeSource
 import uk.gov.nationalarchives.tdr.api.utils.{TestDatabase, TestUtils}
 import uk.gov.nationalarchives.tdr.api.utils.TestUtils._
 
@@ -16,7 +17,7 @@ class ConsignmentRepositorySpec extends AnyFlatSpec with TestDatabase with Scala
 
   "addParentFolder" should "add parent folder name to an existing consignment row" in {
     val db = DbConnection.db
-    val consignmentRepository = new ConsignmentRepository(db)
+    val consignmentRepository = new ConsignmentRepository(db, new CurrentTimeSource)
     val consignmentId = UUID.fromString("0292019d-d112-465b-b31e-72dfb4d1254d")
 
     TestUtils.createConsignment(consignmentId, userId)
@@ -30,7 +31,7 @@ class ConsignmentRepositorySpec extends AnyFlatSpec with TestDatabase with Scala
 
   "getParentFolder" should "get parent folder name for a consignment" in {
     val db = DbConnection.db
-    val consignmentRepository = new ConsignmentRepository(db)
+    val consignmentRepository = new ConsignmentRepository(db, new CurrentTimeSource)
     val consignmentId = UUID.fromString("b6da7577-3800-4ebc-821b-9d33e52def9e")
 
     TestUtils.createConsignment(consignmentId, userId)
@@ -43,7 +44,7 @@ class ConsignmentRepositorySpec extends AnyFlatSpec with TestDatabase with Scala
 
   "getParentFolder" should "return nothing if no parent folder exists" in {
     val db = DbConnection.db
-    val consignmentRepository = new ConsignmentRepository(db)
+    val consignmentRepository = new ConsignmentRepository(db, new CurrentTimeSource)
     val consignmentId = UUID.fromString("8233b9a4-5c2d-4c2d-9355-e6ec5751fea5")
 
     TestUtils.createConsignment(consignmentId, userId)
@@ -55,7 +56,7 @@ class ConsignmentRepositorySpec extends AnyFlatSpec with TestDatabase with Scala
 
   "getSeriesOfConsignment" should "get the series for a consignment" in {
     val db = DbConnection.db
-    val consignmentRepository = new ConsignmentRepository(db)
+    val consignmentRepository = new ConsignmentRepository(db, new CurrentTimeSource)
     val consignmentId = UUID.fromString("b59a8bfd-5709-46c7-a5e9-71bae146e2f1")
     val seriesId = UUID.fromString("9e2e2a51-c2d0-4b99-8bef-2ca322528861")
     val bodyId = UUID.fromString("6e3b76c4-1745-4467-8ac5-b4dd736e1b3e")
@@ -71,7 +72,7 @@ class ConsignmentRepositorySpec extends AnyFlatSpec with TestDatabase with Scala
 
   "getTransferringBodyOfConsignment" should "get the transferring body for a consignment" in {
     val db = DbConnection.db
-    val consignmentRepository = new ConsignmentRepository(db)
+    val consignmentRepository = new ConsignmentRepository(db, new CurrentTimeSource)
     val consignmentId = UUID.fromString("a3088f8a-59a3-4ab3-9e50-1677648e8186")
     val seriesId = UUID.fromString("845a4589-d412-49d7-80c6-63969112728a")
     val bodyId = UUID.fromString("edb31587-4357-4e63-b40c-75368c9d9cc9")

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentServiceSpec.scala
@@ -140,7 +140,7 @@ class ConsignmentServiceSpec extends AnyFlatSpec with MockitoSugar with ResetMoc
 
     val fixedZonedDatetime = ZonedDateTime.ofInstant(FixedTimeSource.now, ZoneOffset.UTC)
     val consignmentId = UUID.fromString("d8383f9f-c277-49dc-b082-f6e266a39618")
-    val input = UpdateExportLocationInput(consignmentId, "exportLocation", fixedZonedDatetime)
+    val input = UpdateExportLocationInput(consignmentId, "exportLocation", Some(fixedZonedDatetime))
     when(consignmentRepoMock.updateExportLocation(input)).thenReturn(Future(1))
 
     val response = service.updateExportLocation(input).futureValue

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentServiceSpec.scala
@@ -1,6 +1,7 @@
 package uk.gov.nationalarchives.tdr.api.service
 
 import java.sql.Timestamp
+import java.time.{ZoneOffset, ZonedDateTime}
 import java.util.UUID
 
 import org.mockito.ArgumentMatchers._
@@ -137,9 +138,10 @@ class ConsignmentServiceSpec extends AnyFlatSpec with MockitoSugar with ResetMoc
       FixedTimeSource,
       fixedUuidSource)
 
+    val fixedZonedDatetime = ZonedDateTime.ofInstant(FixedTimeSource.now, ZoneOffset.UTC)
     val consignmentId = UUID.fromString("d8383f9f-c277-49dc-b082-f6e266a39618")
-    val input = UpdateExportLocationInput(consignmentId, "exportLocation")
-    when(consignmentRepoMock.updateExportLocation(input, Timestamp.from(FixedTimeSource.now))).thenReturn(Future(1))
+    val input = UpdateExportLocationInput(consignmentId, "exportLocation", fixedZonedDatetime)
+    when(consignmentRepoMock.updateExportLocation(input)).thenReturn(Future(1))
 
     val response = service.updateExportLocation(input).futureValue
 


### PR DESCRIPTION
Export datetime value is required before the DB table is updated, so client provides this value.