### PR TITLE
Refactor file service getFileMetadata method

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/http/GraphQLServer.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/http/GraphQLServer.scala
@@ -75,6 +75,7 @@ object GraphQLServer {
     val fileMetadataRepository = new FileMetadataRepository(db)
     val fileRepository = new FileRepository(db)
     val ffidMetadataRepository = new FFIDMetadataRepository(db)
+    val ffidMetadataMatchesRepository = new FFIDMetadataMatchesRepository(db)
     val consignmentStatusRepository = new ConsignmentStatusRepository(db)
     val consignmentService = new ConsignmentService(consignmentRepository, fileMetadataRepository, fileRepository,
       ffidMetadataRepository, timeSource, uuidSource)
@@ -82,7 +83,7 @@ object GraphQLServer {
     val transferAgreementService = new TransferAgreementService(new ConsignmentMetadataRepository(db), uuidSource, timeSource)
     val finalTransferConfirmationService = new FinalTransferConfirmationService(new ConsignmentMetadataRepository(db), uuidSource, timeSource)
     val clientFileMetadataService = new ClientFileMetadataService(fileMetadataRepository, uuidSource, timeSource)
-    val fileService = new FileService(fileRepository, consignmentRepository, fileMetadataRepository, ffidMetadataRepository,
+    val fileService = new FileService(fileRepository, consignmentRepository, fileMetadataRepository, ffidMetadataRepository, ffidMetadataMatchesRepository,
       new CurrentTimeSource, uuidSource)
     val transferringBodyService = new TransferringBodyService(new TransferringBodyRepository(db))
     val antivirusMetadataService = new AntivirusMetadataService(new AntivirusMetadataRepository(db))

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/http/GraphQLServer.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/http/GraphQLServer.scala
@@ -83,12 +83,11 @@ object GraphQLServer {
     val transferAgreementService = new TransferAgreementService(new ConsignmentMetadataRepository(db), uuidSource, timeSource)
     val finalTransferConfirmationService = new FinalTransferConfirmationService(new ConsignmentMetadataRepository(db), uuidSource, timeSource)
     val clientFileMetadataService = new ClientFileMetadataService(fileMetadataRepository, uuidSource, timeSource)
-    val fileService = new FileService(fileRepository, consignmentRepository, fileMetadataRepository, ffidMetadataRepository, ffidMetadataMatchesRepository,
-      new CurrentTimeSource, uuidSource)
-    val transferringBodyService = new TransferringBodyService(new TransferringBodyRepository(db))
-    val antivirusMetadataService = new AntivirusMetadataService(new AntivirusMetadataRepository(db))
     val fileMetadataService = new FileMetadataService(fileMetadataRepository, timeSource, uuidSource)
     val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepository, new FFIDMetadataMatchesRepository(db), timeSource, uuidSource)
+    val fileService = new FileService(fileRepository, consignmentRepository, fileMetadataService, ffidMetadataService, new CurrentTimeSource, uuidSource)
+    val transferringBodyService = new TransferringBodyService(new TransferringBodyRepository(db))
+    val antivirusMetadataService = new AntivirusMetadataService(new AntivirusMetadataRepository(db))
     val consignmentStatusService = new ConsignmentStatusService(consignmentStatusRepository)
 
     ConsignmentApiContext(

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FFIDMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FFIDMetadataService.scala
@@ -1,5 +1,6 @@
 package uk.gov.nationalarchives.tdr.api.service
 
+import uk.gov.nationalarchives
 import uk.gov.nationalarchives.Tables
 
 import java.sql.{SQLException, Timestamp}
@@ -32,18 +33,34 @@ class FFIDMetadataService(ffidMetadataRepository: FFIDMetadataRepository, matche
       ffidMetadataRow <- ffidMetadataRepository.addFFIDMetadata(metadataRows)
       ffidMetadataMatchesRow <- addFFIDMetadataMatches(ffidMetadataRow.ffidmetadataid)
     } yield {
-      FFIDMetadata(
-        ffidMetadataRow.fileid,
-        ffidMetadataRow.software,
-        ffidMetadataRow.softwareversion,
-        ffidMetadataRow.binarysignaturefileversion,
-        ffidMetadataRow.containersignaturefileversion,
-        ffidMetadataRow.method,
-        ffidMetadataMatchesRow.map(r => FFIDMetadataMatches(r.extension, r.identificationbasis, r.puid)).toList,
-        ffidMetadataRow.datetime.getTime
-      )
+      rowToFFIDMetadata(ffidMetadataRow, ffidMetadataMatchesRow)
     }).recover {
       case e: SQLException => throw InputDataException(e.getLocalizedMessage)
     }
+  }
+
+  def getFFIDMetadata(consignmentId: UUID): Future[List[FFIDMetadata]] = {
+    ffidMetadataRepository.getFFIDMetadata(consignmentId).map {
+      ffidMetadataAndMatchesRows =>
+        val ffidMetadataAndMatches: Map[FfidmetadataRow, Seq[FfidmetadatamatchesRow]] = {
+          ffidMetadataAndMatchesRows.groupBy(_._1).view.mapValues(_.map(_._2)).toMap
+        }
+        ffidMetadataAndMatches.map {
+          case (metadata, matches) => rowToFFIDMetadata(metadata, matches)
+        }.toList
+    }
+  }
+
+  private def rowToFFIDMetadata(ffidMetadataRow: nationalarchives.Tables.FfidmetadataRow, ffidMetadataMatchesRow: Seq[FfidmetadatamatchesRow]) = {
+    FFIDMetadata(
+      ffidMetadataRow.fileid,
+      ffidMetadataRow.software,
+      ffidMetadataRow.softwareversion,
+      ffidMetadataRow.binarysignaturefileversion,
+      ffidMetadataRow.containersignaturefileversion,
+      ffidMetadataRow.method,
+      ffidMetadataMatchesRow.map(r => FFIDMetadataMatches(r.extension, r.identificationbasis, r.puid)).toList,
+      ffidMetadataRow.datetime.getTime
+    )
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FFIDMetadataServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FFIDMetadataServiceSpec.scala
@@ -1,15 +1,17 @@
 package uk.gov.nationalarchives.tdr.api.service
 
+import org.mockito.ArgumentMatchers.any
+
 import java.sql.Timestamp
 import java.util.UUID
-
 import org.mockito.{ArgumentCaptor, MockitoSugar}
+import org.scalatest.Assertion
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import uk.gov.nationalarchives.Tables.{FfidmetadataRow, FfidmetadatamatchesRow}
 import uk.gov.nationalarchives.tdr.api.db.repository.{FFIDMetadataMatchesRepository, FFIDMetadataRepository}
-import uk.gov.nationalarchives.tdr.api.graphql.fields.FFIDMetadataFields.{FFIDMetadataInput, FFIDMetadataInputMatches}
+import uk.gov.nationalarchives.tdr.api.graphql.fields.FFIDMetadataFields.{FFIDMetadata, FFIDMetadataInput, FFIDMetadataInputMatches, FFIDMetadataMatches}
 import uk.gov.nationalarchives.tdr.api.utils.{FixedTimeSource, FixedUUIDSource}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -79,6 +81,82 @@ class FFIDMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     matches.extension.get shouldEqual "ext"
     matches.identificationBasis shouldEqual "identificationBasis"
     matches.puid.get shouldEqual "puid"
+  }
+
+  "getFFIDMetadata" should "call the repository with the correct arguments" in {
+    val ffidMetadataRepositoryMock = mock[FFIDMetadataRepository]
+    val consignmentIdCaptor: ArgumentCaptor[UUID] = ArgumentCaptor.forClass(classOf[UUID])
+    val consignmentId = UUID.randomUUID()
+
+    when(ffidMetadataRepositoryMock.getFFIDMetadata(consignmentIdCaptor.capture())).thenReturn(Future(Seq()))
+
+    val service = new FFIDMetadataService(ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, new FixedUUIDSource())
+    service.getFFIDMetadata(consignmentId)
+
+    consignmentIdCaptor.getValue should equal(consignmentId)
+  }
+
+  "getFFIDMetadata" should "return the correct values" in {
+    val ffidMetadataRepositoryMock = mock[FFIDMetadataRepository]
+    val consignmentId = UUID.randomUUID()
+    val fileIdOne = UUID.randomUUID()
+    val fileIdTwo = UUID.randomUUID()
+    val metadataRowOne = FfidmetadataRow(
+      UUID.randomUUID(),
+      fileIdOne,
+      "softwareRow1",
+      "softwareVersionRow1",
+      Timestamp.from(FixedTimeSource.now),
+      "binarySignatureFileVersionRow1",
+      "containerSignatureFileVersionRow1",
+      "methodRow1"
+    )
+    val matchesRowOneMatchOne = FfidmetadatamatchesRow(UUID.randomUUID(), Option("extensionRow1Match1"), "basisRow1Match1", Option("puidRow1Match1"))
+    val matchesRowOneMatchTwo = FfidmetadatamatchesRow(UUID.randomUUID(), Option("extensionRow1Match2"), "basisRow1Match2", Option("puidRow1Match2"))
+
+    val metadataRowTwo = FfidmetadataRow(
+      UUID.randomUUID(),
+      fileIdTwo,
+      "softwareRow2",
+      "softwareVersionRow2",
+      Timestamp.from(FixedTimeSource.now),
+      "binarySignatureFileVersionRow2",
+      "containerSignatureFileVersionRow2",
+      "methodRow2"
+    )
+    val matchesRowTwoMatchOne = FfidmetadatamatchesRow(UUID.randomUUID(), Option("extensionRow2Match1"), "basisRow2Match1", Option("puidRow2Match1"))
+
+    when(ffidMetadataRepositoryMock.getFFIDMetadata(any[UUID])).thenReturn(
+      Future(Seq(
+        (metadataRowOne,matchesRowOneMatchOne ), (metadataRowOne, matchesRowOneMatchTwo), (metadataRowTwo, matchesRowTwoMatchOne)
+      ))
+    )
+
+    val service = new FFIDMetadataService(ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, new FixedUUIDSource())
+    val response = service.getFFIDMetadata(consignmentId).futureValue
+
+    val ffidMetadataRowOne = response.find(_.fileId == fileIdOne).get
+    val ffidMetadataRowTwo = response.find(_.fileId == fileIdTwo).get
+    checkMetadataRow(ffidMetadataRowOne, 1)
+    checkMetadataRow(ffidMetadataRowTwo, 2)
+
+    checkMatch(ffidMetadataRowOne.matches.head, 1, 1)
+    checkMatch(ffidMetadataRowOne.matches.last, 1, 2)
+    checkMatch(ffidMetadataRowTwo.matches.head, 2, 1)
+  }
+
+  def checkMetadataRow(ffidMetadata: FFIDMetadata, rowNumber: Int): Assertion = {
+    ffidMetadata.binarySignatureFileVersion should equal(s"binarySignatureFileVersionRow$rowNumber")
+    ffidMetadata.containerSignatureFileVersion should equal(s"containerSignatureFileVersionRow$rowNumber")
+    ffidMetadata.method should equal(s"methodRow$rowNumber")
+    ffidMetadata.software should equal(s"softwareRow$rowNumber")
+    ffidMetadata.softwareVersion should equal(s"softwareVersionRow$rowNumber")
+  }
+
+  def checkMatch(ffidMetadataMatch: FFIDMetadataMatches, rowNumber: Int, matchNumber: Int): Assertion = {
+    ffidMetadataMatch.extension.get should equal(s"extensionRow${rowNumber}Match$matchNumber")
+    ffidMetadataMatch.identificationBasis should equal(s"basisRow${rowNumber}Match$matchNumber")
+    ffidMetadataMatch.puid.get should equal(s"puidRow${rowNumber}Match$matchNumber")
   }
 
   private def getMetadataInput(fixedFileUuid: UUID) = {

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FFIDMetadataServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FFIDMetadataServiceSpec.scala
@@ -96,7 +96,7 @@ class FFIDMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     consignmentIdCaptor.getValue should equal(consignmentId)
   }
 
-  "getFFIDMetadata" should "return the correct values" in {
+  "getFFIDMetadata" should "return multiple rows and matches for multiple files" in {
     val ffidMetadataRepositoryMock = mock[FFIDMetadataRepository]
     val consignmentId = UUID.randomUUID()
     val fileIdOne = UUID.randomUUID()

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataServiceSpec.scala
@@ -154,7 +154,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     consignmentIdCaptor.getValue should equal(consignmentId)
   }
 
-  "getFileMetadata" should "return the correct values for multiple files" in {
+  "getFileMetadata" should "return mutiple map entries for multiple files" in {
     val fileMetadataRepositoryMock = mock[FileMetadataRepository]
     val consignmentId = UUID.randomUUID()
     val fileIdOne = UUID.randomUUID()

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
@@ -39,9 +39,9 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     when(consignmentRepositoryMock.addParentFolder(consignmentId, "Parent folder name")).thenReturn(mockConsignmentResponse)
     val mockFileMetadataResponse = Future.successful(Seq(FilemetadataRow(UUID.randomUUID(), fileId, "value", Timestamp.from(Instant.now), uuid, "name")))
     when(fileMetadataRepositoryMock.addFileMetadata(any[Seq[FilemetadataRow]])).thenReturn(mockFileMetadataResponse)
-
-    val fileService = new FileService(fileRepositoryMock, consignmentRepositoryMock, fileMetadataRepositoryMock,
-      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
+    val fileMetadataService = new FileMetadataService(fileMetadataRepositoryMock, FixedTimeSource, fixedUuidSource)
+    val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
+    val fileService = new FileService(fileRepositoryMock, consignmentRepositoryMock, fileMetadataService, ffidMetadataService, FixedTimeSource, fixedUuidSource)
     val result: Files = fileService.addFile(AddFilesInput(consignmentId, 1, "Parent folder name"), uuid).futureValue
 
     result.fileIds shouldBe List(fileId)
@@ -69,9 +69,10 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
       Seq(FilemetadataRow(UUID.randomUUID(), fileUuidOne, "value", Timestamp.from(Instant.now), userUuid, "name"))
     )
     when(fileMetadataRepositoryMock.addFileMetadata(any[Seq[FilemetadataRow]])).thenReturn(mockFileMetadataResponse)
+    val fileMetadataService = new FileMetadataService(fileMetadataRepositoryMock, FixedTimeSource, fixedUuidSource)
+    val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
 
-    val fileService = new FileService(fileRepositoryMock, consignmentRepositoryMock, fileMetadataRepositoryMock,
-      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
+    val fileService = new FileService(fileRepositoryMock, consignmentRepositoryMock, fileMetadataService, ffidMetadataService, FixedTimeSource, fixedUuidSource)
     val result: Files = fileService.addFile(AddFilesInput(consignmentUuid, 3, "Parent folder name"), userUuid).futureValue
 
     captor.getAllValues.size should equal(1)
@@ -90,8 +91,10 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val fileRepositoryMock = mock[FileRepository]
     val consignmentRepositoryMock = mock[ConsignmentRepository]
     val fileMetadataRepositoryMock = mock[FileMetadataRepository]
-    val fileService = new FileService(fileRepositoryMock, consignmentRepositoryMock, fileMetadataRepositoryMock,
-      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
+    val fileMetadataService = new FileMetadataService(fileMetadataRepositoryMock, FixedTimeSource, fixedUuidSource)
+    val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
+
+    val fileService = new FileService(fileRepositoryMock, consignmentRepositoryMock,fileMetadataService, ffidMetadataService, FixedTimeSource, fixedUuidSource)
     fixedUuidSource.reset
     val timeNow = Timestamp.from(FixedTimeSource.now)
 
@@ -135,8 +138,12 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val captor: ArgumentCaptor[Seq[FilemetadataRow]] = ArgumentCaptor.forClass(classOf[Seq[FilemetadataRow]])
     when(fileMetadataRepositoryMock.addFileMetadata(captor.capture())).thenReturn(mockFileMetadataResponse)
 
-    val fileService = new FileService(fileRepositoryMock, consignmentRepositoryMock, fileMetadataRepositoryMock,
-      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUUIDSource)
+    val fileMetadataService = new FileMetadataService(fileMetadataRepositoryMock, FixedTimeSource, fixedUUIDSource)
+    val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUUIDSource)
+
+    val fileService = new FileService(
+      fileRepositoryMock, consignmentRepositoryMock, fileMetadataService, ffidMetadataService, FixedTimeSource, fixedUUIDSource
+    )
     fileService.addFile(AddFilesInput(consignmentId, 1, "Parent folder name"), uuid).futureValue
 
     val metadataRows: Seq[Tables.FilemetadataRow] = captor.getValue
@@ -185,8 +192,12 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
       consignmentreference = "TEST-TDR-2021-3B"
     )
 
-    val fileService = new FileService(fileRepositoryMock, consignmentRepositoryMock, fileMetadataRepositoryMock,
-      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
+    val fileMetadataService = new FileMetadataService(fileMetadataRepositoryMock, FixedTimeSource, fixedUuidSource)
+    val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
+
+    val fileService = new FileService(
+      fileRepositoryMock, consignmentRepositoryMock, fileMetadataService, ffidMetadataService, FixedTimeSource, fixedUuidSource
+    )
 
     when(consignmentRepositoryMock.getConsignmentsOfFiles(Seq(fileId1)))
       .thenReturn(Future.successful(Seq((fileId1, consignment1), (fileId2, consignment2))))
@@ -217,8 +228,12 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val mockFileMetadataResponse = Future.successful(Seq(FilemetadataRow(UUID.randomUUID(), fileIdOne, "value", Timestamp.from(Instant.now), uuid, "name")))
     when(fileMetadataRepositoryMock.addFileMetadata(any[Seq[FilemetadataRow]])).thenReturn(mockFileMetadataResponse)
 
-    val fileService = new FileService(fileRepositoryMock, consignmentRepositoryMock, fileMetadataRepositoryMock,
-      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
+    val fileMetadataService = new FileMetadataService(fileMetadataRepositoryMock, FixedTimeSource, fixedUuidSource)
+    val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
+
+    val fileService = new FileService(
+      fileRepositoryMock, consignmentRepositoryMock, fileMetadataService, ffidMetadataService, FixedTimeSource, fixedUuidSource
+    )
     val result: Files = fileService.getFiles(consignmentId).futureValue
 
     result.fileIds shouldBe List(fileIdOne, fileIdTwo)
@@ -254,8 +269,12 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     )
     when(fileMetadataRepositoryMock.getFileMetadata(consignmentId)).thenReturn(Future(fileMetadataRows))
 
-    val service = new FileService(fileRepositoryMock, consignmentRepositoryMock, fileMetadataRepositoryMock,
-      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
+    val fileMetadataService = new FileMetadataService(fileMetadataRepositoryMock, FixedTimeSource, fixedUuidSource)
+    val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
+
+    val service = new FileService(
+      fileRepositoryMock, consignmentRepositoryMock, fileMetadataService, ffidMetadataService, FixedTimeSource, fixedUuidSource
+    )
     val metadataList: Seq[File] = service.getFileMetadata(consignmentId).futureValue
 
     metadataList.length should equal(1)
@@ -307,8 +326,11 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     )
     when(fileMetadataRepositoryMock.getFileMetadata(consignmentId)).thenReturn(Future(fileMetadataRows))
 
-    val service = new FileService(fileRepositoryMock, consignmentRepositoryMock, fileMetadataRepositoryMock,
-      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
+    val fileMetadataService = new FileMetadataService(fileMetadataRepositoryMock, FixedTimeSource, fixedUuidSource)
+    val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
+
+    val service = new FileService(
+      fileRepositoryMock, consignmentRepositoryMock, fileMetadataService, ffidMetadataService, FixedTimeSource, fixedUuidSource)
     val fileMetadataList = service.getFileMetadata(consignmentId).futureValue
 
     fileMetadataList.length should equal(1)

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
@@ -8,7 +8,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import uk.gov.nationalarchives.Tables
 import uk.gov.nationalarchives.Tables.{ConsignmentRow, ConsignmentstatusRow, FfidmetadataRow, FfidmetadatamatchesRow, FileRow, FilemetadataRow}
-import uk.gov.nationalarchives.tdr.api.db.repository.{ConsignmentRepository, FFIDMetadataRepository, FileMetadataRepository, FileRepository}
+import uk.gov.nationalarchives.tdr.api.db.repository._
 import uk.gov.nationalarchives.tdr.api.graphql.fields.FFIDMetadataFields.{FFIDMetadata, FFIDMetadataMatches}
 import uk.gov.nationalarchives.tdr.api.graphql.fields.FileFields.{AddFilesInput, Files}
 import uk.gov.nationalarchives.tdr.api.service.FileMetadataService.{File, FileMetadataValues, staticMetadataProperties}
@@ -41,7 +41,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     when(fileMetadataRepositoryMock.addFileMetadata(any[Seq[FilemetadataRow]])).thenReturn(mockFileMetadataResponse)
 
     val fileService = new FileService(fileRepositoryMock, consignmentRepositoryMock, fileMetadataRepositoryMock,
-      ffidMetadataRepositoryMock, FixedTimeSource, fixedUuidSource)
+      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
     val result: Files = fileService.addFile(AddFilesInput(consignmentId, 1, "Parent folder name"), uuid).futureValue
 
     result.fileIds shouldBe List(fileId)
@@ -71,7 +71,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     when(fileMetadataRepositoryMock.addFileMetadata(any[Seq[FilemetadataRow]])).thenReturn(mockFileMetadataResponse)
 
     val fileService = new FileService(fileRepositoryMock, consignmentRepositoryMock, fileMetadataRepositoryMock,
-      ffidMetadataRepositoryMock, FixedTimeSource, fixedUuidSource)
+      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
     val result: Files = fileService.addFile(AddFilesInput(consignmentUuid, 3, "Parent folder name"), userUuid).futureValue
 
     captor.getAllValues.size should equal(1)
@@ -91,7 +91,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val consignmentRepositoryMock = mock[ConsignmentRepository]
     val fileMetadataRepositoryMock = mock[FileMetadataRepository]
     val fileService = new FileService(fileRepositoryMock, consignmentRepositoryMock, fileMetadataRepositoryMock,
-      ffidMetadataRepositoryMock, FixedTimeSource, fixedUuidSource)
+      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
     fixedUuidSource.reset
     val timeNow = Timestamp.from(FixedTimeSource.now)
 
@@ -136,7 +136,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     when(fileMetadataRepositoryMock.addFileMetadata(captor.capture())).thenReturn(mockFileMetadataResponse)
 
     val fileService = new FileService(fileRepositoryMock, consignmentRepositoryMock, fileMetadataRepositoryMock,
-      ffidMetadataRepositoryMock, FixedTimeSource, fixedUUIDSource)
+      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUUIDSource)
     fileService.addFile(AddFilesInput(consignmentId, 1, "Parent folder name"), uuid).futureValue
 
     val metadataRows: Seq[Tables.FilemetadataRow] = captor.getValue
@@ -186,7 +186,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     )
 
     val fileService = new FileService(fileRepositoryMock, consignmentRepositoryMock, fileMetadataRepositoryMock,
-      ffidMetadataRepositoryMock, FixedTimeSource, fixedUuidSource)
+      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
 
     when(consignmentRepositoryMock.getConsignmentsOfFiles(Seq(fileId1)))
       .thenReturn(Future.successful(Seq((fileId1, consignment1), (fileId2, consignment2))))
@@ -218,7 +218,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     when(fileMetadataRepositoryMock.addFileMetadata(any[Seq[FilemetadataRow]])).thenReturn(mockFileMetadataResponse)
 
     val fileService = new FileService(fileRepositoryMock, consignmentRepositoryMock, fileMetadataRepositoryMock,
-      ffidMetadataRepositoryMock, FixedTimeSource, fixedUuidSource)
+      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
     val result: Files = fileService.getFiles(consignmentId).futureValue
 
     result.fileIds shouldBe List(fileIdOne, fileIdTwo)
@@ -255,7 +255,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     when(fileMetadataRepositoryMock.getFileMetadata(consignmentId)).thenReturn(Future(fileMetadataRows))
 
     val service = new FileService(fileRepositoryMock, consignmentRepositoryMock, fileMetadataRepositoryMock,
-      ffidMetadataRepositoryMock, FixedTimeSource, fixedUuidSource)
+      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
     val metadataList: Seq[File] = service.getFileMetadata(consignmentId).futureValue
 
     metadataList.length should equal(1)
@@ -308,7 +308,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     when(fileMetadataRepositoryMock.getFileMetadata(consignmentId)).thenReturn(Future(fileMetadataRows))
 
     val service = new FileService(fileRepositoryMock, consignmentRepositoryMock, fileMetadataRepositoryMock,
-      ffidMetadataRepositoryMock, FixedTimeSource, fixedUuidSource)
+      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
     val fileMetadataList = service.getFileMetadata(consignmentId).futureValue
 
     fileMetadataList.length should equal(1)


### PR DESCRIPTION
The getFileMetadata method was getting complicated because all the logic for getting the FFID and client side metadata was in a single method. If we were to add the antivirus to this then it would be too messy. I've refactored this so the client metadata and the FFID metadata comes from different methods.
