### PR TITLE
Ensure only files with ffid matches are counted

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/FFIDMetadataRepository.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/FFIDMetadataRepository.scala
@@ -22,9 +22,10 @@ class FFIDMetadataRepository(db: Database)(implicit val executionContext: Execut
 
   def countProcessedFfidMetadata(consignmentId: UUID): Future[Int] = {
     val query = Ffidmetadata.join(File)
-      .on(_.fileid === _.fileid)
-      .filter(_._2.consignmentid === consignmentId)
-      .groupBy(_._1.fileid)
+      .on(_.fileid === _.fileid).join(Ffidmetadatamatches)
+      .on(_._1.ffidmetadataid === _.ffidmetadataid)
+      .filter(_._1._2.consignmentid === consignmentId)
+      .groupBy(_._1._2.fileid)
       .map(_._1)
       .length
     db.run(query.result)

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/FFIDMetadataRepositorySpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/FFIDMetadataRepositorySpec.scala
@@ -74,6 +74,22 @@ class FFIDMetadataRepositorySpec extends AnyFlatSpec with TestDatabase with Scal
     fileMetadataFiles shouldBe 2
   }
 
+  "countProcessedFfidMetadata" should "return 0 if file has ffid metadata but no ffid matches" in {
+    val db = DbConnection.db
+    val ffidMetadataRepository = new FFIDMetadataRepository(db)
+    val consignment = UUID.fromString("a9ccec45-5325-4e07-a0cd-1b0f4dc0d6fd")
+    val fileId = "be77573a-8710-42a2-9a9f-522bd681d467"
+
+    TestUtils.createConsignment(consignment, userId)
+
+    TestUtils.createFile(UUID.fromString(fileId), consignment)
+    TestUtils.addFFIDMetadata(fileId)
+
+    val fileMetadataFiles = ffidMetadataRepository.countProcessedFfidMetadata(consignment).futureValue
+
+    fileMetadataFiles shouldBe 0
+  }
+
   "countProcessedFfidMetadata" should "return number of ffidMetadata rows with repetitive data filtered out" in {
     val db = DbConnection.db
     val ffidMetadataRepository = new FFIDMetadataRepository(db)


### PR DESCRIPTION
There is potential that the ffid matches will not contain any results

In this case ensure that the file checks do not complete