### PR TITLE
Make consignment ref normal field

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-optics" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-generic-extras" % circeVersion,
-  "uk.gov.nationalarchives" %% "consignment-api-db" % "0.0.45",
+  "uk.gov.nationalarchives" %% "consignment-api-db" % "0.0.46",
   "org.postgresql" % "postgresql" % "42.2.11",
   "com.typesafe.slick" %% "slick" % "3.3.2",
   "com.typesafe.slick" %% "slick-hikaricp" % "3.3.2",

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepository.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepository.scala
@@ -96,8 +96,4 @@ class ConsignmentRepository(db: Database, timeSource: TimeSource) {
     db.run(query.result).map(_.headOption.flatten)
   }
 
-  def getConsignmentReference(consignmentId: UUID)(implicit executionContext: ExecutionContext): Future[Option[String]] = {
-    val query = Consignment.filter(_.consignmentid === consignmentId).map(_.consignmentreference)
-    db.run(query.result).map(_.headOption.flatten)
-  }
 }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/DeferredResolver.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/DeferredResolver.scala
@@ -21,7 +21,6 @@ class DeferredResolver extends sangria.execution.deferred.DeferredResolver[Consi
       case DeferConsignmentSeries(consignmentId) => context.consignmentService.getSeriesOfConsignment(consignmentId)
       case DeferConsignmentBody(consignmentId) => context.consignmentService.getTransferringBodyOfConsignment(consignmentId)
       case DeferFiles(consignmentId) => context.fileMetadataService.getFileMetadata(consignmentId)
-      case DeferConsignmentReference(consignmentId) => context.consignmentService.getConsignmentReference(consignmentId)
       case other => throw UnsupportedDeferError(other)
     }
   }
@@ -33,4 +32,3 @@ case class DeferParentFolder(consignmentId: UUID) extends Deferred[Option[String
 case class DeferConsignmentSeries(consignmentId: UUID) extends Deferred[Option[Series]]
 case class DeferConsignmentBody(consignmentId: UUID) extends Deferred[TransferringBody]
 case class DeferFiles(consignmentId: UUID) extends Deferred[List[File]]
-case class DeferConsignmentReference(consignmentId: UUID) extends Deferred[Option[String]]

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentFields.scala
@@ -19,7 +19,8 @@ object ConsignmentFields {
                          seriesid: UUID,
                          createdDateTime: ZonedDateTime,
                          transferInitiatedDatetime: Option[ZonedDateTime],
-                         exportDatetime: Option[ZonedDateTime]
+                         exportDatetime: Option[ZonedDateTime],
+                         consignmentReference: String
                         )
 
   case class AddConsignmentInput(seriesid: UUID)
@@ -89,11 +90,7 @@ object ConsignmentFields {
         ListType(FileType),
         resolve = context => DeferFiles(context.value.consignmentid)
       ),
-      Field(
-        "consignmentReference",
-        OptionType(StringType),
-        resolve = context => DeferConsignmentReference(context.value.consignmentid)
-      )
+      Field("consignmentReference", StringType, resolve = _.value.consignmentReference)
     )
   )
 

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentService.scala
@@ -41,7 +41,7 @@ class ConsignmentService(
         userId,
         Timestamp.from(now),
         consignmentsequence = Option(sequence),
-        consignmentreference = Option(consignmentRef))
+        consignmentreference = consignmentRef)
       consignmentRepository.addConsignment(consignmentRow).map(
         row => convertRowToConsignment(row)
       )
@@ -82,10 +82,6 @@ class ConsignmentService(
     consignmentRepository.getParentFolder(consignmentId)
   }
 
-  def getConsignmentReference(consignmentId: UUID): Future[Option[String]] = {
-    consignmentRepository.getConsignmentReference(consignmentId)
-  }
-
   private def convertRowToConsignment(row: ConsignmentRow): Consignment = {
     Consignment(
       row.consignmentid,
@@ -93,6 +89,7 @@ class ConsignmentService(
       row.seriesid,
       row.datetime.toZonedDateTime,
       row.transferinitiateddatetime.map(ts => ts.toZonedDateTime),
-      row.exportdatetime.map(ts => ts.toZonedDateTime))
+      row.exportdatetime.map(ts => ts.toZonedDateTime),
+      row.consignmentreference)
   }
 }

--- a/src/test/resources/scripts/init.sql
+++ b/src/test/resources/scripts/init.sql
@@ -31,7 +31,7 @@ CREATE TABLE IF NOT EXISTS Consignment (
   ExportDatetime timestamp with time zone,
   ExportLocation text,
   ConsignmentSequence bigint DEFAULT NEXT VALUE FOR consignment_sequence_id,
-  ConsignmentReference varchar(255),
+  ConsignmentReference varchar(255) NOT NULL,
   PRIMARY KEY (ConsignmentId)
 );
 

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepositorySpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepositorySpec.scala
@@ -103,15 +103,4 @@ class ConsignmentRepositorySpec extends AnyFlatSpec with TestDatabase with Scala
     sequenceId should be(expectedSeq)
   }
 
-  "getConsignmentReference" should "get the consignment reference for a given consignment row" in {
-    val db = DbConnection.db
-    val consignmentRepository = new ConsignmentRepository(db, new CurrentTimeSource)
-    val consignmentId = UUID.fromString("4fba1299-83b4-44f1-a1aa-574ff44e54ed")
-
-    TestUtils.createConsignment(consignmentId, userId)
-
-    val reference = consignmentRepository.getConsignmentReference(consignmentId).futureValue
-
-    reference.get should be("TDR-2021-TESTMTB")
-  }
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ClientFileMetadataRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ClientFileMetadataRouteSpec.scala
@@ -134,12 +134,6 @@ class ClientFileMetadataRouteSpec extends AnyFlatSpec with Matchers with TestReq
     response.errors.head.extensions.get.code should equal(expectedResponse.errors.head.extensions.get.code)
   }
 
-  private def createConsignment(consignmentId: UUID, userId: UUID): Unit = {
-    val sql = s"insert into Consignment (ConsignmentId, SeriesId, UserId) VALUES ('$consignmentId', 1, '$userId')"
-    val ps: PreparedStatement = DbConnection.db.source.createConnection().prepareStatement(sql)
-    ps.executeUpdate()
-  }
-
   private def createFile(fileId: UUID, consignmentId: UUID): Unit = {
     val sql = s"insert into File (FileId, ConsignmentId) VALUES ('$fileId', '$consignmentId')"
     val ps: PreparedStatement = DbConnection.db.source.createConnection().prepareStatement(sql)

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentRouteSpec.scala
@@ -110,7 +110,9 @@ class ConsignmentRouteSpec extends AnyFlatSpec with Matchers with TestRequest wi
 
   //scalastyle:off magic.number
   "getConsignment" should "return all requested fields" in {
-    val sql = "INSERT INTO Consignment (ConsignmentId, SeriesId, UserId, Datetime, TransferInitiatedDatetime, ExportDatetime) VALUES (?, ?, ?, ?, ?, ?)"
+    val sql = "INSERT INTO Consignment" +
+      "(ConsignmentId, SeriesId, UserId, Datetime, TransferInitiatedDatetime, ExportDatetime, ConsignmentReference)" +
+      "VALUES (?, ?, ?, ?, ?, ?, ?)"
     val ps: PreparedStatement = databaseConnection.prepareStatement(sql)
     val bodyId = UUID.fromString("5c761efa-ae1a-4ec8-bb08-dc609fce51f8")
     val bodyCode = "consignment-body-code"
@@ -123,6 +125,7 @@ class ConsignmentRouteSpec extends AnyFlatSpec with Matchers with TestRequest wi
     ps.setTimestamp(4, fixedTimeStamp)
     ps.setTimestamp(5, fixedTimeStamp)
     ps.setTimestamp(6, fixedTimeStamp)
+    ps.setString(7, "TEST-TDR-2021-MTB")
     ps.executeUpdate()
     val fileOneId = "e7ba59c9-5b8b-4029-9f27-2d03957463ad"
     val fileTwoId = "42910a85-85c3-40c3-888f-32f697bfadb6"

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentRouteSpec.scala
@@ -172,14 +172,8 @@ class ConsignmentRouteSpec extends AnyFlatSpec with Matchers with TestRequest wi
   }
 
   "getConsignment" should "return the expected data" in {
-    val fixedUuidSource = new FixedUUIDSource()
-    val sql = "INSERT INTO Consignment (ConsignmentId, SeriesId, UserId) VALUES (?,?,?)"
-    val ps: PreparedStatement = databaseConnection.prepareStatement(sql)
-    val uuid = fixedUuidSource.uuid.toString
-    ps.setString(1, uuid)
-    ps.setString(2, uuid)
-    ps.setString(3, userId.toString)
-    ps.executeUpdate()
+    val consignmentId = UUID.fromString("6e3b76c4-1745-4467-8ac5-b4dd736e1b3e")
+    createConsignment(consignmentId, userId)
 
     val expectedResponse: GraphqlQueryData = expectedQueryResponse("data_some")
     val response: GraphqlQueryData = runTestQuery("query_somedata", validUserToken())
@@ -188,14 +182,8 @@ class ConsignmentRouteSpec extends AnyFlatSpec with Matchers with TestRequest wi
 
   "getConsignment" should "allow a user with export access to return data" in {
     val exportAccessToken = validBackendChecksToken("export")
-    val fixedUuidSource = new FixedUUIDSource()
-    val sql = "INSERT INTO Consignment (ConsignmentId, SeriesId, UserId) VALUES (?,?,?)"
-    val ps: PreparedStatement = databaseConnection.prepareStatement(sql)
-    val uuid = fixedUuidSource.uuid.toString
-    ps.setString(1, uuid)
-    ps.setString(2, uuid)
-    ps.setString(3, userId.toString)
-    ps.executeUpdate()
+    val consignmentId = UUID.fromString("6e3b76c4-1745-4467-8ac5-b4dd736e1b3e")
+    createConsignment(consignmentId, userId)
 
     val expectedResponse: GraphqlQueryData = expectedQueryResponse("data_some")
     val response: GraphqlQueryData = runTestQuery("query_somedata", exportAccessToken)
@@ -203,10 +191,9 @@ class ConsignmentRouteSpec extends AnyFlatSpec with Matchers with TestRequest wi
   }
 
   "getConsignment" should "not allow a user to get a consignment that they did not create" in {
+    val consignmentId = UUID.fromString("f1dbc692-e56c-4d76-be94-d8d3d79bd38a")
     val otherUserId = "73abd1dc-294d-4068-b60d-c1cd4782d08d"
-    val sql = s"INSERT INTO Consignment (SeriesId, UserId) VALUES (1, '$otherUserId')"
-    val ps: PreparedStatement = databaseConnection.prepareStatement(sql)
-    ps.executeUpdate()
+    createConsignment(consignmentId, UUID.fromString(otherUserId))
 
     val response: GraphqlQueryData = runTestQuery("query_somedata", validUserToken())
 

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
@@ -34,9 +34,8 @@ class FileRouteSpec extends AnyFlatSpec with Matchers with TestRequest with Test
   val fixedUuidSource = new FixedUUIDSource()
 
   "The api" should "add one file if the correct information is provided" in {
-    val sql = s"insert into Consignment (SeriesId, UserId) VALUES (1,'$userId')"
-    val ps: PreparedStatement = DbConnection.db.source.createConnection().prepareStatement(sql)
-    ps.executeUpdate()
+    val consignmentId = UUID.fromString("6e3b76c4-1745-4467-8ac5-b4dd736e1b3e")
+    createConsignment(consignmentId, userId)
 
     val expectedResponse: GraphqlMutationData = expectedMutationResponse("data_one_file")
     val response: GraphqlMutationData = runTestMutation("mutation_one_file", validUserToken())
@@ -47,9 +46,8 @@ class FileRouteSpec extends AnyFlatSpec with Matchers with TestRequest with Test
   }
 
   "The api" should "add the static metadata if the correct information is provided" in {
-    val sql = s"insert into Consignment (SeriesId, UserId) VALUES (1,'$userId')"
-    val ps: PreparedStatement = DbConnection.db.source.createConnection().prepareStatement(sql)
-    ps.executeUpdate()
+    val consignmentId = UUID.fromString("6e3b76c4-1745-4467-8ac5-b4dd736e1b3e")
+    createConsignment(consignmentId, userId)
 
     val response: GraphqlMutationData = runTestMutation("mutation_one_file", validUserToken())
 
@@ -57,11 +55,8 @@ class FileRouteSpec extends AnyFlatSpec with Matchers with TestRequest with Test
   }
 
   "The api" should "add three files if the correct information is provided" in {
-    val sql = "insert into Consignment (SeriesId, UserId) VALUES (?,?)"
-    val ps: PreparedStatement = DbConnection.db.source.createConnection().prepareStatement(sql)
-    ps.setString(1, fixedUuidSource.uuid.toString)
-    ps.setString(2, userId.toString)
-    ps.executeUpdate()
+    val consignmentId = UUID.fromString("6e3b76c4-1745-4467-8ac5-b4dd736e1b3e")
+    createConsignment(consignmentId, userId)
 
     val expectedResponse: GraphqlMutationData = expectedMutationResponse("data_all")
     val response: GraphqlMutationData = runTestMutation("mutation_alldata", validUserToken())
@@ -85,9 +80,10 @@ class FileRouteSpec extends AnyFlatSpec with Matchers with TestRequest with Test
   }
 
   "The api" should "throw an error if the user does not own the consignment" in {
-    val sql = "insert into Consignment (SeriesId, UserId) VALUES (1,'5ab14990-ed63-4615-8336-56fbb9960300')"
-    val ps: PreparedStatement = DbConnection.db.source.createConnection().prepareStatement(sql)
-    ps.executeUpdate()
+    val userId = UUID.fromString("5ab14990-ed63-4615-8336-56fbb9960300")
+    val consignmentId = UUID.fromString("6e3b76c4-1745-4467-8ac5-b4dd736e1b3e")
+
+    createConsignment(consignmentId, userId)
 
     val expectedResponse: GraphqlMutationData = expectedMutationResponse("data_error_not_owner")
     val response: GraphqlMutationData = runTestMutation("mutation_alldata", validUserToken())
@@ -96,9 +92,8 @@ class FileRouteSpec extends AnyFlatSpec with Matchers with TestRequest with Test
   }
 
   "The api" should "throw an error if the consignment already has had files uploaded" in {
-    val sqlConsignment = s"insert into Consignment (SeriesId, UserId) VALUES (1,'$userId')"
-    val psConsignment: PreparedStatement = DbConnection.db.source.createConnection().prepareStatement(sqlConsignment)
-    psConsignment.executeUpdate()
+    val consignmentId = UUID.fromString("6e3b76c4-1745-4467-8ac5-b4dd736e1b3e")
+    createConsignment(consignmentId, userId)
     //Seed DB with initial file for consignment
     runTestMutation("mutation_one_file", validUserToken())
 

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/TransferAgreementRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/TransferAgreementRouteSpec.scala
@@ -91,9 +91,8 @@ class TransferAgreementRouteSpec extends AnyFlatSpec with Matchers with TestRequ
   }
 
   "The api" should "return an existing transfer agreement consignment metadata properties for a user owned consignment" in {
-    val consignmentSql = s"INSERT INTO Consignment (SeriesId, UserId) VALUES (1,'$userId')"
-    val psConsignment: PreparedStatement = DbConnection.db.source.createConnection().prepareStatement(consignmentSql)
-    psConsignment.executeUpdate()
+    val consignmentId = UUID.fromString("6e3b76c4-1745-4467-8ac5-b4dd736e1b3e")
+    createConsignment(consignmentId, userId)
 
     val expectedResponse: GraphqlQueryData = expectedQueryResponse("data_all")
     val response: GraphqlQueryData = runTestQuery("query_alldata", validUserToken())

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentServiceSpec.scala
@@ -207,11 +207,4 @@ class ConsignmentServiceSpec extends AnyFlatSpec with MockitoSugar with ResetMoc
     body.name shouldBe mockBody.head.name
   }
 
-  "getConsignmentReference" should "return the consignment reference for a given consignment" in {
-    val consignmentReference = Option("TDR-2021-MTB")
-    when(consignmentRepoMock.getConsignmentReference(consignmentId)).thenReturn(Future.successful(consignmentReference))
-
-    val consignmentReferenceResult = consignmentService.getConsignmentReference(consignmentId).futureValue
-    consignmentReferenceResult shouldBe consignmentReference
-  }
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentServiceSpec.scala
@@ -36,7 +36,7 @@ class ConsignmentServiceSpec extends AnyFlatSpec with MockitoSugar with ResetMoc
   //scalastyle:off magic.number
   val consignmentSequence: Option[Long] = Option(400L)
   //scalastyle:on magic.number
-  val consignmentReference = Option("TDR-2020-VB")
+  val consignmentReference = "TDR-2020-VB"
   val mockConsignment: ConsignmentRow = ConsignmentRow(
     consignmentId,
     seriesId,

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
@@ -161,8 +161,22 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
 
     val fileRepositoryMock = mock[FileRepository]
     val consignmentRepositoryMock = mock[ConsignmentRepository]
-    val consignment1 = ConsignmentRow(consignmentId1, seriesId1, userId1, Timestamp.from(Instant.now), consignmentsequence = Option(400L))
-    val consignment2 = ConsignmentRow(consignmentId2, seriesId2, userId2, Timestamp.from(Instant.now), consignmentsequence = Option(500L))
+    val consignment1 = ConsignmentRow(
+      consignmentId1,
+      seriesId1,
+      userId1,
+      Timestamp.from(Instant.now),
+      consignmentsequence = Option(400L),
+      consignmentreference = "TEST-TDR-2021-VB"
+    )
+    val consignment2 = ConsignmentRow(
+      consignmentId2,
+      seriesId2,
+      userId2,
+      Timestamp.from(Instant.now),
+      consignmentsequence = Option(500L),
+      consignmentreference = "TEST-TDR-2021-3B"
+    )
     val fileMetadataRepositoryMock = mock[FileMetadataRepository]
     val fileService = new FileService(fileRepositoryMock, consignmentRepositoryMock, fileMetadataRepositoryMock, FixedTimeSource, fixedUuidSource)
 


### PR DESCRIPTION
This PR changes the `consignmentReference` field on the API to be a normal field rather than utilising the deferred resolver. It has no effect on the [relevant generated graphql query](https://github.com/nationalarchives/tdr-generated-graphql/blob/master/src/main/graphql/GetConsignmentSummary.graphql#L10).

I also took the chance to fix some of the routeSpec tests as they were explicitly inserting into the test `Consignment` table rather than utilising available helper methods. I edited the existing helper method and changed tests to call this rather than hard-coding SQL. Though there was a test within the `ConsignmentRouteSpec` which was inserting more complex data that I left hard-coded.