### PR TITLE
Revert "Make sure we're using the latest version of apk-tools"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR /api
 RUN addgroup --system apigroup && adduser --system apiuser -G apigroup && \
     apk update && \
     apk upgrade p11-kit && \
-    apk upgrade apk-tools && \
     apk add ca-certificates && \
     chown -R apiuser /api && \
     wget https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem


### PR DESCRIPTION
This reverts commit 3755203454727a0a3ccbeb9d7878e17f6a540c62.

It looks like this isn't actually needed, because the previous version didn't report any vulnerabilities in ECR.