### PR TITLE
Update generated graphql version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-optics" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-generic-extras" % circeVersion,
-  "uk.gov.nationalarchives" %% "consignment-api-db" % "0.0.51",
+  "uk.gov.nationalarchives" %% "consignment-api-db" % "0.0.52",
   "org.postgresql" % "postgresql" % "42.2.11",
   "com.typesafe.slick" %% "slick" % "3.3.2",
   "com.typesafe.slick" %% "slick-hikaricp" % "3.3.2",

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/auth/AuthorisationTags.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/auth/AuthorisationTags.scala
@@ -56,8 +56,8 @@ object ValidateSeries extends AuthorisationTag {
 
     bodyResult.map(body => {
       body.tdrCode match {
-        case Some(code) if code == userBody => continue
-        case Some(code) =>
+        case code if code == userBody => continue
+        case code if code != userBody =>
           val message = s"User '${token.userId}' is from transferring body '$userBody' and does not have permission " +
             s"to create a consignment under series '$addConsignmentInput' owned by body '$code'"
           throw AuthorisationException(message)

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/auth/AuthorisationTags.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/auth/AuthorisationTags.scala
@@ -57,12 +57,10 @@ object ValidateSeries extends AuthorisationTag {
     bodyResult.map(body => {
       body.tdrCode match {
         case code if code == userBody => continue
-        case code if code != userBody =>
+        case code =>
           val message = s"User '${token.userId}' is from transferring body '$userBody' and does not have permission " +
             s"to create a consignment under series '$addConsignmentInput' owned by body '$code'"
           throw AuthorisationException(message)
-        // This exception can be removed when we use body IDs rather than names
-        case _ => throw new IllegalStateException("")
       }
     })
   }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentFields.scala
@@ -31,7 +31,7 @@ object ConsignmentFields {
   case class FFIDProgress(filesProcessed: Int)
 
   case class FileChecks(antivirusProgress: AntivirusProgress, checksumProgress: ChecksumProgress, ffidProgress: FFIDProgress)
-  case class TransferringBody(name: Option[String], tdrCode: Option[String])
+  case class TransferringBody(name: String, tdrCode: String)
   case class CurrentStatus(upload: Option[String])
 
   case class UpdateExportLocationInput(consignmentId: UUID, exportLocation: String, exportDatetime: Option[ZonedDateTime])

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/SeriesFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/SeriesFields.scala
@@ -11,7 +11,7 @@ import uk.gov.nationalarchives.tdr.api.auth.ValidateBody
 import uk.gov.nationalarchives.tdr.api.graphql.ConsignmentApiContext
 
 object SeriesFields {
-  case class Series(seriesid: UUID, bodyid: UUID, name: Option[String] = None, code: Option[String] = None, description: Option[String] = None)
+  case class Series(seriesid: UUID, bodyid: UUID, name: String, code: String, description: Option[String] = None)
 
   implicit val SeriesType: ObjectType[Unit, Series] = deriveObjectType[Unit, Series]()
 

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/model/TransferringBody.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/model/TransferringBody.scala
@@ -1,3 +1,3 @@
 package uk.gov.nationalarchives.tdr.api.model
 
-case class TransferringBody(tdrCode: Option[String])
+case class TransferringBody(tdrCode: String)

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepositorySpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepositorySpec.scala
@@ -67,7 +67,7 @@ class ConsignmentRepositorySpec extends AnyFlatSpec with TestDatabase with Scala
 
     val consignmentSeries = consignmentRepository.getSeriesOfConsignment(consignmentId).futureValue.head
 
-    consignmentSeries.code.get should be(seriesCode)
+    consignmentSeries.code should be(seriesCode)
   }
 
   "getTransferringBodyOfConsignment" should "get the transferring body for a consignment" in {
@@ -85,7 +85,7 @@ class ConsignmentRepositorySpec extends AnyFlatSpec with TestDatabase with Scala
 
     val consignmentBody = consignmentRepository.getTransferringBodyOfConsignment(consignmentId).futureValue.head
 
-    consignmentBody.name.get should be(bodyName)
+    consignmentBody.name should be(bodyName)
   }
 
   "getNextConsignmentSequence" should "get the next sequence ID number for a consignment row" in {

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentServiceSpec.scala
@@ -27,11 +27,11 @@ class ConsignmentServiceSpec extends AnyFlatSpec with MockitoSugar with ResetMoc
   val userId: UUID = UUID.fromString("8d415358-f68b-403b-a90a-daab3fd60109")
   val seriesId: UUID = UUID.fromString("b6b19341-8c33-4272-8636-aafa1e3d98de")
   val consignmentId: UUID = UUID.fromString("6e3b76c4-1745-4467-8ac5-b4dd736e1b3e")
-  val seriesName: Option[String] = Option("Mock series")
-  val seriesCode: Option[String] = Option("Mock series")
+  val seriesName: String = "Mock series"
+  val seriesCode: String = "Mock series"
   val seriesDescription: Option[String] = Option("Series description")
-  val bodyName: Option[String] = Option("Mock department")
-  val bodyCode: Option[String] = Option("Mock department")
+  val bodyName: String = "Mock department"
+  val bodyCode: String = "Mock department"
   val bodyDescription: Option[String] = Option("Body description")
   //scalastyle:off magic.number
   val consignmentSequence: Long = 400L
@@ -200,7 +200,7 @@ class ConsignmentServiceSpec extends AnyFlatSpec with MockitoSugar with ResetMoc
   }
 
   "getTransferringBodyOfConsignment" should "return the transferring body for a given consignment" in {
-    val mockBody = Seq(BodyRow(bodyId, bodyName, bodyCode, bodyDescription))
+    val mockBody = Seq(BodyRow(bodyId, bodyName, bodyDescription, bodyCode))
     when(consignmentRepoMock.getTransferringBodyOfConsignment(consignmentId)).thenReturn(Future.successful(mockBody))
 
     val body: ConsignmentFields.TransferringBody = consignmentService.getTransferringBodyOfConsignment(consignmentId).futureValue.get

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/SeriesServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/SeriesServiceSpec.scala
@@ -34,14 +34,14 @@ class SeriesServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with
   private def checkFields(series: SeriesFields.Series, seriesCheck: SeriesCheck) = {
     series.seriesid should equal(seriesCheck.seriesId)
     series.bodyid should equal(seriesCheck.bodyId)
-    series.name.get should equal(seriesCheck.name)
-    series.code.get should equal(seriesCheck.code)
+    series.name should equal(seriesCheck.name)
+    series.code should equal(seriesCheck.code)
     series.description.get should equal(seriesCheck.description)
   }
 
   private def setupSeriesResponses = {
     val fixedUuidSource = new FixedUUIDSource()
-    val seriesOne = SeriesRow(fixedUuidSource.uuid, fixedUuidSource.uuid, Option.apply("name1"), Option.apply("code1"), Option.apply("description1"))
+    val seriesOne = SeriesRow(fixedUuidSource.uuid, fixedUuidSource.uuid, "name1", "code1", Option.apply("description1"))
 
     val mockResponseOne: Future[Seq[SeriesRow]] = Future.successful(Seq(seriesOne))
 

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/TransferringBodyServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/TransferringBodyServiceSpec.scala
@@ -22,11 +22,11 @@ class TransferringBodyServiceSpec extends AnyFlatSpec with MockitoSugar with Mat
     val seriesId = UUID.fromString("20e88b3c-d063-4a6e-8b61-187d8c51d11d")
     val bodyId = UUID.fromString("8a72cc59-7f2f-4e55-a263-4a4cb9f677f5")
 
-    val bodyRow = BodyRow(bodyId, Some("Some department name"), Some("CODE"), None, Option("CODE"))
+    val bodyRow = BodyRow(bodyId, "Some department name", None, "CODE")
     when(repository.getTransferringBody(seriesId)).thenReturn(Future.successful(bodyRow))
 
     val body = service.getBody(seriesId)
 
-    body.futureValue.tdrCode.get should equal("CODE")
+    body.futureValue.tdrCode should equal("CODE")
   }
 }


### PR DESCRIPTION
This includes the change to drop the Code column from the Body table which will stop slick trying to select from it.
The new changes also include making some columns mandatory. To update to the latest version of the generated slick classes, I've removed all of the options from these fields.
