### PR TITLE
Add antivirus metadata

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/AntivirusMetadataRepository.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/AntivirusMetadataRepository.scala
@@ -1,8 +1,9 @@
 package uk.gov.nationalarchives.tdr.api.db.repository
 
 import slick.jdbc.PostgresProfile.api._
-import uk.gov.nationalarchives.Tables.{AvmetadataRow, Avmetadata}
+import uk.gov.nationalarchives.Tables.{Avmetadata, AvmetadataRow, File}
 
+import java.util.UUID
 import scala.concurrent.Future
 
 class AntivirusMetadataRepository(db: Database) {
@@ -11,5 +12,13 @@ class AntivirusMetadataRepository(db: Database) {
 
   def addAntivirusMetadata(antivirusMetadataRow: AvmetadataRow): Future[AvmetadataRow] = {
     db.run(insertQuery += antivirusMetadataRow)
+  }
+
+  def getAntivirusMetadata(consignmentId: UUID): Future[Seq[AvmetadataRow]] = {
+    val query = Avmetadata.join(File)
+      .on(_.fileid === _.fileid)
+      .filter(_._2.consignmentid === consignmentId)
+      .map(_._1)
+    db.run(query.result)
   }
 }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/http/GraphQLServer.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/http/GraphQLServer.scala
@@ -77,6 +77,7 @@ object GraphQLServer {
     val ffidMetadataRepository = new FFIDMetadataRepository(db)
     val ffidMetadataMatchesRepository = new FFIDMetadataMatchesRepository(db)
     val consignmentStatusRepository = new ConsignmentStatusRepository(db)
+    val antivirusMetadataRepository = new AntivirusMetadataRepository(db)
     val consignmentService = new ConsignmentService(consignmentRepository, fileMetadataRepository, fileRepository,
       ffidMetadataRepository, timeSource, uuidSource)
     val seriesService = new SeriesService(new SeriesRepository(db), uuidSource)
@@ -84,9 +85,9 @@ object GraphQLServer {
     val finalTransferConfirmationService = new FinalTransferConfirmationService(new ConsignmentMetadataRepository(db), uuidSource, timeSource)
     val clientFileMetadataService = new ClientFileMetadataService(fileMetadataRepository, uuidSource, timeSource)
     val fileService = new FileService(fileRepository, consignmentRepository, fileMetadataRepository, ffidMetadataRepository, ffidMetadataMatchesRepository,
-      new CurrentTimeSource, uuidSource)
+      antivirusMetadataRepository, new CurrentTimeSource, uuidSource)
     val transferringBodyService = new TransferringBodyService(new TransferringBodyRepository(db))
-    val antivirusMetadataService = new AntivirusMetadataService(new AntivirusMetadataRepository(db))
+    val antivirusMetadataService = new AntivirusMetadataService(antivirusMetadataRepository)
     val fileMetadataService = new FileMetadataService(fileMetadataRepository, timeSource, uuidSource)
     val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepository, new FFIDMetadataMatchesRepository(db), timeSource, uuidSource)
     val consignmentStatusService = new ConsignmentStatusService(consignmentStatusRepository)

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/http/GraphQLServer.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/http/GraphQLServer.scala
@@ -84,7 +84,6 @@ object GraphQLServer {
     val transferAgreementService = new TransferAgreementService(new ConsignmentMetadataRepository(db), uuidSource, timeSource)
     val finalTransferConfirmationService = new FinalTransferConfirmationService(new ConsignmentMetadataRepository(db), uuidSource, timeSource)
     val clientFileMetadataService = new ClientFileMetadataService(fileMetadataRepository, uuidSource, timeSource)
-
     val antivirusMetadataService = new AntivirusMetadataService(antivirusMetadataRepository)
     val fileMetadataService = new FileMetadataService(fileMetadataRepository, timeSource, uuidSource)
     val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepository, new FFIDMetadataMatchesRepository(db), timeSource, uuidSource)

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/AntivirusMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/AntivirusMetadataService.scala
@@ -2,11 +2,11 @@ package uk.gov.nationalarchives.tdr.api.service
 
 import java.sql.Timestamp
 import java.time.Instant
-
 import uk.gov.nationalarchives.Tables.AvmetadataRow
 import uk.gov.nationalarchives.tdr.api.db.repository.AntivirusMetadataRepository
 import uk.gov.nationalarchives.tdr.api.graphql.fields.AntivirusMetadataFields.{AddAntivirusMetadataInput, AntivirusMetadata}
 
+import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 
 class AntivirusMetadataService(antivirusMetadataRepository: AntivirusMetadataRepository)
@@ -22,15 +22,22 @@ class AntivirusMetadataService(antivirusMetadataRepository: AntivirusMetadataRep
       input.result,
       Timestamp.from(Instant.ofEpochMilli(input.datetime)))
 
-    antivirusMetadataRepository.addAntivirusMetadata(inputRow).map(row => {
-      AntivirusMetadata(
-        row.fileid,
-        row.software,
-        row.softwareversion,
-        row.databaseversion,
-        row.result,
-        row.datetime.getTime
-      )
-    })
+    antivirusMetadataRepository.addAntivirusMetadata(inputRow).map(rowToAntivirusMetadata)
+  }
+
+  private def rowToAntivirusMetadata(row: AvmetadataRow) = {
+    AntivirusMetadata(
+      row.fileid,
+      row.software,
+      row.softwareversion,
+      row.databaseversion,
+      row.result,
+      row.datetime.getTime
+    )
+  }
+
+  def getAntivirusMetadata(consignmentId: UUID): Future[List[AntivirusMetadata]] = {
+    antivirusMetadataRepository.getAntivirusMetadata(consignmentId)
+      .map(r => r.map(rowToAntivirusMetadata).toList)
   }
 }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/AntivirusMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/AntivirusMetadataService.scala
@@ -25,7 +25,7 @@ class AntivirusMetadataService(antivirusMetadataRepository: AntivirusMetadataRep
     antivirusMetadataRepository.addAntivirusMetadata(inputRow).map(rowToAntivirusMetadata)
   }
 
-  private def rowToAntivirusMetadata(row: AvmetadataRow) = {
+  private def rowToAntivirusMetadata(row: AvmetadataRow): AntivirusMetadata = {
     AntivirusMetadata(
       row.fileid,
       row.software,

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
@@ -6,6 +6,7 @@ import java.util.UUID
 import uk.gov.nationalarchives.Tables.FilemetadataRow
 import uk.gov.nationalarchives.tdr.api.db.repository.FileMetadataRepository
 import uk.gov.nationalarchives.tdr.api.graphql.DataExceptions.InputDataException
+import uk.gov.nationalarchives.tdr.api.graphql.fields.AntivirusMetadataFields.AntivirusMetadata
 import uk.gov.nationalarchives.tdr.api.graphql.fields.FFIDMetadataFields.FFIDMetadata
 import uk.gov.nationalarchives.tdr.api.graphql.fields.FileMetadataFields.{AddFileMetadataInput, FileMetadata, SHA256ServerSideChecksum}
 import uk.gov.nationalarchives.tdr.api.service.FileMetadataService._
@@ -81,7 +82,7 @@ object FileMetadataService {
   val clientSideProperties = List(SHA256ClientSideChecksum, ClientSideOriginalFilepath, ClientSideFileLastModifiedDate, ClientSideFileSize)
   val staticMetadataProperties = List(RightsCopyright, LegalStatus, HeldBy, Language, FoiExemptionCode)
 
-  case class File(fileId: UUID, metadata: FileMetadataValues, ffidMetadata: Option[FFIDMetadata])
+  case class File(fileId: UUID, metadata: FileMetadataValues, ffidMetadata: Option[FFIDMetadata], antivirusMetadata: Option[AntivirusMetadata])
 
   case class FileMetadataValues(sha256ClientSideChecksum: Option[String],
                                 clientSideOriginalFilePath: Option[String],

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
@@ -1,9 +1,5 @@
 package uk.gov.nationalarchives.tdr.api.service
 
-import uk.gov
-import uk.gov.nationalarchives
-import uk.gov.nationalarchives.Tables
-
 import java.sql.Timestamp
 import java.time.LocalDateTime
 import java.util.UUID

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileService.scala
@@ -15,6 +15,7 @@ class FileService(
                    fileMetadataRepository: FileMetadataRepository,
                    ffidMetadataRepository: FFIDMetadataRepository,
                    ffidMetadataMatchesRepository: FFIDMetadataMatchesRepository,
+                   antivirusMetadataRepository: AntivirusMetadataRepository,
                    timeSource: TimeSource,
                    uuidSource: UUIDSource
                  )(implicit val executionContext: ExecutionContext) {
@@ -55,13 +56,15 @@ class FileService(
   def getFileMetadata(consignmentId: UUID): Future[List[File]] = {
     val fileMetadataService = new FileMetadataService(fileMetadataRepository, timeSource, uuidSource)
     val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepository, ffidMetadataMatchesRepository, timeSource, uuidSource)
+    val avMetadataService = new AntivirusMetadataService(antivirusMetadataRepository)
     for {
       fileMetadataList <- fileMetadataService.getFileMetadata(consignmentId)
       ffidMetadataList <- ffidMetadataService.getFFIDMetadata(consignmentId)
+      avList <- avMetadataService.getAntivirusMetadata(consignmentId)
     } yield {
       fileMetadataList map {
         case (fileId, fileMetadata) =>
-          File(fileId, fileMetadata, ffidMetadataList.find(_.fileId == fileId))
+          File(fileId, fileMetadata, ffidMetadataList.find(_.fileId == fileId), avList.find(_.fileId == fileId))
       }
     }.toList
   }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileService.scala
@@ -1,6 +1,6 @@
 package uk.gov.nationalarchives.tdr.api.service
 
-import uk.gov.nationalarchives.Tables.{ConsignmentstatusRow, FileRow, FilemetadataRow}
+import uk.gov.nationalarchives.Tables.{ConsignmentstatusRow, FileRow}
 import uk.gov.nationalarchives.tdr.api.db.repository._
 import uk.gov.nationalarchives.tdr.api.graphql.fields.FileFields.{AddFilesInput, Files}
 import uk.gov.nationalarchives.tdr.api.service.FileMetadataService._

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/AntivirusMetadataServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/AntivirusMetadataServiceSpec.scala
@@ -3,15 +3,15 @@ package uk.gov.nationalarchives.tdr.api.service
 import java.sql.Timestamp
 import java.time.Instant
 import java.util.UUID
-
 import org.mockito.ArgumentMatchers._
-import org.mockito.MockitoSugar
+import org.mockito.{ArgumentCaptor, MockitoSugar}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import uk.gov.nationalarchives.Tables.AvmetadataRow
 import uk.gov.nationalarchives.tdr.api.db.repository.AntivirusMetadataRepository
 import uk.gov.nationalarchives.tdr.api.graphql.fields.AntivirusMetadataFields.AddAntivirusMetadataInput
+import uk.gov.nationalarchives.tdr.api.utils.FixedTimeSource
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -50,5 +50,39 @@ class AntivirusMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Ma
     result.databaseVersion shouldBe "database version"
     result.result shouldBe "result"
     result.datetime shouldBe dummyInstant.toEpochMilli
+  }
+
+  "getAntivirusMetadata" should "call the repository with the correct arguments" in {
+    val avRepositoryMock = mock[AntivirusMetadataRepository]
+    val consignmentCaptor: ArgumentCaptor[UUID] = ArgumentCaptor.forClass(classOf[UUID])
+    val consignmentId = UUID.randomUUID()
+    when(avRepositoryMock.getAntivirusMetadata(consignmentCaptor.capture())).thenReturn(Future(Seq()))
+    new AntivirusMetadataService(avRepositoryMock).getAntivirusMetadata(consignmentId).futureValue
+    consignmentCaptor.getValue should equal(consignmentId)
+  }
+
+  "getAntivirusMetadata" should "return the correct data" in {
+    val fixedFileUuid = UUID.fromString("07a3a4bd-0281-4a6d-a4c1-8fa3239e1313")
+    val dummyTimestamp = Timestamp.from(FixedTimeSource.now)
+    val consignmentId = UUID.randomUUID()
+    val avRepositoryMock = mock[AntivirusMetadataRepository]
+    val mockResponse = Future.successful(Seq(AvmetadataRow(
+      fixedFileUuid,
+      "software",
+      "software version",
+      "database version",
+      "result",
+      dummyTimestamp
+    )))
+
+    when(avRepositoryMock.getAntivirusMetadata(any[UUID])).thenReturn(mockResponse)
+    val response = new AntivirusMetadataService(avRepositoryMock).getAntivirusMetadata(consignmentId).futureValue
+    val antivirus = response.head
+    antivirus.fileId should equal(fixedFileUuid)
+    antivirus.databaseVersion should equal("database version")
+    antivirus.result should equal("result")
+    antivirus.software should equal("software")
+    antivirus.softwareVersion should equal("software version")
+    antivirus.datetime should equal(dummyTimestamp.getTime)
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/AntivirusMetadataServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/AntivirusMetadataServiceSpec.scala
@@ -75,7 +75,7 @@ class AntivirusMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Ma
       dummyTimestamp
     )))
 
-    when(avRepositoryMock.getAntivirusMetadata(any[UUID])).thenReturn(mockResponse)
+    when(avRepositoryMock.getAntivirusMetadata(consignmentId)).thenReturn(mockResponse)
     val response = new AntivirusMetadataService(avRepositoryMock).getAntivirusMetadata(consignmentId).futureValue
     val antivirus = response.head
     antivirus.fileId should equal(fixedFileUuid)

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
@@ -7,8 +7,9 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import uk.gov.nationalarchives.Tables
-import uk.gov.nationalarchives.Tables.{ConsignmentRow, ConsignmentstatusRow, FfidmetadataRow, FfidmetadatamatchesRow, FileRow, FilemetadataRow}
+import uk.gov.nationalarchives.Tables.{AvmetadataRow, ConsignmentRow, ConsignmentstatusRow, FfidmetadataRow, FfidmetadatamatchesRow, FileRow, FilemetadataRow}
 import uk.gov.nationalarchives.tdr.api.db.repository._
+import uk.gov.nationalarchives.tdr.api.graphql.fields.AntivirusMetadataFields.AntivirusMetadata
 import uk.gov.nationalarchives.tdr.api.graphql.fields.FFIDMetadataFields.{FFIDMetadata, FFIDMetadataMatches}
 import uk.gov.nationalarchives.tdr.api.graphql.fields.FileFields.{AddFilesInput, Files}
 import uk.gov.nationalarchives.tdr.api.service.FileMetadataService.{File, FileMetadataValues, staticMetadataProperties}
@@ -41,7 +42,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     when(fileMetadataRepositoryMock.addFileMetadata(any[Seq[FilemetadataRow]])).thenReturn(mockFileMetadataResponse)
 
     val fileService = new FileService(fileRepositoryMock, consignmentRepositoryMock, fileMetadataRepositoryMock,
-      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
+      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], mock[AntivirusMetadataRepository], FixedTimeSource, fixedUuidSource)
     val result: Files = fileService.addFile(AddFilesInput(consignmentId, 1, "Parent folder name"), uuid).futureValue
 
     result.fileIds shouldBe List(fileId)
@@ -71,7 +72,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     when(fileMetadataRepositoryMock.addFileMetadata(any[Seq[FilemetadataRow]])).thenReturn(mockFileMetadataResponse)
 
     val fileService = new FileService(fileRepositoryMock, consignmentRepositoryMock, fileMetadataRepositoryMock,
-      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
+      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], mock[AntivirusMetadataRepository], FixedTimeSource, fixedUuidSource)
     val result: Files = fileService.addFile(AddFilesInput(consignmentUuid, 3, "Parent folder name"), userUuid).futureValue
 
     captor.getAllValues.size should equal(1)
@@ -91,7 +92,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val consignmentRepositoryMock = mock[ConsignmentRepository]
     val fileMetadataRepositoryMock = mock[FileMetadataRepository]
     val fileService = new FileService(fileRepositoryMock, consignmentRepositoryMock, fileMetadataRepositoryMock,
-      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
+      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], mock[AntivirusMetadataRepository], FixedTimeSource, fixedUuidSource)
     fixedUuidSource.reset
     val timeNow = Timestamp.from(FixedTimeSource.now)
 
@@ -136,7 +137,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     when(fileMetadataRepositoryMock.addFileMetadata(captor.capture())).thenReturn(mockFileMetadataResponse)
 
     val fileService = new FileService(fileRepositoryMock, consignmentRepositoryMock, fileMetadataRepositoryMock,
-      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUUIDSource)
+      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], mock[AntivirusMetadataRepository], FixedTimeSource, fixedUUIDSource)
     fileService.addFile(AddFilesInput(consignmentId, 1, "Parent folder name"), uuid).futureValue
 
     val metadataRows: Seq[Tables.FilemetadataRow] = captor.getValue
@@ -186,7 +187,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     )
 
     val fileService = new FileService(fileRepositoryMock, consignmentRepositoryMock, fileMetadataRepositoryMock,
-      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
+      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], mock[AntivirusMetadataRepository], FixedTimeSource, fixedUuidSource)
 
     when(consignmentRepositoryMock.getConsignmentsOfFiles(Seq(fileId1)))
       .thenReturn(Future.successful(Seq((fileId1, consignment1), (fileId2, consignment2))))
@@ -218,7 +219,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     when(fileMetadataRepositoryMock.addFileMetadata(any[Seq[FilemetadataRow]])).thenReturn(mockFileMetadataResponse)
 
     val fileService = new FileService(fileRepositoryMock, consignmentRepositoryMock, fileMetadataRepositoryMock,
-      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
+      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], mock[AntivirusMetadataRepository], FixedTimeSource, fixedUuidSource)
     val result: Files = fileService.getFiles(consignmentId).futureValue
 
     result.fileIds shouldBe List(fileIdOne, fileIdTwo)
@@ -227,6 +228,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
   "getFileMetadata" should "return the correct metadata" in {
     val fileMetadataRepositoryMock = mock[FileMetadataRepository]
     val ffidMetadataRepositoryMock = mock[FFIDMetadataRepository]
+    val antivirusRepositoryMock = mock[AntivirusMetadataRepository]
     val fixedUuidSource = new FixedUUIDSource()
 
     val consignmentId = UUID.randomUUID()
@@ -252,10 +254,14 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
       fileMetadataRow(fileId, "Language", "language"),
       fileMetadataRow(fileId, "FoiExemptionCode", "foiExemption")
     )
+    val mockAvMetadataResponse = Future(
+      Seq(AvmetadataRow(fileId, "software", "softwareVersion", "databaseVersion", "result", timestamp))
+    )
     when(fileMetadataRepositoryMock.getFileMetadata(consignmentId)).thenReturn(Future(fileMetadataRows))
+    when(antivirusRepositoryMock.getAntivirusMetadata(consignmentId)).thenReturn(mockAvMetadataResponse)
 
     val service = new FileService(fileRepositoryMock, consignmentRepositoryMock, fileMetadataRepositoryMock,
-      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
+      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], antivirusRepositoryMock, FixedTimeSource, fixedUuidSource)
     val metadataList: Seq[File] = service.getFileMetadata(consignmentId).futureValue
 
     metadataList.length should equal(1)
@@ -280,7 +286,8 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
         "signature",
         "pronom",
         List(FFIDMetadataMatches(Some("txt"), "identification", Some("x-fmt/111"))),
-        datetime.getTime))
+        datetime.getTime)),
+      Option(AntivirusMetadata(fileId, "software", "softwareVersion", "databaseVersion", "result", timestamp.getTime))
     )
 
     actualFileMetadata should equal(expectedFileMetadata)
@@ -289,6 +296,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
   "getFileMetadata" should "return empty fields if the metadata has an unexpected property name" in {
     val fileMetadataRepositoryMock = mock[FileMetadataRepository]
     val ffidMetadataRepositoryMock = mock[FFIDMetadataRepository]
+    val antivirusRepositoryMock = mock[AntivirusMetadataRepository]
     val fixedUuidSource = new FixedUUIDSource()
 
     val consignmentId = UUID.randomUUID()
@@ -300,6 +308,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
       (ffidMetadataRow(ffidMetadataId, fileId, datetime), ffidMetadataMatchesRow(ffidMetadataId))
     )
     when(ffidMetadataRepositoryMock.getFFIDMetadata(consignmentId)).thenReturn(Future(ffidMetadataRows))
+    when(antivirusRepositoryMock.getAntivirusMetadata(consignmentId)).thenReturn(Future(List()))
 
     val fileMetadataRows = Seq(
       fileMetadataRow(fileId, "customPropertyNameOne", "customValueOne"),
@@ -308,7 +317,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     when(fileMetadataRepositoryMock.getFileMetadata(consignmentId)).thenReturn(Future(fileMetadataRows))
 
     val service = new FileService(fileRepositoryMock, consignmentRepositoryMock, fileMetadataRepositoryMock,
-      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
+      ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], antivirusRepositoryMock, FixedTimeSource, fixedUuidSource)
     val fileMetadataList = service.getFileMetadata(consignmentId).futureValue
 
     fileMetadataList.length should equal(1)
@@ -324,7 +333,8 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
         "signature",
         "pronom",
         List(FFIDMetadataMatches(Some("txt"), "identification", Some("x-fmt/111"))),
-        datetime.getTime))
+        datetime.getTime)),
+      Option.empty
     )
 
     actualFileMetadata should equal(expectedFileMetadata)

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
@@ -27,6 +27,8 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
   val fileMetadataRepositoryMock: FileMetadataRepository = mock[FileMetadataRepository]
   val fileRepositoryMock: FileRepository = mock[FileRepository]
   val ffidMetadataRepositoryMock: FFIDMetadataRepository = mock[FFIDMetadataRepository]
+  val antivirusMetadataRepositoryMock: AntivirusMetadataRepository = mock[AntivirusMetadataRepository]
+  def fileMetadataService(fixedUUIDSource: FixedUUIDSource = new FixedUUIDSource()) = new FileMetadataService(fileMetadataRepositoryMock, FixedTimeSource, new FixedUUIDSource())
 
   "createFile" should "create a file given correct arguments" in {
     val fixedUuidSource = new FixedUUIDSource()
@@ -41,12 +43,11 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val mockFileMetadataResponse = Future.successful(Seq(FilemetadataRow(UUID.randomUUID(), fileId, "value", Timestamp.from(Instant.now), uuid, "name")))
     when(fileMetadataRepositoryMock.addFileMetadata(any[Seq[FilemetadataRow]])).thenReturn(mockFileMetadataResponse)
 
-    val fileMetadataService = new FileMetadataService(fileMetadataRepositoryMock, FixedTimeSource, fixedUuidSource)
     val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
-    val antivirusMetadataService = new AntivirusMetadataService(mock[AntivirusMetadataRepository])
+    val antivirusMetadataService = new AntivirusMetadataService(antivirusMetadataRepositoryMock)
 
     val fileService = new FileService(
-      fileRepositoryMock, consignmentRepositoryMock, fileMetadataService, ffidMetadataService, antivirusMetadataService, FixedTimeSource, fixedUuidSource
+      fileRepositoryMock, consignmentRepositoryMock, fileMetadataService(), ffidMetadataService, antivirusMetadataService, FixedTimeSource, fixedUuidSource
     )
     val result: Files = fileService.addFile(AddFilesInput(consignmentId, 1, "Parent folder name"), uuid).futureValue
 
@@ -75,12 +76,11 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
       Seq(FilemetadataRow(UUID.randomUUID(), fileUuidOne, "value", Timestamp.from(Instant.now), userUuid, "name"))
     )
     when(fileMetadataRepositoryMock.addFileMetadata(any[Seq[FilemetadataRow]])).thenReturn(mockFileMetadataResponse)
-    val fileMetadataService = new FileMetadataService(fileMetadataRepositoryMock, FixedTimeSource, fixedUuidSource)
     val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
-    val antivirusMetadataService = new AntivirusMetadataService(mock[AntivirusMetadataRepository])
+    val antivirusMetadataService = new AntivirusMetadataService(antivirusMetadataRepositoryMock)
 
     val fileService = new FileService(
-      fileRepositoryMock, consignmentRepositoryMock, fileMetadataService, ffidMetadataService, antivirusMetadataService, FixedTimeSource, fixedUuidSource
+      fileRepositoryMock, consignmentRepositoryMock, fileMetadataService(), ffidMetadataService, antivirusMetadataService, FixedTimeSource, fixedUuidSource
     )
     val result: Files = fileService.addFile(AddFilesInput(consignmentUuid, 3, "Parent folder name"), userUuid).futureValue
 
@@ -101,12 +101,11 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val consignmentRepositoryMock = mock[ConsignmentRepository]
     val fileMetadataRepositoryMock = mock[FileMetadataRepository]
 
-    val fileMetadataService = new FileMetadataService(fileMetadataRepositoryMock, FixedTimeSource, fixedUuidSource)
     val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
-    val antivirusMetadataService = new AntivirusMetadataService(mock[AntivirusMetadataRepository])
+    val antivirusMetadataService = new AntivirusMetadataService(antivirusMetadataRepositoryMock)
 
     val fileService = new FileService(
-      fileRepositoryMock, consignmentRepositoryMock,fileMetadataService, ffidMetadataService, antivirusMetadataService, FixedTimeSource, fixedUuidSource
+      fileRepositoryMock, consignmentRepositoryMock,fileMetadataService(fixedUuidSource), ffidMetadataService, antivirusMetadataService, FixedTimeSource, fixedUuidSource
     )
 
     fixedUuidSource.reset
@@ -152,12 +151,11 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val captor: ArgumentCaptor[Seq[FilemetadataRow]] = ArgumentCaptor.forClass(classOf[Seq[FilemetadataRow]])
     when(fileMetadataRepositoryMock.addFileMetadata(captor.capture())).thenReturn(mockFileMetadataResponse)
 
-    val fileMetadataService = new FileMetadataService(fileMetadataRepositoryMock, FixedTimeSource, fixedUUIDSource)
     val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUUIDSource)
-    val antivirusMetadataService = new AntivirusMetadataService(mock[AntivirusMetadataRepository])
+    val antivirusMetadataService = new AntivirusMetadataService(antivirusMetadataRepositoryMock)
 
     val fileService = new FileService(
-      fileRepositoryMock, consignmentRepositoryMock, fileMetadataService, ffidMetadataService, antivirusMetadataService, FixedTimeSource, fixedUUIDSource
+      fileRepositoryMock, consignmentRepositoryMock, fileMetadataService(), ffidMetadataService, antivirusMetadataService, FixedTimeSource, fixedUUIDSource
     )
 
     fileService.addFile(AddFilesInput(consignmentId, 1, "Parent folder name"), uuid).futureValue
@@ -210,7 +208,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
 
     val fileMetadataService = new FileMetadataService(fileMetadataRepositoryMock, FixedTimeSource, fixedUuidSource)
     val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
-    val antivirusMetadataService = new AntivirusMetadataService(mock[AntivirusMetadataRepository])
+    val antivirusMetadataService = new AntivirusMetadataService(antivirusMetadataRepositoryMock)
 
     val fileService = new FileService(
       fileRepositoryMock, consignmentRepositoryMock, fileMetadataService, ffidMetadataService, antivirusMetadataService, FixedTimeSource, fixedUuidSource
@@ -248,7 +246,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
 
     val fileMetadataService = new FileMetadataService(fileMetadataRepositoryMock, FixedTimeSource, fixedUuidSource)
     val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
-    val antivirusMetadataService = new AntivirusMetadataService(mock[AntivirusMetadataRepository])
+    val antivirusMetadataService = new AntivirusMetadataService(antivirusMetadataRepositoryMock)
 
     val fileService = new FileService(
       fileRepositoryMock, consignmentRepositoryMock, fileMetadataService, ffidMetadataService, antivirusMetadataService, FixedTimeSource, fixedUuidSource

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
@@ -28,7 +28,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
   val fileRepositoryMock: FileRepository = mock[FileRepository]
   val ffidMetadataRepositoryMock: FFIDMetadataRepository = mock[FFIDMetadataRepository]
   val antivirusMetadataRepositoryMock: AntivirusMetadataRepository = mock[AntivirusMetadataRepository]
-  def fileMetadataService(fixedUUIDSource: FixedUUIDSource = new FixedUUIDSource()) = new FileMetadataService(fileMetadataRepositoryMock, FixedTimeSource, new FixedUUIDSource())
+  val fileMetadataService = new FileMetadataService(fileMetadataRepositoryMock, FixedTimeSource, new FixedUUIDSource())
 
   "createFile" should "create a file given correct arguments" in {
     val fixedUuidSource = new FixedUUIDSource()
@@ -47,7 +47,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val antivirusMetadataService = new AntivirusMetadataService(antivirusMetadataRepositoryMock)
 
     val fileService = new FileService(
-      fileRepositoryMock, consignmentRepositoryMock, fileMetadataService(), ffidMetadataService, antivirusMetadataService, FixedTimeSource, fixedUuidSource
+      fileRepositoryMock, consignmentRepositoryMock, fileMetadataService, ffidMetadataService, antivirusMetadataService, FixedTimeSource, fixedUuidSource
     )
     val result: Files = fileService.addFile(AddFilesInput(consignmentId, 1, "Parent folder name"), uuid).futureValue
 
@@ -80,7 +80,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val antivirusMetadataService = new AntivirusMetadataService(antivirusMetadataRepositoryMock)
 
     val fileService = new FileService(
-      fileRepositoryMock, consignmentRepositoryMock, fileMetadataService(), ffidMetadataService, antivirusMetadataService, FixedTimeSource, fixedUuidSource
+      fileRepositoryMock, consignmentRepositoryMock, fileMetadataService, ffidMetadataService, antivirusMetadataService, FixedTimeSource, fixedUuidSource
     )
     val result: Files = fileService.addFile(AddFilesInput(consignmentUuid, 3, "Parent folder name"), userUuid).futureValue
 
@@ -103,9 +103,10 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
 
     val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
     val antivirusMetadataService = new AntivirusMetadataService(antivirusMetadataRepositoryMock)
+    val fileMetadataService = new FileMetadataService(fileMetadataRepositoryMock, FixedTimeSource, fixedUuidSource)
 
     val fileService = new FileService(
-      fileRepositoryMock, consignmentRepositoryMock,fileMetadataService(fixedUuidSource), ffidMetadataService, antivirusMetadataService, FixedTimeSource, fixedUuidSource
+      fileRepositoryMock, consignmentRepositoryMock,fileMetadataService, ffidMetadataService, antivirusMetadataService, FixedTimeSource, fixedUuidSource
     )
 
     fixedUuidSource.reset
@@ -153,9 +154,10 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
 
     val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUUIDSource)
     val antivirusMetadataService = new AntivirusMetadataService(antivirusMetadataRepositoryMock)
+    val fileMetadataService = new FileMetadataService(fileMetadataRepositoryMock, FixedTimeSource, fixedUUIDSource)
 
     val fileService = new FileService(
-      fileRepositoryMock, consignmentRepositoryMock, fileMetadataService(), ffidMetadataService, antivirusMetadataService, FixedTimeSource, fixedUUIDSource
+      fileRepositoryMock, consignmentRepositoryMock, fileMetadataService, ffidMetadataService, antivirusMetadataService, FixedTimeSource, fixedUUIDSource
     )
 
     fileService.addFile(AddFilesInput(consignmentId, 1, "Parent folder name"), uuid).futureValue


### PR DESCRIPTION
This adds the antivirus metadata to the consignment output. There is a new service method to get the data and a test for that.
