### PR TITLE
Update consignment status upon upload

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-optics" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-generic-extras" % circeVersion,
-  "uk.gov.nationalarchives" %% "consignment-api-db" % "0.0.46",
+  "uk.gov.nationalarchives" %% "consignment-api-db" % "0.0.47",
   "org.postgresql" % "postgresql" % "42.2.11",
   "com.typesafe.slick" %% "slick" % "3.3.2",
   "com.typesafe.slick" %% "slick-hikaricp" % "3.3.2",

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileRepository.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileRepository.scala
@@ -1,15 +1,14 @@
 package uk.gov.nationalarchives.tdr.api.db.repository
 
 import java.util.UUID
-
 import slick.jdbc.PostgresProfile.api._
 import uk.gov.nationalarchives.Tables
-import uk.gov.nationalarchives.Tables.{Avmetadata, File, FileRow}
+import uk.gov.nationalarchives.Tables.{Avmetadata, Consignmentstatus, ConsignmentstatusRow, File, FileRow}
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
-class FileRepository(db: Database) {
-  private val insertQuery = File  returning File.map(_.fileid)into ((file, fileid) => file.copy(fileid = fileid))
+class FileRepository(db: Database)(implicit val executionContext: ExecutionContext) {
+  private val insertFileQuery = File  returning File.map(_.fileid)into ((file, fileid) => file.copy(fileid = fileid))
 
   def getFilesWithPassedAntivirus(consignmentId: UUID): Future[Seq[Tables.FileRow]] = {
     val query = Avmetadata.join(File)
@@ -20,8 +19,9 @@ class FileRepository(db: Database) {
     db.run(query.result)
   }
 
-  def addFiles(fileRows: Seq[FileRow]): Future[Seq[Tables.FileRow]] = {
-    db.run(insertQuery ++= fileRows)
+  def addFiles(fileRows: Seq[FileRow], consignmentStatusRow: ConsignmentstatusRow): Future[Seq[Tables.FileRow]] = {
+    val allAdditions = DBIO.seq(insertFileQuery ++= fileRows, Consignmentstatus += consignmentStatusRow).transactionally
+    db.run(allAdditions).map(_ => fileRows)
   }
 
   def countFilesInConsignment(consignmentId: UUID): Future[Int] = {

--- a/src/test/resources/scripts/init.sql
+++ b/src/test/resources/scripts/init.sql
@@ -110,3 +110,13 @@ CREATE TABLE IF NOT EXISTS FFIDMetadataMatches (
     PUID varchar(255) not null,
     FOREIGN KEY (FFIDMetadataId) REFERENCES FFIDMetadata(FFIDMetadataId)
 );
+
+CREATE TABLE IF NOT EXISTS ConsignmentStatus (
+    ConsignmentStatusId uuid not null,
+    ConsignmentId uuid not null,
+    StatusType varchar(255) not null,
+    Value varchar(255) not null,
+    CreatedDatetime timestamp not null,
+    PRIMARY KEY (ConsignmentStatusId),
+    FOREIGN KEY (ConsignmentId) REFERENCES Consignment(ConsignmentId)
+);

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileRepositorySpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileRepositorySpec.scala
@@ -9,7 +9,7 @@ import uk.gov.nationalarchives.tdr.api.db.DbConnection
 import uk.gov.nationalarchives.tdr.api.utils.TestUtils._
 import uk.gov.nationalarchives.tdr.api.utils.{TestDatabase, TestUtils}
 
-import java.sql.Timestamp
+import java.sql.{PreparedStatement, ResultSet, Timestamp}
 import java.time.Instant
 import java.util.UUID
 import scala.concurrent.ExecutionContext
@@ -44,6 +44,7 @@ class FileRepositorySpec extends AnyFlatSpec with TestDatabase with ScalaFutures
       file.consignmentid shouldBe consignmentId
       file.userid shouldBe userId
     }
+    checkConsignmentStatusExists(consignmentId)
   }
 
   "countFilesInConsignment" should "return 0 if a consignment has no files" in {
@@ -154,5 +155,15 @@ class FileRepositorySpec extends AnyFlatSpec with TestDatabase with ScalaFutures
 
     files.size shouldBe 1
     files.head.fileid shouldBe fileOneId
+  }
+
+  private def checkConsignmentStatusExists(consignmentId: UUID): Unit = {
+    val sql = "SELECT * FROM ConsignmentStatus WHERE ConsignmentId = ?"
+    val ps:PreparedStatement = DbConnection.db.source.createConnection().prepareStatement(sql)
+    ps.setString(1, consignmentId.toString)
+    val rs: ResultSet = ps.executeQuery()
+    rs.next()
+    rs.getString("ConsignmentId") should equal(consignmentId.toString)
+    rs.next() should equal (false)
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileRepositorySpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileRepositorySpec.scala
@@ -1,16 +1,50 @@
 package uk.gov.nationalarchives.tdr.api.db.repository
 
-import java.util.UUID
-
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import uk.gov.nationalarchives
+import uk.gov.nationalarchives.Tables._
 import uk.gov.nationalarchives.tdr.api.db.DbConnection
-import uk.gov.nationalarchives.tdr.api.utils.{TestDatabase, TestUtils}
 import uk.gov.nationalarchives.tdr.api.utils.TestUtils._
+import uk.gov.nationalarchives.tdr.api.utils.{TestDatabase, TestUtils}
+
+import java.sql.Timestamp
+import java.time.Instant
+import java.util.UUID
+import scala.concurrent.ExecutionContext
 
 
 class FileRepositorySpec extends AnyFlatSpec with TestDatabase with ScalaFutures with Matchers {
+  implicit val executionContext: ExecutionContext = ExecutionContext.Implicits.global
+
+  "addFiles" should "create files and update ConsignmentStatus table for a consignment" in {
+    val db = DbConnection.db
+    val fileRepository = new FileRepository(db)
+    val consignmentId = UUID.fromString("94abafc4-165e-469b-ba93-eace3f224de5")
+    val fileOneId = UUID.fromString("7499a278-2fec-4c47-92fb-dd9024c65d0d")
+    val fileTwoId = UUID.fromString("e7d21444-0c62-4115-a4ad-320fd3d3dae3")
+    val fileRows = Seq(
+      FileRow(fileOneId, consignmentId, userId, Timestamp.from(Instant.now)),
+      FileRow(fileTwoId, consignmentId, userId, Timestamp.from(Instant.now))
+    )
+    val consignmentStatusRow = ConsignmentstatusRow(
+      UUID.fromString("ad5ac54c-6a67-4892-b8ac-120362df7917"),
+      consignmentId,
+      "Upload",
+      "InProgress",
+      Timestamp.from(Instant.now)
+    )
+
+    TestUtils.createConsignment(consignmentId, userId)
+
+    val addFiles: Seq[nationalarchives.Tables.FileRow] = fileRepository.addFiles(fileRows, consignmentStatusRow).futureValue
+
+    addFiles.foreach{ file =>
+      file.consignmentid shouldBe consignmentId
+      file.userid shouldBe userId
+    }
+  }
 
   "countFilesInConsignment" should "return 0 if a consignment has no files" in {
     val db = DbConnection.db

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
@@ -3,15 +3,14 @@ package uk.gov.nationalarchives.tdr.api.service
 import java.sql.Timestamp
 import java.time.Instant
 import java.util.UUID
-
 import org.mockito.ArgumentMatchers.any
-import org.mockito.{ArgumentCaptor, MockitoSugar}
+import org.mockito.{ArgumentCaptor, ArgumentMatchers, MockitoSugar}
 import org.scalatest.Assertion
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import uk.gov.nationalarchives.Tables
-import uk.gov.nationalarchives.Tables.{ConsignmentRow, FileRow, FilemetadataRow}
+import uk.gov.nationalarchives.Tables.{ConsignmentRow, ConsignmentstatusRow, FileRow, FilemetadataRow}
 import uk.gov.nationalarchives.tdr.api.db.repository.{ConsignmentRepository, FileMetadataRepository, FileRepository}
 import uk.gov.nationalarchives.tdr.api.graphql.fields.FileFields.{AddFilesInput, Files}
 import uk.gov.nationalarchives.tdr.api.service.FileMetadataService.staticMetadataProperties
@@ -33,7 +32,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val fileMetadataRepositoryMock = mock[FileMetadataRepository]
 
     val mockFileResponse = Future.successful(List(FileRow(fileId, consignmentId, uuid, Timestamp.from(Instant.now))))
-    when(fileRepositoryMock.addFiles(any[List[FileRow]])).thenReturn(mockFileResponse)
+    when(fileRepositoryMock.addFiles(any[List[FileRow]], any[ConsignmentstatusRow])).thenReturn(mockFileResponse)
     val mockConsignmentResponse = Future.successful(())
     when(consignmentRepositoryMock.addParentFolder(consignmentId, "Parent folder name")).thenReturn(mockConsignmentResponse)
     val mockFileMetadataResponse = Future.successful(Seq(FilemetadataRow(UUID.randomUUID(), fileId, "value", Timestamp.from(Instant.now), uuid, "name")))
@@ -63,7 +62,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val captor: ArgumentCaptor[List[FileRow]] = ArgumentCaptor.forClass(classOf[List[FileRow]])
 
     val mockResponse = Future.successful(List(fileRowOne, fileRowTwo, fileRowThree))
-    when(fileRepositoryMock.addFiles(captor.capture())).thenReturn(mockResponse)
+    when(fileRepositoryMock.addFiles(captor.capture(), any[ConsignmentstatusRow])).thenReturn(mockResponse)
     val mockConsignmentResponse = Future.successful(())
     when(consignmentRepositoryMock.addParentFolder(consignmentUuid, "Parent folder name")).thenReturn(mockConsignmentResponse)
     val mockFileMetadataResponse = Future.successful(
@@ -86,27 +85,31 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val userId = UUID.randomUUID()
     val fileUuid = fixedUuidSource.uuid
     val consignmentUuid = UUID.randomUUID()
+    val consignmentStatusUuid = fixedUuidSource.uuid
     val fileRepositoryMock = mock[FileRepository]
     val consignmentRepositoryMock = mock[ConsignmentRepository]
     val fileMetadataRepositoryMock = mock[FileMetadataRepository]
     val fileService = new FileService(fileRepositoryMock, consignmentRepositoryMock, fileMetadataRepositoryMock, FixedTimeSource, fixedUuidSource)
     fixedUuidSource.reset
+    val timeNow = Timestamp.from(FixedTimeSource.now)
 
-    val expectedRow = List(FileRow(fileUuid, consignmentUuid, userId, Timestamp.from(FixedTimeSource.now)))
-    val captor: ArgumentCaptor[List[FileRow]] = ArgumentCaptor.forClass(classOf[List[FileRow]])
-    val mockResponse = Future.successful(List(FileRow(fileUuid, consignmentUuid, userId, Timestamp.from(FixedTimeSource.now))))
-    when(fileRepositoryMock.addFiles(captor.capture())).thenReturn(mockResponse)
+    val mockConsignmentStatusRow = ConsignmentstatusRow(consignmentStatusUuid, consignmentUuid, "Upload", "InProgress", timeNow)
+    val expectedFileRow = List(FileRow(fileUuid, consignmentUuid, userId, timeNow))
+    val fileCaptor: ArgumentCaptor[List[FileRow]] = ArgumentCaptor.forClass(classOf[List[FileRow]])
+    val consignmentStatusCaptor: ArgumentCaptor[ConsignmentstatusRow] = ArgumentCaptor.forClass(classOf[ConsignmentstatusRow])
+    val mockResponse = Future.successful(List(FileRow(fileUuid, consignmentUuid, userId, timeNow)))
+    when(fileRepositoryMock.addFiles(fileCaptor.capture(), consignmentStatusCaptor.capture())).thenReturn(mockResponse)
     val mockConsignmentResponse = Future.successful(())
     when(consignmentRepositoryMock.addParentFolder(consignmentUuid, "Parent folder name")).thenReturn(mockConsignmentResponse)
-    val mockFileMetadataResponse = Future.successful(Seq(FilemetadataRow(UUID.randomUUID(), fileUuid, "value", Timestamp.from(Instant.now), userId, "name")))
+    val mockFileMetadataResponse = Future.successful(Seq(FilemetadataRow(UUID.randomUUID(), fileUuid, "value", timeNow, userId, "name")))
     when(fileMetadataRepositoryMock.addFileMetadata(any[Seq[FilemetadataRow]])).thenReturn(mockFileMetadataResponse)
 
     fileService.addFile(AddFilesInput(consignmentUuid, 1, "Parent folder name"), userId).futureValue
 
-    verify(fileRepositoryMock).addFiles(expectedRow)
-    captor.getAllValues.size should equal(1)
-    captor.getAllValues.get(0).head.consignmentid should equal(consignmentUuid)
-    captor.getAllValues.get(0).head.userid should equal(userId)
+    verify(fileRepositoryMock).addFiles(expectedFileRow, mockConsignmentStatusRow)
+    fileCaptor.getAllValues.size should equal(1)
+    fileCaptor.getAllValues.get(0).head.consignmentid should equal(consignmentUuid)
+    fileCaptor.getAllValues.get(0).head.userid should equal(userId)
   }
 
   "createFile" should "create the correct static metadata" in {
@@ -114,13 +117,14 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val uuid = UUID.randomUUID()
     val fileId = UUID.randomUUID()
     val consignmentId = UUID.randomUUID()
+    val consignmentStatusId = fixedUUIDSource.uuid
 
     val fileRepositoryMock = mock[FileRepository]
     val consignmentRepositoryMock = mock[ConsignmentRepository]
     val fileMetadataRepositoryMock = mock[FileMetadataRepository]
 
     val mockFileResponse = Future.successful(List(FileRow(fileId, consignmentId, uuid, Timestamp.from(Instant.now))))
-    when(fileRepositoryMock.addFiles(any[List[FileRow]])).thenReturn(mockFileResponse)
+    when(fileRepositoryMock.addFiles(any[List[FileRow]], any[ConsignmentstatusRow])).thenReturn(mockFileResponse)
     val mockConsignmentResponse = Future.successful(())
     when(consignmentRepositoryMock.addParentFolder(consignmentId, "Parent folder name")).thenReturn(mockConsignmentResponse)
     val mockFileMetadataResponse = Future.successful(Seq(FilemetadataRow(UUID.randomUUID(), fileId, "value", Timestamp.from(Instant.now), uuid, "name")))

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
@@ -1,10 +1,7 @@
 package uk.gov.nationalarchives.tdr.api.service
 
-import java.sql.Timestamp
-import java.time.Instant
-import java.util.UUID
 import org.mockito.ArgumentMatchers.any
-import org.mockito.{ArgumentCaptor, ArgumentMatchers, MockitoSugar}
+import org.mockito.{ArgumentCaptor, MockitoSugar}
 import org.scalatest.Assertion
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
@@ -16,6 +13,9 @@ import uk.gov.nationalarchives.tdr.api.graphql.fields.FileFields.{AddFilesInput,
 import uk.gov.nationalarchives.tdr.api.service.FileMetadataService.staticMetadataProperties
 import uk.gov.nationalarchives.tdr.api.utils.{FixedTimeSource, FixedUUIDSource}
 
+import java.sql.Timestamp
+import java.time.Instant
+import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 
 class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with ScalaFutures {
@@ -80,7 +80,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     result.fileIds shouldBe List(fileUuidOne, fileUuidTwo, fileUuidThree)
   }
 
-  "createFile" should "link a file to the correct user and consignment" in {
+  "createFile" should "link a file to the correct user, consignment, and consignment status" in {
     val fixedUuidSource = new FixedUUIDSource()
     val userId = UUID.randomUUID()
     val fileUuid = fixedUuidSource.uuid
@@ -110,6 +110,12 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     fileCaptor.getAllValues.size should equal(1)
     fileCaptor.getAllValues.get(0).head.consignmentid should equal(consignmentUuid)
     fileCaptor.getAllValues.get(0).head.userid should equal(userId)
+    consignmentStatusCaptor.getAllValues.size() should equal(1)
+    consignmentStatusCaptor.getAllValues.get(0).consignmentstatusid should equal(consignmentStatusUuid)
+    consignmentStatusCaptor.getAllValues.get(0).consignmentid should equal(consignmentUuid)
+    consignmentStatusCaptor.getAllValues.get(0).statustype should equal("Upload")
+    consignmentStatusCaptor.getAllValues.get(0).value should equal("InProgress")
+    consignmentStatusCaptor.getAllValues.get(0).createddatetime should equal(timeNow)
   }
 
   "createFile" should "create the correct static metadata" in {
@@ -117,7 +123,6 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val uuid = UUID.randomUUID()
     val fileId = UUID.randomUUID()
     val consignmentId = UUID.randomUUID()
-    val consignmentStatusId = fixedUUIDSource.uuid
 
     val fileRepositoryMock = mock[FileRepository]
     val consignmentRepositoryMock = mock[ConsignmentRepository]

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestDatabase.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestDatabase.scala
@@ -28,6 +28,7 @@ trait TestDatabase extends BeforeAndAfterEach {
     databaseConnection.prepareStatement("DELETE FROM File").execute()
     databaseConnection.prepareStatement("DELETE FROM ConsignmentMetadata").execute()
     databaseConnection.prepareStatement("DELETE FROM ConsignmentProperty").execute()
+    databaseConnection.prepareStatement("DELETE FROM ConsignmentStatus").execute()
     databaseConnection.prepareStatement("DELETE FROM Consignment").execute()
     databaseConnection.prepareStatement("DELETE FROM Series").execute()
     databaseConnection.prepareStatement("DELETE FROM Body").execute()


### PR DESCRIPTION
These changes update the newly created `ConsignmentStatus` table upon consignment upload, to facilitate showing the user an error should they try to upload for a consignment that already has an upload.

This is performed using the Slick `transactionally` combinator to perform the `File` table update as well as the `ConsignmentStatus` insert. This means that if anything goes wrong within the function both tables will not be updated, helping us keep our data consistent across tables. Within the `FileService` `addFile` function I've added functionality to insert the `ConsignmentStatusRow` with some info hard-coded for now, but we can change this once we're utilising the `ConsignmentStatus` table for other points in the user journey.

I've also added a test for the repository method and made additions to the FileServiceSpec