### PR TITLE
Only require database port and host in environment-specific config

### DIFF
--- a/src/main/resources/application.base.conf
+++ b/src/main/resources/application.base.conf
@@ -12,17 +12,10 @@ source = {
   uuid = uk.gov.nationalarchives.tdr.api.service.RandomUUID
 }
 
-consignmentapi = {
-  useIamAuth = true
+consignmentapi {
   profile = "slick.jdbc.PostgresProfile$"
   db {
     connectionPool = "HikariCP"
     driver = "org.postgresql.Driver",
-    port = ${DB_PORT}
-    host = ${DB_ADDR}
-    url = "jdbc:postgresql://"${consignmentapi.db.host}":"${consignmentapi.db.port}"/consignmentapi?ssl=true&sslrootcert=/api/rds-ca-2019-root.pem&sslmode=verify-full",
-    user = "consignment_api_user"
-    # We're setting the password using hikariDataSource.ds.getHikariConfigMXBean.setPassword This config option is needed to allow you to do it. https://github.com/brettwooldridge/HikariCP/wiki/MBean-(JMX)-Monitoring-and-Management
-    registerMbeans = true
   }
 }

--- a/src/main/resources/application.env-base.conf
+++ b/src/main/resources/application.env-base.conf
@@ -1,0 +1,16 @@
+# The base config file for all hosted environments
+
+include "application.base"
+
+consignmentapi = {
+  useIamAuth = true
+  profile = "slick.jdbc.PostgresProfile$"
+  db {
+    port = ${DB_PORT}
+    host = ${DB_ADDR}
+    url = "jdbc:postgresql://"${consignmentapi.db.host}":"${consignmentapi.db.port}"/consignmentapi?ssl=true&sslrootcert=/api/rds-ca-2019-root.pem&sslmode=verify-full",
+    user = "consignment_api_user"
+    # We're setting the password using hikariDataSource.ds.getHikariConfigMXBean.setPassword This config option is needed to allow you to do it. https://github.com/brettwooldridge/HikariCP/wiki/MBean-(JMX)-Monitoring-and-Management
+    registerMbeans = true
+  }
+}

--- a/src/main/resources/application.intg.conf
+++ b/src/main/resources/application.intg.conf
@@ -1,4 +1,4 @@
-include "application.base"
+include "application.env-base"
 
 frontend = {
   // Allow cross-origin requests from the integration frontend and local dev environment, to make it easier to do

--- a/src/main/resources/application.prod.conf
+++ b/src/main/resources/application.prod.conf
@@ -1,1 +1,1 @@
-include "application.base"
+include "application.env-base"

--- a/src/main/resources/application.staging.conf
+++ b/src/main/resources/application.staging.conf
@@ -1,1 +1,1 @@
-include "application.base"
+include "application.env-base"


### PR DESCRIPTION
Add a new layer of config file which is the base for the hosted environments (intg, staging and prod). Move the database config into this file, so that the dev environment doesn't try to load the non-existent environment variables `DB_PORT` and `DB_ADDR`.