### PR TITLE
Get consignment reference

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepository.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepository.scala
@@ -95,4 +95,9 @@ class ConsignmentRepository(db: Database, timeSource: TimeSource) {
     val query = Consignment.filter(_.consignmentid === consignmentId).map(_.parentfolder)
     db.run(query.result).map(_.headOption.flatten)
   }
+
+  def getConsignmentReference(consignmentId: UUID)(implicit executionContext: ExecutionContext): Future[Option[String]] = {
+    val query = Consignment.filter(_.consignmentid === consignmentId).map(_.consignmentreference)
+    db.run(query.result).map(_.headOption.flatten)
+  }
 }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/DeferredResolver.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/DeferredResolver.scala
@@ -21,6 +21,7 @@ class DeferredResolver extends sangria.execution.deferred.DeferredResolver[Consi
       case DeferConsignmentSeries(consignmentId) => context.consignmentService.getSeriesOfConsignment(consignmentId)
       case DeferConsignmentBody(consignmentId) => context.consignmentService.getTransferringBodyOfConsignment(consignmentId)
       case DeferFiles(consignmentId) => context.fileMetadataService.getFileMetadata(consignmentId)
+      case DeferConsignmentReference(consignmentId) => context.consignmentService.getConsignmentReference(consignmentId)
       case other => throw UnsupportedDeferError(other)
     }
   }
@@ -32,3 +33,4 @@ case class DeferParentFolder(consignmentId: UUID) extends Deferred[Option[String
 case class DeferConsignmentSeries(consignmentId: UUID) extends Deferred[Option[Series]]
 case class DeferConsignmentBody(consignmentId: UUID) extends Deferred[TransferringBody]
 case class DeferFiles(consignmentId: UUID) extends Deferred[List[File]]
+case class DeferConsignmentReference(consignmentId: UUID) extends Deferred[Option[String]]

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentFields.scala
@@ -88,6 +88,11 @@ object ConsignmentFields {
         "files",
         ListType(FileType),
         resolve = context => DeferFiles(context.value.consignmentid)
+      ),
+      Field(
+        "consignmentReference",
+        OptionType(StringType),
+        resolve = context => DeferConsignmentReference(context.value.consignmentid)
       )
     )
   )

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentService.scala
@@ -82,6 +82,10 @@ class ConsignmentService(
     consignmentRepository.getParentFolder(consignmentId)
   }
 
+  def getConsignmentReference(consignmentId: UUID): Future[Option[String]] = {
+    consignmentRepository.getConsignmentReference(consignmentId)
+  }
+
   private def convertRowToConsignment(row: ConsignmentRow): Consignment = {
     Consignment(
       row.consignmentid,

--- a/src/test/resources/json/getconsignment_data_all.json
+++ b/src/test/resources/json/getconsignment_data_all.json
@@ -26,7 +26,8 @@
       "transferringBody": {
         "name": "Some department name",
         "code": "consignment-body-code"
-      }
+      },
+      "consignmentReference": "TDR-2021-GB"
     }
   }
 }

--- a/src/test/resources/json/getconsignment_query_alldata.json
+++ b/src/test/resources/json/getconsignment_query_alldata.json
@@ -1,3 +1,3 @@
 {
-  "query": "{getConsignment(consignmentid: \"b130e097-2edc-4e67-a7e9-5364a09ae9cb\") {seriesid, consignmentid, userid, totalFiles, fileChecks {antivirusProgress {filesProcessed}, checksumProgress {filesProcessed}, ffidProgress {filesProcessed}}, parentFolder, series {code}, transferringBody {name, code}, createdDatetime, transferInitiatedDatetime, exportDatetime}}"
+  "query": "{getConsignment(consignmentid: \"b130e097-2edc-4e67-a7e9-5364a09ae9cb\") {seriesid, consignmentid, userid, totalFiles, fileChecks {antivirusProgress {filesProcessed}, checksumProgress {filesProcessed}, ffidProgress {filesProcessed}}, parentFolder, series {code}, transferringBody {name, code}, consignmentReference, createdDatetime, transferInitiatedDatetime, exportDatetime}}"
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepositorySpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepositorySpec.scala
@@ -102,4 +102,16 @@ class ConsignmentRepositorySpec extends AnyFlatSpec with TestDatabase with Scala
 
     sequenceId should be(expectedSeq)
   }
+
+  "getConsignmentReference" should "get the consignment reference for a given consignment row" in {
+    val db = DbConnection.db
+    val consignmentRepository = new ConsignmentRepository(db, new CurrentTimeSource)
+    val consignmentId = UUID.fromString("4fba1299-83b4-44f1-a1aa-574ff44e54ed")
+
+    TestUtils.createConsignment(consignmentId, userId)
+
+    val reference = consignmentRepository.getConsignmentReference(consignmentId).futureValue
+
+    reference.get should be("TDR-2021-TESTMTB")
+  }
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentServiceSpec.scala
@@ -206,4 +206,12 @@ class ConsignmentServiceSpec extends AnyFlatSpec with MockitoSugar with ResetMoc
     val body: ConsignmentFields.TransferringBody = consignmentService.getTransferringBodyOfConsignment(consignmentId).futureValue.get
     body.name shouldBe mockBody.head.name
   }
+
+  "getConsignmentReference" should "return the consignment reference for a given consignment" in {
+    val consignmentReference = Option("TDR-2021-MTB")
+    when(consignmentRepoMock.getConsignmentReference(consignmentId)).thenReturn(Future.successful(consignmentReference))
+
+    val consignmentReferenceResult = consignmentService.getConsignmentReference(consignmentId).futureValue
+    consignmentReferenceResult shouldBe consignmentReference
+  }
 }


### PR DESCRIPTION
These changes retrieve a specified consignment's consignment reference from the DB and creates a service to call this method.
A `consignmentReference` field has been added to the consignment fields and the deferred resolver. This will allow us to add the `consignmentReference` to the generated [graphql query](https://github.com/nationalarchives/tdr-generated-graphql/blob/master/src/main/graphql/GetConsignmentSummary.graphql) for the transfer summary page.