### PR TITLE
Fix consignment seq reference

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-optics" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-generic-extras" % circeVersion,
-  "uk.gov.nationalarchives" %% "consignment-api-db" % "0.0.44",
+  "uk.gov.nationalarchives" %% "consignment-api-db" % "0.0.45",
   "org.postgresql" % "postgresql" % "42.2.11",
   "com.typesafe.slick" %% "slick" % "3.3.2",
   "com.typesafe.slick" %% "slick-hikaricp" % "3.3.2",

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepository.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepository.scala
@@ -42,7 +42,7 @@ class ConsignmentRepository(db: Database, timeSource: TimeSource) {
   }
 
   def getNextConsignmentSequence(implicit executionContext: ExecutionContext): Future[Long] = {
-    val query = sql"select nextval('ConsignmentSequenceID')".as[Long]
+    val query = sql"select nextval('consignment_sequence_id')".as[Long]
     db.run(query).map(result => {
       if (result.size == 1) {
         result.head

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepository.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepository.scala
@@ -4,7 +4,6 @@ import java.sql.Timestamp
 import java.util.UUID
 
 import slick.jdbc.PostgresProfile.api._
-import slick.sql.SqlStreamingAction
 import uk.gov.nationalarchives.Tables.{Body, BodyRow, Consignment, ConsignmentRow, File, Series, SeriesRow}
 import uk.gov.nationalarchives.tdr.api.graphql.fields.ConsignmentFields
 import uk.gov.nationalarchives.tdr.api.service.TimeSource

--- a/src/test/resources/scripts/init.sql
+++ b/src/test/resources/scripts/init.sql
@@ -1,4 +1,4 @@
-CREATE SEQUENCE IF NOT EXISTS "ConsignmentSequenceID"
+CREATE SEQUENCE IF NOT EXISTS consignment_sequence_id
     START WITH 1
     NO CYCLE
     INCREMENT BY 1;
@@ -30,7 +30,7 @@ CREATE TABLE IF NOT EXISTS Consignment (
   TransferInitiatedBy uuid,
   ExportDatetime timestamp with time zone,
   ExportLocation text,
-  ConsignmentSequence bigint DEFAULT NEXT VALUE FOR "ConsignmentSequenceID",
+  ConsignmentSequence bigint DEFAULT NEXT VALUE FOR consignment_sequence_id,
   ConsignmentReference varchar(255),
   PRIMARY KEY (ConsignmentId)
 );

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestDatabase.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestDatabase.scala
@@ -30,7 +30,7 @@ trait TestDatabase extends BeforeAndAfterEach {
     databaseConnection.prepareStatement("DELETE FROM Consignment").execute()
     databaseConnection.prepareStatement("DELETE FROM Series").execute()
     databaseConnection.prepareStatement("DELETE FROM Body").execute()
-    databaseConnection.prepareStatement("ALTER SEQUENCE ConsignmentSequenceID RESTART WITH 1").execute()
+    databaseConnection.prepareStatement("ALTER SEQUENCE consignment_sequence_id RESTART WITH 1").execute()
 
     databaseConnection.prepareStatement("INSERT INTO FileProperty (Name, Description, Shortname) " +
       "VALUES ('SHA256ServerSideChecksum', 'The checksum calculated after upload', 'Checksum')")


### PR DESCRIPTION
Due to the production and test DB's being different types of database, the consignment sequence object needed it's name changed to follow PostgreSQL convention.

The previous casing of the sequence ("ConsignmentSequenceId") meant that the sql query needed specific quotation marks to override the fact that tables/objects/columns are usually in lower snake case within PostgreSQL DB's, but these meant that the H2 database detected the sql different, meaning either the production API worked OR the tests passed. 

This change will hopefully lead to both working in production and locally :+1: 