### PR TITLE
Use base alpine image with jdk 15 installed.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:15-jdk-alpine
+FROM alpine
 #For alpine versions need to create a group before adding a user to the image
 WORKDIR /api
 RUN addgroup --system apigroup && adduser --system apiuser -G apigroup && \
@@ -6,7 +6,8 @@ RUN addgroup --system apigroup && adduser --system apiuser -G apigroup && \
     apk upgrade p11-kit busybox && \
     apk add ca-certificates && \
     chown -R apiuser /api && \
-    wget https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem
+    wget https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && \
+    apk add openjdk15 --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
 COPY target/scala-2.13/consignmentapi.jar /api
 
 USER apiuser


### PR DESCRIPTION
We have tried upgrading busybox on the openjdk image but it seems to be
on an older version of alpine and there are still vulnerabilities in the
latest version of busybox for that version.

Instead of using the openjdk image, I've changed this to use the
standard alpine image and installed openjdk 15 from the alpine edge
repository.

I've tested this on integration and it's working.
