### PR TITLE
Set json logs and output file status

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,6 +50,7 @@ libraryDependencies ++= Seq(
   "ch.megard" %% "akka-http-cors" % "0.4.2",
   "ch.qos.logback" % "logback-classic" % "1.2.3",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
+  "net.logstash.logback" % "logstash-logback-encoder" % "6.6",
   "org.jboss.logging" % "jboss-logging" % "3.4.1.Final",
   "com.lightbend.akka" %% "akka-stream-alpakka-slick" % "1.1.2",
   "software.amazon.awssdk" % "rds" % "2.16.16",

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -3,8 +3,8 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <!-- encoders are assigned the type
              ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>{"application":"consignment-api"}</customFields>
         </encoder>
     </appender>
 

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/AntivirusMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/AntivirusMetadataService.scala
@@ -12,11 +12,12 @@ import uk.gov.nationalarchives.tdr.api.service.FileStatusService.{Antivirus, Suc
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 import com.typesafe.scalalogging.Logger
+import uk.gov.nationalarchives.tdr.api.utils.LoggingUtils
 
 class AntivirusMetadataService(antivirusMetadataRepository: AntivirusMetadataRepository, uuidSource: UUIDSource, timeSource: TimeSource)
                               (implicit val executionContext: ExecutionContext) {
 
-  val logger: Logger = Logger("AntivirusMetadataService")
+  val loggingUtils: LoggingUtils = LoggingUtils(Logger("AntivirusMetadataService"))
 
   def addAntivirusMetadata(input: AddAntivirusMetadataInput): Future[AntivirusMetadata] = {
 
@@ -33,10 +34,7 @@ class AntivirusMetadataService(antivirusMetadataRepository: AntivirusMetadataRep
     }
     val fileStatusRow = FilestatusRow(uuidSource.uuid, input.fileId, Antivirus, fileStatusValue, Timestamp.from(timeSource.now))
 
-    logger.info("File check {} for fileId {} completed with status {}",
-      value("fileCheck", "antivirus"),
-      value("fileId", input.fileId),
-      value("fileCheckStatus", fileStatusValue))
+    loggingUtils.logFileFormatStatus("antivirus", input.fileId, fileStatusValue)
 
     antivirusMetadataRepository.addAntivirusMetadata(inputRow, fileStatusRow).map(rowToAntivirusMetadata)
   }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/AntivirusMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/AntivirusMetadataService.scala
@@ -1,6 +1,6 @@
 package uk.gov.nationalarchives.tdr.api.service
 
-import net.logstash.logback.argument.StructuredArguments.value
+import net.logstash.logback.argument.StructuredArguments._
 
 import java.sql.Timestamp
 import java.time.Instant

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FFIDMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FFIDMetadataService.scala
@@ -3,9 +3,9 @@ package uk.gov.nationalarchives.tdr.api.service
 import com.typesafe.scalalogging.Logger
 import uk.gov.nationalarchives
 import uk.gov.nationalarchives.Tables
-
 import java.sql.{SQLException, Timestamp}
 import java.util.UUID
+
 import uk.gov.nationalarchives.Tables.{FfidmetadataRow, FfidmetadatamatchesRow, FilestatusRow}
 import uk.gov.nationalarchives.tdr.api.db.repository.{FFIDMetadataMatchesRepository, FFIDMetadataRepository}
 import uk.gov.nationalarchives.tdr.api.graphql.DataExceptions.InputDataException

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FFIDMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FFIDMetadataService.scala
@@ -3,22 +3,23 @@ package uk.gov.nationalarchives.tdr.api.service
 import com.typesafe.scalalogging.Logger
 import uk.gov.nationalarchives
 import uk.gov.nationalarchives.Tables
+
 import java.sql.{SQLException, Timestamp}
 import java.util.UUID
-
 import uk.gov.nationalarchives.Tables.{FfidmetadataRow, FfidmetadatamatchesRow, FilestatusRow}
 import uk.gov.nationalarchives.tdr.api.db.repository.{FFIDMetadataMatchesRepository, FFIDMetadataRepository}
 import uk.gov.nationalarchives.tdr.api.graphql.DataExceptions.InputDataException
 import uk.gov.nationalarchives.tdr.api.graphql.fields.FFIDMetadataFields.{FFIDMetadata, FFIDMetadataInput, FFIDMetadataMatches}
 import uk.gov.nationalarchives.tdr.api.service.FileStatusService.{FFID, PasswordProtected, Success, Zip}
 import net.logstash.logback.argument.StructuredArguments._
+import uk.gov.nationalarchives.tdr.api.utils.LoggingUtils
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class FFIDMetadataService(ffidMetadataRepository: FFIDMetadataRepository, matchesRepository: FFIDMetadataMatchesRepository,
                           timeSource: TimeSource, uuidSource: UUIDSource)(implicit val executionContext: ExecutionContext) {
 
-  val logger: Logger = Logger("FFIDMetadataService")
+  val loggingUtils: LoggingUtils = LoggingUtils(Logger("FFIDMetadataService"))
 
   val passwordProtectedPuids: List[String] = List("fmt/494", "fmt/754", "fmt/755")
   val zipPuids: List[String] = List("fmt/289", "fmt/329", "fmt/484", "fmt/508", "fmt/600", "fmt/610", "fmt/613",
@@ -39,10 +40,7 @@ class FFIDMetadataService(ffidMetadataRepository: FFIDMetadataRepository, matche
 
     val fileStatusRows = generateFileStatusRows(ffidMetadata)
 
-    logger.info("File check {} for fileId {} completed with status {}",
-      value("fileCheck", "FFID"),
-      value("fileId", ffidMetadata.fileId),
-      value("fileCheckStatus", fileStatusRows.map(_.value).mkString(",")))
+    loggingUtils.logFileFormatStatus("FFID", ffidMetadata.fileId, fileStatusRows.map(_.value).mkString(","))
 
     def addFFIDMetadataMatches(ffidmetadataid: UUID): Future[Seq[Tables.FfidmetadatamatchesRow]] = {
       val matchRows = ffidMetadata.matches.map(m => FfidmetadatamatchesRow(ffidmetadataid, m.extension, m.identificationBasis, m.puid))

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/utils/LoggingUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/utils/LoggingUtils.scala
@@ -1,0 +1,18 @@
+package uk.gov.nationalarchives.tdr.api.utils
+
+import com.typesafe.scalalogging.Logger
+import net.logstash.logback.argument.StructuredArguments._
+
+import java.util.UUID
+
+class LoggingUtils(logger: Logger) {
+  def logFileFormatStatus(fileCheck: String, fileId: UUID, fileCheckStatus: String): Unit =
+    logger.info("File check {} for fileId {} completed with status {}",
+      value("fileCheck",fileCheck),
+      value("fileId", fileId),
+      value("fileCheckStatus", fileCheckStatus))
+}
+
+object LoggingUtils {
+  def apply(logger: Logger): LoggingUtils = new LoggingUtils(logger)
+}


### PR DESCRIPTION
- Set logs to output in json format.
- Log the file status so we can query this in Grafana
