### PR TITLE
Do not add ffid metadata if no ffid matches

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FFIDMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FFIDMetadataService.scala
@@ -30,6 +30,11 @@ class FFIDMetadataService(ffidMetadataRepository: FFIDMetadataRepository, matche
     "x-fmt/268", "x-fmt/269", "x-fmt/412", "x-fmt/416", "x-fmt/429")
 
   def addFFIDMetadata(ffidMetadata: FFIDMetadataInput): Future[FFIDMetadata] = {
+
+    if (ffidMetadata.matches.isEmpty) {
+      throw InputDataException(s"No ffid matches for file ${ffidMetadata.fileId}")
+    }
+
     val metadataRow = FfidmetadataRow(uuidSource.uuid, ffidMetadata.fileId,
       ffidMetadata.software,
       ffidMetadata.softwareVersion,

--- a/src/test/resources/json/addffidmetadata_data_no_ffid_matches.json
+++ b/src/test/resources/json/addffidmetadata_data_no_ffid_matches.json
@@ -1,0 +1,11 @@
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "No ffid matches for file 07a3a4bd-0281-4a6d-a4c1-8fa3239e1313",
+      "extensions": {
+        "code": "INVALID_INPUT_DATA"
+      }
+    }
+  ]
+}

--- a/src/test/resources/json/addffidmetadata_mutation_no_ffid_matches.json
+++ b/src/test/resources/json/addffidmetadata_mutation_no_ffid_matches.json
@@ -1,0 +1,3 @@
+{
+  "query": "mutation { addFFIDMetadata(addFFIDMetadataInput:  { fileId: \"07a3a4bd-0281-4a6d-a4c1-8fa3239e1313\",  software: \"pronom\",  softwareVersion: \"1.8.0\", binarySignatureFileVersion: \"DROID_SignatureFile_V96.xml\", containerSignatureFileVersion: \"container-signature-20200121.xml\",method: \"pronom\"matches: [    ]    }) { fileId software softwareVersion binarySignatureFileVersion containerSignatureFileVersion method datetime matches {identificationBasis puid extension} } }"
+}

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FFIDMetadataRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FFIDMetadataRouteSpec.scala
@@ -161,6 +161,14 @@ class FFIDMetadataRouteSpec extends AnyFlatSpec with Matchers with TestRequest w
     checkNoFFIDMetadataAdded()
   }
 
+  "addFFIDMetadata" should "throw an error if there are no ffid matches" in {
+    val expectedResponse: GraphqlMutationData = expectedMutationResponse("data_no_ffid_matches")
+    val response: GraphqlMutationData = runTestMutation("mutation_no_ffid_matches", validBackendChecksToken("file_format"))
+    response.errors.head.extensions should equal (expectedResponse.errors.head.extensions)
+    response.errors.head.message should equal (expectedResponse.errors.head.message)
+    checkNoFFIDMetadataAdded()
+  }
+
   private def checkFFIDMetadataExists(fileId: UUID): Unit = {
     val sql = "select * from FFIDMetadata where FileId = ?;"
     val ps: PreparedStatement = DbConnection.db.source.createConnection().prepareStatement(sql)


### PR DESCRIPTION
There is the potential that no ffid matches are returned

When this happens no ffid metadata should be added to prevent invalid data being stored in the database