### PR TITLE
Move DbConnection.db from the Routes constructor.

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/http/ApiServer.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/http/ApiServer.scala
@@ -5,7 +5,6 @@ import akka.http.scaladsl.Http
 import akka.stream.Materializer
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.Logger
-import uk.gov.nationalarchives.tdr.api.db.DbConnection
 
 import scala.concurrent.Await
 import scala.language.postfixOps
@@ -22,7 +21,7 @@ object ApiServer extends App {
 
   scala.sys.addShutdownHook(() -> shutdown())
 
-  val routes = new Routes(ConfigFactory.load(), DbConnection.db)
+  val routes = new Routes(ConfigFactory.load())
 
   Http().bindAndHandle(routes.route, "0.0.0.0", PORT)
   logger.info(s"Consignment API is running")

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/http/Routes.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/http/Routes.scala
@@ -15,9 +15,9 @@ import com.typesafe.config._
 import com.typesafe.scalalogging.Logger
 import sangria.ast.{Field, OperationDefinition}
 import sangria.parser.QueryParser
-import slick.jdbc.PostgresProfile.api._
 import spray.json.{JsObject, JsString, JsValue}
 import uk.gov.nationalarchives.tdr.api.auth.AuthorisationException
+import uk.gov.nationalarchives.tdr.api.db.DbConnection
 import uk.gov.nationalarchives.tdr.api.service.FullHealthCheckService
 import uk.gov.nationalarchives.tdr.keycloak.{KeycloakUtils, TdrKeycloakDeployment, Token}
 
@@ -25,7 +25,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
 import scala.util.{Failure, Success}
 
-class Routes(val config: Config, db: Database) extends Cors {
+class Routes(val config: Config) extends Cors {
   val url: String = config.getString("auth.url")
 
   implicit val system: ActorSystem = ActorSystem("consignmentApi")
@@ -79,7 +79,7 @@ class Routes(val config: Config, db: Database) extends Cors {
         complete(StatusCodes.OK)
       } ~ (get & path("healthcheck-full")) {
         val fullHealthCheck = new FullHealthCheckService()
-        onSuccess(fullHealthCheck.checkDbIsUpAndRunning(db)) {
+        onSuccess(fullHealthCheck.checkDbIsUpAndRunning(DbConnection.db)) {
           complete(StatusCodes.OK)
         }
       }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/CorsSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/CorsSpec.scala
@@ -6,7 +6,6 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import uk.gov.nationalarchives.tdr.api.db.DbConnection
 import uk.gov.nationalarchives.tdr.api.http.Routes
 
 import scala.jdk.CollectionConverters._
@@ -19,7 +18,7 @@ class CorsSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest {
 
   private val config = ConfigFactory.load()
     .withValue("frontend.urls", ConfigValueFactory.fromIterable(crossOriginUrls))
-  private val route = new Routes(config, DbConnection.db).route
+  private val route = new Routes(config).route
 
   "the pre-flight request" should "allow credentials, required headers and methods" in {
     Options("/graphql") ~> route ~> check {
@@ -65,7 +64,7 @@ class CorsSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest {
 
     val testConfig = ConfigFactory.load()
       .withValue("frontend.urls", ConfigValueFactory.fromIterable(crossOriginUrls))
-    val testRoute = new Routes(testConfig, DbConnection.db).route
+    val testRoute = new Routes(testConfig).route
 
     val headers = List(Origin(allowedDomain))
 
@@ -81,7 +80,7 @@ class CorsSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest {
 
     val testConfig = ConfigFactory.load()
       .withValue("frontend.urls", ConfigValueFactory.fromIterable(crossOriginUrls))
-    val testRoute = new Routes(testConfig, DbConnection.db).route
+    val testRoute = new Routes(testConfig).route
 
     val headers = List(Origin(domainWithOtherPort))
 

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/RouteAuthenticationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/RouteAuthenticationSpec.scala
@@ -2,30 +2,21 @@ package uk.gov.nationalarchives.tdr.api.routes
 
 import akka.http.scaladsl.model.headers.HttpChallenge
 import akka.http.scaladsl.model.{ContentTypes, StatusCodes}
-import akka.http.scaladsl.server.AuthenticationFailedRejection
+import akka.http.scaladsl.server.{AuthenticationFailedRejection, Route}
 import akka.http.scaladsl.server.AuthenticationFailedRejection.{CredentialsMissing, CredentialsRejected}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import akka.stream.alpakka.slick.scaladsl.SlickSession
 import com.typesafe.config.ConfigFactory
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import scalacache.CacheConfig
-import scalacache.caffeine.CaffeineCache
-import slick.jdbc.JdbcBackend
-import slick.jdbc.hikaricp.HikariCPJdbcDataSource
-import uk.gov.nationalarchives.tdr.api.db.DbConnection
-import uk.gov.nationalarchives.tdr.api.db.DbConnection.getPassword
 import uk.gov.nationalarchives.tdr.api.http.Routes
 import uk.gov.nationalarchives.tdr.api.utils.TestDatabase
 import uk.gov.nationalarchives.tdr.api.utils.TestUtils.{addTransferringBody, invalidToken, validUserToken}
 
-import java.sql.PreparedStatement
 import java.util.UUID
-import scala.util.{Failure, Success}
 
 class RouteAuthenticationSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest with TestDatabase {
 
-  val route = new Routes(ConfigFactory.load(), DbConnection.db).route
+  val route: Route = new Routes(ConfigFactory.load()).route
 
   "The api" should "return ok" in {
     Get("/healthcheck") ~> route ~> check {
@@ -60,33 +51,6 @@ class RouteAuthenticationSpec extends AnyFlatSpec with Matchers with ScalatestRo
   }
 
   "The db" should "return 500 Internal Server Error if there are no transferring bodies in the db" in {
-    Get("/healthcheck-full") ~> route ~> check {
-      status shouldEqual StatusCodes.InternalServerError
-    }
-  }
-
-  "The db" should "return 500 Internal Server Error if the db is down" in {
-    object DbConnectionTest {
-      implicit val passwordCache: CaffeineCache[String] = CaffeineCache[String](CacheConfig())
-      val db: JdbcBackend#DatabaseDef = SlickSession.forConfig("consignmentapi").db
-
-      def addTransferringBody(id: UUID, name: String, code: String): Unit = {
-        val sql = s"INSERT INTO Body (BodyId, Name, TdrCode) VALUES (?, ?, ?)"
-        val ps: PreparedStatement = this.db.source.createConnection().prepareStatement(sql)
-        ps.setString(1, id.toString)
-        ps.setString(2, name)
-        ps.setString(3, code)
-
-        ps.executeUpdate()
-      }
-    }
-
-    val testDb = DbConnectionTest.db
-    /* Add transferring body to ensure that the 'Internal Server Error' produced by this test is due to db being closed
-     and not due to db not having any transferring bodies */
-    DbConnectionTest.addTransferringBody(UUID.randomUUID(), "MOCK Department", "Code")
-    val route = new Routes(ConfigFactory.load(), testDb).route
-    testDb.close()
     Get("/healthcheck-full") ~> route ~> check {
       status shouldEqual StatusCodes.InternalServerError
     }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/RoutesSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/RoutesSpec.scala
@@ -16,7 +16,7 @@ import scala.jdk.CollectionConverters._
 class RoutesSpec extends AnyFlatSpec with BeforeAndAfterEach with TestRequest {
 
   private val logCaptor = LogCaptor.forClass(classOf[Routes])
-  private val routes = new Routes(ConfigFactory.load(), DbConnection.db)
+  private val routes = new Routes(ConfigFactory.load())
 
   override def beforeEach(): Unit = {
     logCaptor.clearLogs()

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestRequest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestRequest.scala
@@ -8,7 +8,6 @@ import com.typesafe.config.ConfigFactory
 import io.circe.Decoder
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import uk.gov.nationalarchives.tdr.api.db.DbConnection
 import uk.gov.nationalarchives.tdr.api.http.Routes
 import uk.gov.nationalarchives.tdr.api.utils.TestUtils.unmarshalResponse
 
@@ -17,7 +16,7 @@ import scala.reflect.ClassTag
 
 trait TestRequest extends AnyFlatSpec with ScalatestRouteTest with Matchers {
 
-  val route = new Routes(ConfigFactory.load(), DbConnection.db).route
+  val route = new Routes(ConfigFactory.load()).route
 
   def runTestRequest[A](prefix: String)(queryFileName: String, token: OAuth2BearerToken)
                        (implicit decoder: Decoder[A], classTag: ClassTag[A])


### PR DESCRIPTION
What I think is happening is that DbConnection.db is being called when the API starts which is caching the current IAM password but then it's never being called again so we never get an updated passsword. I've removed it from the Routes constructor and added called it within the route definition.

I've moved the test which runs against the closed database out of the RouteAuthenticationSpec as it's not possible to do it in there now and added it into the FullHealthCheckServiceSpec class.
