### PR TITLE
Change the validateGraphqlSchema task to not ignore breaking changes.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import rocks.muki.graphql.quietError
 import rocks.muki.graphql.schema.SchemaLoader
 import sbt.File
 import sbt.Keys.libraryDependencies
@@ -34,7 +35,7 @@ val graphqlValidateSchemaTask = Def.inputTask[Unit] {
   val changes = graphqlSchemaChanges.evaluated
   if (changes.nonEmpty) {
     changes.foreach(change => log.error(s" * ${change.description}"))
-    log.error("Validation failed: Changes found")
+    quietError("Validation failed: Changes found")
   }
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,17 @@ graphqlSchemas += GraphQLSchema(
   ).taskValue
 )
 
+val graphqlValidateSchemaTask = Def.inputTask[Unit] {
+  val log = streams.value.log
+  val changes = graphqlSchemaChanges.evaluated
+  if (changes.nonEmpty) {
+    changes.foreach(change => log.error(s" * ${change.description}"))
+    log.error("Validation failed: Changes found")
+  }
+}
+
+graphqlValidateSchema := graphqlValidateSchemaTask.evaluated
+
 enablePlugins(GraphQLSchemaPlugin)
 
 graphqlSchemaSnippet := "uk.gov.nationalarchives.tdr.api.graphql.GraphQlTypes.schema"

--- a/schema.graphql
+++ b/schema.graphql
@@ -204,8 +204,8 @@ type Query {
 type Series {
   seriesid: UUID!
   bodyid: UUID!
-  name: String
-  code: String
+  name: String!
+  code: String!
   description: String
 }
 
@@ -221,8 +221,8 @@ type TransferAgreement {
 }
 
 type TransferringBody {
-  name: String
-  tdrCode: String
+  name: String!
+  tdrCode: String!
 }
 
 scalar UUID


### PR DESCRIPTION
The sbt-graphql graphqlValidateSchema plugin ignores any non-breaking changes. [The code doing this is here 
](https://github.com/muuki88/sbt-graphql/blob/37d62dd17475cadcea23cd0a000df8152b633189/src/main/scala/rocks/muki/graphql/GraphQLSchemaPlugin.scala#L166)
We would like this to fail on any schema changes, not just ones which will break so I've changed the graphqlValidateSchema task to do this. I've modified the code from the original plugin to do this.

I've also change the `schema.graphql` file. The changes to this should have failed on the PR that put didn't so I'm adding them in here so the build will pass.