### PR TITLE
Update db library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-optics" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-generic-extras" % circeVersion,
-  "uk.gov.nationalarchives" %% "consignment-api-db" % "0.0.48",
+  "uk.gov.nationalarchives" %% "consignment-api-db" % "0.0.50",
   "org.postgresql" % "postgresql" % "42.2.11",
   "com.typesafe.slick" %% "slick" % "3.3.2",
   "com.typesafe.slick" %% "slick-hikaricp" % "3.3.2",

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentService.scala
@@ -40,7 +40,7 @@ class ConsignmentService(
         addConsignmentInput.seriesid,
         userId,
         Timestamp.from(now),
-        consignmentsequence = Option(sequence),
+        consignmentsequence = sequence,
         consignmentreference = consignmentRef)
       consignmentRepository.addConsignment(consignmentRow).map(
         row => convertRowToConsignment(row)

--- a/src/test/resources/scripts/init.sql
+++ b/src/test/resources/scripts/init.sql
@@ -117,6 +117,7 @@ CREATE TABLE IF NOT EXISTS ConsignmentStatus (
     StatusType varchar(255) not null,
     Value varchar(255) not null,
     CreatedDatetime timestamp not null,
+    ModifiedDatetime  timestamp,
     PRIMARY KEY (ConsignmentStatusId),
     FOREIGN KEY (ConsignmentId) REFERENCES Consignment(ConsignmentId)
 );

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentServiceSpec.scala
@@ -34,7 +34,7 @@ class ConsignmentServiceSpec extends AnyFlatSpec with MockitoSugar with ResetMoc
   val bodyCode: Option[String] = Option("Mock department")
   val bodyDescription: Option[String] = Option("Body description")
   //scalastyle:off magic.number
-  val consignmentSequence: Option[Long] = Option(400L)
+  val consignmentSequence: Long = 400L
   //scalastyle:on magic.number
   val consignmentReference = "TDR-2020-VB"
   val mockConsignment: ConsignmentRow = ConsignmentRow(
@@ -71,7 +71,7 @@ class ConsignmentServiceSpec extends AnyFlatSpec with MockitoSugar with ResetMoc
   }
 
   "addConsignment" should "link a consignment to the user's ID" in {
-    when(consignmentRepoMock.getNextConsignmentSequence).thenReturn(Future.successful(consignmentSequence.get))
+    when(consignmentRepoMock.getNextConsignmentSequence).thenReturn(Future.successful(consignmentSequence))
     when(consignmentRepoMock.addConsignment(any[ConsignmentRow])).thenReturn(mockResponse)
     when(fixedUuidSource.uuid).thenReturn(consignmentId)
     consignmentService.addConsignment(AddConsignmentInput(seriesId), userId).futureValue

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
@@ -196,7 +196,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
       seriesId1,
       userId1,
       Timestamp.from(Instant.now),
-      consignmentsequence = Option(400L),
+      consignmentsequence = 400L,
       consignmentreference = "TEST-TDR-2021-VB"
     )
     val consignment2 = ConsignmentRow(
@@ -204,7 +204,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
       seriesId2,
       userId2,
       Timestamp.from(Instant.now),
-      consignmentsequence = Option(500L),
+      consignmentsequence = 500L,
       consignmentreference = "TEST-TDR-2021-3B"
     )
 


### PR DESCRIPTION
The ConsignmentSequence column on Consignment is now mandatory so I've
updated the library and removed all of the Option[Long]
There was also a change in the database library to add ModifiedDate to
ConsignmentStatus which I've added to the test init script.
