### PR TITLE
Fix the logic for allChecksSucceeded

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileStatusService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileStatusService.scala
@@ -12,9 +12,10 @@ class FileStatusService(fileStatusRepository: FileStatusRepository)(implicit val
     for {
       checksumStatus <- fileStatusRepository.getFileStatus(consignmentId, Checksum)
       avStatus <- fileStatusRepository.getFileStatus(consignmentId, Antivirus)
-    } yield
-      checksumStatus.headOption.exists(_.value == Success) &&
-        avStatus.headOption.exists(_.value == Success)
+    } yield {
+      checksumStatus.nonEmpty && avStatus.nonEmpty &&
+        (checksumStatus.filter(_.value != Success) ++ avStatus.filter(_.value != Success)).isEmpty
+    }
   }
 }
 

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileStatusServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileStatusServiceSpec.scala
@@ -72,4 +72,18 @@ class FileStatusServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers 
     val response = new FileStatusService(fileStatusRepositoryMock).allChecksSucceeded(consignmentId).futureValue
     response should equal(false)
   }
+
+  "allChecksSucceeded" should "return false if there are multiple checksum rows with one failure and multiple successful antivirus rows" in {
+    mockResponse(Checksum, Seq(fileStatusRow(Checksum, Mismatch), fileStatusRow(Checksum, Success)))
+    mockResponse(Antivirus, Seq(fileStatusRow(Antivirus, Success), fileStatusRow(Antivirus, Success)))
+    val response = new FileStatusService(fileStatusRepositoryMock).allChecksSucceeded(consignmentId).futureValue
+    response should equal(false)
+  }
+
+  "allChecksSucceeded" should "return false if there are multiple antivirus rows with one failure and multiple successful checksum rows" in {
+    mockResponse(Checksum, Seq(fileStatusRow(Checksum, Success), fileStatusRow(Checksum, Success)))
+    mockResponse(Antivirus, Seq(fileStatusRow(Antivirus, Success), fileStatusRow(Antivirus, VirusDetected)))
+    val response = new FileStatusService(fileStatusRepositoryMock).allChecksSucceeded(consignmentId).futureValue
+    response should equal(false)
+  }
 }


### PR DESCRIPTION
The logic originally only worked if there was only a single file for a
consignment. If there's more than one and any one has no status errors,
then it was returning allChecksSucceeded true.

I've changed this so it checks to make sure there are statuses and that
none of them are not Success. I've added a couple of tests to check for
this as well.
