### PR TITLE
Consignment status update upload complete

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentStatusRepository.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentStatusRepository.scala
@@ -3,6 +3,7 @@ package uk.gov.nationalarchives.tdr.api.db.repository
 import slick.jdbc.PostgresProfile.api._
 import uk.gov.nationalarchives.Tables.{Consignmentstatus, ConsignmentstatusRow}
 
+import java.sql.Timestamp
 import java.util.UUID
 import scala.concurrent.Future
 
@@ -11,5 +12,12 @@ class ConsignmentStatusRepository(db: Database) {
   def getConsignmentStatus(consignmentId: UUID): Future[Seq[ConsignmentstatusRow]] = {
     val query = Consignmentstatus.filter(_.consignmentid === consignmentId)
     db.run(query.result)
+  }
+
+  def updateConsignmentStatusUploadComplete(consignmentId: UUID, statusType: String, statusValue: String, modifiedTimestamp: Timestamp): Future[Int] = {
+    val dbUpdate = Consignmentstatus.filter(_.consignmentid === consignmentId)
+      .map(c => (c.statustype, c.value, c.modifieddatetime))
+      .update((statusType, statusValue, Option(modifiedTimestamp)))
+    db.run(dbUpdate)
   }
 }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/GraphQlTypes.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/GraphQlTypes.scala
@@ -17,6 +17,7 @@ object GraphQlTypes {
       TransferAgreementFields.mutationFields ++
       ClientFileMetadataFields.mutationFields ++
       FileFields.mutationFields ++
+      ConsignmentStatusFields.mutationFields ++
       AntivirusMetadataFields.mutationFields ++
       FileMetadataFields.mutationFields ++
       FFIDMetadataFields.mutationFields ++

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentStatusFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentStatusFields.scala
@@ -1,0 +1,52 @@
+package uk.gov.nationalarchives.tdr.api.graphql.fields
+
+import sangria.macros.derive.deriveInputObjectType
+import uk.gov.nationalarchives.tdr.api.graphql.ConsignmentApiContext
+import uk.gov.nationalarchives.tdr.api.graphql.fields.ConsignmentFields.ConsignmentIdArg
+import uk.gov.nationalarchives.tdr.api.graphql.fields.FieldTypes.{UuidType, ZonedDateTimeType}
+import io.circe.generic.auto._
+import sangria.marshalling.circe._
+import sangria.schema.{Argument, Field, InputObjectType, IntType, ObjectType, OptionType, StringType, fields}
+import uk.gov.nationalarchives.tdr.api.auth.ValidateUserHasAccessToConsignment
+import uk.gov.nationalarchives.tdr.api.graphql.validation.UserOwnsConsignment
+
+import java.time.ZonedDateTime
+import java.util.UUID
+
+object ConsignmentStatusFields {
+
+  case class ConsignmentStatus(consignmentStatusId: UUID,
+                               consignmentId: UUID,
+                               statusType: String,
+                               value: String,
+                               createdDatetime: ZonedDateTime,
+                               modifiedDatetime: ZonedDateTime
+                              )
+
+  case class UpdateConsignmentStatusInput(consignmentId: UUID, statusType: String, statusValue: String) extends UserOwnsConsignment
+
+  implicit val UpdateConsignmentStatusType: InputObjectType[UpdateConsignmentStatusInput] =
+    deriveInputObjectType[UpdateConsignmentStatusInput]()
+
+  implicit val ConsignmentStatusType: ObjectType[Unit, ConsignmentStatus] = ObjectType(
+    "ConsignmentStatus",
+    fields[Unit, ConsignmentStatus](
+      Field("consignmentStatusId", UuidType, resolve = _.value.consignmentStatusId),
+      Field("consignmentId", UuidType, resolve = _.value.consignmentId),
+      Field("statusType", StringType, resolve = _.value.statusType),
+      Field("value", StringType, resolve = _.value.value),
+      Field("createdDatetime", ZonedDateTimeType, resolve = _.value.createdDatetime),
+      Field("modifiedDatetime", ZonedDateTimeType, resolve = _.value.modifiedDatetime)
+    )
+  )
+
+  val UploadCompleteUpdateArg: Argument[UpdateConsignmentStatusInput] = Argument("uploadCompleteUpdate", UpdateConsignmentStatusType)
+
+  val mutationFields: List[Field[ConsignmentApiContext, Unit]] = fields[ConsignmentApiContext, Unit](
+    Field("updateConsignmentStatusUploadComplete", OptionType(IntType),
+      arguments = UploadCompleteUpdateArg :: Nil,
+      resolve = ctx => ctx.ctx.consignmentStatusService.updateConsignmentStatusUploadComplete(ctx.arg(UploadCompleteUpdateArg)),
+      tags = List(ValidateUserHasAccessToConsignment(UploadCompleteUpdateArg))
+    )
+  )
+}

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentStatusService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentStatusService.scala
@@ -2,8 +2,11 @@ package uk.gov.nationalarchives.tdr.api.service
 
 import uk.gov.nationalarchives.tdr.api.db.repository.ConsignmentStatusRepository
 import uk.gov.nationalarchives.tdr.api.graphql.fields.ConsignmentFields.CurrentStatus
+import uk.gov.nationalarchives.tdr.api.graphql.fields.ConsignmentStatusFields.UpdateConsignmentStatusInput
 
+import java.sql.Timestamp
 import java.util.UUID
+import java.time.Instant.now
 import scala.concurrent.{ExecutionContext, Future}
 
 class ConsignmentStatusService(consignmentStatusRepository: ConsignmentStatusRepository)
@@ -13,5 +16,14 @@ class ConsignmentStatusService(consignmentStatusRepository: ConsignmentStatusRep
     for {
       upload <- consignmentStatusRepository.getConsignmentStatus(consignmentId)
     } yield CurrentStatus(upload.sortBy(t => t.createddatetime).reverse.map(_.value).headOption)
+  }
+
+  def updateConsignmentStatusUploadComplete(uploadCompleteInput: UpdateConsignmentStatusInput): Future[Int] = {
+    consignmentStatusRepository.updateConsignmentStatusUploadComplete(
+      uploadCompleteInput.consignmentId,
+      uploadCompleteInput.statusType,
+      uploadCompleteInput.statusValue,
+      Timestamp.from(now)
+    )
   }
 }

--- a/src/test/resources/json/updateconsignmentstatus_data_all.json
+++ b/src/test/resources/json/updateconsignmentstatus_data_all.json
@@ -1,0 +1,5 @@
+{
+  "data": {
+    "updateConsignmentStatusUploadComplete": 1
+  }
+}

--- a/src/test/resources/json/updateconsignmentstatus_data_no_consignment.json
+++ b/src/test/resources/json/updateconsignmentstatus_data_no_consignment.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "updateConsignmentStatusUploadComplete": null
+  },
+  "errors": [
+    {
+      "message": "Invalid consignment id",
+      "path": [
+        "updateConsignmentStatusUploadComplete"
+      ],
+      "locations": [
+        {
+          "column": 5,
+          "line": 2
+        }
+      ],
+      "extensions": {
+        "code": "NOT_AUTHORISED"
+      }
+    }
+  ]
+}

--- a/src/test/resources/json/updateconsignmentstatus_mutation_data_all.json
+++ b/src/test/resources/json/updateconsignmentstatus_mutation_data_all.json
@@ -1,0 +1,10 @@
+{
+  "query": "mutation($uploadCompleteUpdate: UpdateConsignmentStatusInput!){updateConsignmentStatusUploadComplete(uploadCompleteUpdate: $uploadCompleteUpdate)}",
+  "variables": {
+    "uploadCompleteUpdate": {
+      "consignmentId": "a8dc972d-58f9-4733-8bb2-4254b89a35f2",
+      "statusType": "Upload",
+      "statusValue": "Completed"
+    }
+  }
+}

--- a/src/test/resources/json/updateconsignmentstatus_mutation_no_consignment.json
+++ b/src/test/resources/json/updateconsignmentstatus_mutation_no_consignment.json
@@ -1,0 +1,10 @@
+{
+  "query": "mutation($uploadCompleteUpdate: UpdateConsignmentStatusInput!){updateConsignmentStatusUploadComplete(uploadCompleteUpdate: $uploadCompleteUpdate)}",
+  "variables": {
+    "uploadCompleteUpdate": {
+      "consignmentId": "a8dc972d-58f9-4733-8bb2-4254b89a35f2",
+      "statusType": "Upload",
+      "statusValue": "Completed"
+    }
+  }
+}

--- a/src/test/resources/scripts/init.sql
+++ b/src/test/resources/scripts/init.sql
@@ -118,7 +118,7 @@ CREATE TABLE IF NOT EXISTS ConsignmentStatus (
     StatusType varchar(255) not null,
     Value varchar(255) not null,
     CreatedDatetime timestamp not null,
-    ModifiedDatetime  timestamp,
+    ModifiedDatetime timestamp,
     PRIMARY KEY (ConsignmentStatusId),
     FOREIGN KEY (ConsignmentId) REFERENCES Consignment(ConsignmentId)
 );

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentRouteSpec.scala
@@ -86,7 +86,7 @@ class ConsignmentRouteSpec extends AnyFlatSpec with Matchers with TestRequest wi
     createSeries(transferringBodyId)
 
     val expectedResponse: GraphqlMutationData = expectedMutationResponse("data_all")
-    val response: GraphqlMutationData = runTestMutation("mutation_alldata", validUserToken(transferringBodyCode))
+    val response: GraphqlMutationData = runTestMutation("mutation_alldata", validUserToken(body = transferringBodyCode))
     response.data.get.addConsignment should equal(expectedResponse.data.get.addConsignment)
 
     checkConsignmentExists(response.data.get.addConsignment.consignmentid.get)
@@ -102,7 +102,7 @@ class ConsignmentRouteSpec extends AnyFlatSpec with Matchers with TestRequest wi
     createSeries(transferringBodyId)
 
     val expectedResponse: GraphqlMutationData = expectedMutationResponse("data_all")
-    val response: GraphqlMutationData = runTestMutation("mutation_alldata", validUserToken(transferringBodyCode))
+    val response: GraphqlMutationData = runTestMutation("mutation_alldata", validUserToken(body = transferringBodyCode))
     response.data.get.addConsignment should equal(expectedResponse.data.get.addConsignment)
 
     response.data.get.addConsignment.userid should contain(userId)
@@ -180,7 +180,7 @@ class ConsignmentRouteSpec extends AnyFlatSpec with Matchers with TestRequest wi
     addSeries(UUID.fromString(seriesId), bodyId, seriesName)
 
     val expectedResponse: GraphqlQueryData = expectedQueryResponse("data_all")
-    val response: GraphqlQueryData = runTestQuery("query_alldata", validUserToken(bodyCode))
+    val response: GraphqlQueryData = runTestQuery("query_alldata", validUserToken(body = bodyCode))
 
     response should equal(expectedResponse)
   }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentStatusRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentStatusRouteSpec.scala
@@ -1,0 +1,68 @@
+package uk.gov.nationalarchives.tdr.api.routes
+
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import io.circe.generic.extras.Configuration
+import io.circe.generic.extras.auto._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import uk.gov.nationalarchives.tdr.api.utils.TestUtils._
+import uk.gov.nationalarchives.tdr.api.utils.{TestDatabase, TestRequest}
+
+import java.time.ZonedDateTime
+import java.util.UUID
+
+
+class ConsignmentStatusRouteSpec extends AnyFlatSpec with Matchers with TestRequest with TestDatabase {
+  private val updateConsignmentStatusJsonFilePrefix: String = "json/updateconsignmentstatus_"
+  private val transferringBodyId = UUID.fromString("4da472a5-16b3-4521-a630-5917a0722359")
+  private val transferringBodyCode = "default-transferring-body-code"
+
+  implicit val customConfig: Configuration = Configuration.default.withDefaults
+  case class GraphqlMutationData(data: Option[UpdateConsignmentStatusUploadComplete], errors: List[GraphqlError] = Nil)
+  case class UpdateConsignmentStatusUploadComplete(updateConsignmentStatusUploadComplete: Option[Int])
+
+  case class ConsignmentStatus(consignmentStatusId: Option[UUID],
+                               consignmentId: Option[UUID],
+                               statusType: Option[String],
+                               value: Option[String],
+                               createdDatetime: Option[ZonedDateTime],
+                               modifiedDatetime: Option[ZonedDateTime]
+                              )
+
+  val runTestMutation: (String, OAuth2BearerToken) => GraphqlMutationData = runTestRequest[GraphqlMutationData](updateConsignmentStatusJsonFilePrefix)
+  val expectedMutationResponse: String => GraphqlMutationData = getDataFromFile[GraphqlMutationData](updateConsignmentStatusJsonFilePrefix)
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+
+    addTransferringBody(transferringBodyId, "Default transferring body name", transferringBodyCode)
+  }
+
+  "updateConsignmentStatusUploadComplete" should "update consignment status" in {
+    val consignmentId = UUID.fromString("a8dc972d-58f9-4733-8bb2-4254b89a35f2")
+    val userId = UUID.fromString("49762121-4425-4dc4-9194-98f72e04d52e")
+    val statusType = "Upload"
+    val statusValue = "InProgress"
+    val token = validUserToken(userId)
+
+    createConsignment(consignmentId, userId)
+    createConsignmentUploadStatus(consignmentId, statusType, statusValue)
+
+    val expectedResponse = getDataFromFile[GraphqlMutationData](updateConsignmentStatusJsonFilePrefix)("data_all")
+    val response = runTestRequest[GraphqlMutationData](updateConsignmentStatusJsonFilePrefix)("mutation_data_all", token)
+
+    response.data.get.updateConsignmentStatusUploadComplete should equal(expectedResponse.data.get.updateConsignmentStatusUploadComplete)
+  }
+
+  "updateConsignmentStatusUploadComplete" should "return an error if a consignment that doesn't exist is queried" in {
+    val userId = UUID.fromString("dfee3d4f-3bb1-492e-9c85-7db1685ab12f")
+    val token = validUserToken(userId)
+
+    val expectedResponse = getDataFromFile[GraphqlMutationData](updateConsignmentStatusJsonFilePrefix)("data_no_consignment")
+    val response = runTestRequest[GraphqlMutationData](updateConsignmentStatusJsonFilePrefix)("mutation_no_consignment", token)
+
+    response.data.get.updateConsignmentStatusUploadComplete should equal(expectedResponse.data.get.updateConsignmentStatusUploadComplete)
+  }
+}
+
+

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/SeriesRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/SeriesRouteSpec.scala
@@ -41,7 +41,7 @@ class SeriesRouteSpec extends AnyFlatSpec with Matchers with TestDatabase with T
     TestUtils.addTransferringBody(bodyId, "Some body name", bodyCode)
 
     val expectedResponse: GraphqlQueryData = expectedQueryResponse("data_empty")
-    val response: GraphqlQueryData = runTestQuery("query_somedata", validUserToken(bodyCode))
+    val response: GraphqlQueryData = runTestQuery("query_somedata", validUserToken(body = bodyCode))
     response.data should equal(expectedResponse.data)
   }
 
@@ -56,7 +56,7 @@ class SeriesRouteSpec extends AnyFlatSpec with Matchers with TestDatabase with T
     TestUtils.addSeries(UUID.fromString("01d2eb57-9d35-43e8-9eff-63e539ada1f9"), otherBodyId, "series-code-3")
 
     val expectedResponse: GraphqlQueryData = expectedQueryResponse("data_some")
-    val response: GraphqlQueryData = runTestQuery("query_somedata", validUserToken(bodyCode))
+    val response: GraphqlQueryData = runTestQuery("query_somedata", validUserToken(body = bodyCode))
     response.data should equal(expectedResponse.data)
   }
 
@@ -72,7 +72,7 @@ class SeriesRouteSpec extends AnyFlatSpec with Matchers with TestDatabase with T
     TestUtils.addTransferringBody(bodyId, "Some body name", bodyCode)
 
     val expectedResponse: GraphqlQueryData = expectedQueryResponse("data_all")
-    val response: GraphqlQueryData = runTestQuery("query_alldata", validUserToken(bodyCode))
+    val response: GraphqlQueryData = runTestQuery("query_alldata", validUserToken(body = bodyCode))
     response.data should equal(expectedResponse.data)
   }
 

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestUtils.scala
@@ -37,7 +37,7 @@ object TestUtils {
   val userId: UUID = UUID.fromString("4ab14990-ed63-4615-8336-56fbb9960300")
   val backendChecksUser: UUID = UUID.fromString("6847253d-b9c6-4ea9-b3c9-57542b8c6375")
 
-  def validUserToken(body: String = "Code"): OAuth2BearerToken = OAuth2BearerToken(tdrMock.getAccessToken(
+  def validUserToken(userId: UUID = userId, body: String = "Code"): OAuth2BearerToken = OAuth2BearerToken(tdrMock.getAccessToken(
     aTokenConfig()
       .withResourceRole("tdr", "tdr_user")
       .withClaim("body", body)


### PR DESCRIPTION
These changes allow us to provide an endpoint to update the consignment status upon the completion of a users' upload.