### PR TITLE
Add check for judgment puid allow list

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileRepository.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileRepository.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import slick.jdbc.PostgresProfile.api._
 import uk.gov.nationalarchives.Tables
-import uk.gov.nationalarchives.Tables.{Avmetadata, Consignment, Consignmentstatus, ConsignmentstatusRow, File, FileRow, Filemetadata, FilemetadataRow, Series}
+import uk.gov.nationalarchives.Tables.{Avmetadata, Consignment, Consignmentstatus, ConsignmentstatusRow, File, FileRow, Filemetadata, FilemetadataRow}
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileRepository.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileRepository.scala
@@ -1,14 +1,15 @@
 package uk.gov.nationalarchives.tdr.api.db.repository
 
 import java.util.UUID
+
 import slick.jdbc.PostgresProfile.api._
 import uk.gov.nationalarchives.Tables
-import uk.gov.nationalarchives.Tables.{Avmetadata, Consignmentstatus, ConsignmentstatusRow, File, FileRow, Filemetadata, FilemetadataRow}
+import uk.gov.nationalarchives.Tables.{Avmetadata, Consignment, Consignmentstatus, ConsignmentstatusRow, File, FileRow, Filemetadata, FilemetadataRow, Series}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class FileRepository(db: Database)(implicit val executionContext: ExecutionContext) {
-  private val insertFileQuery = File  returning File.map(_.fileid)into ((file, fileid) => file.copy(fileid = fileid))
+  private val insertFileQuery = File returning File.map(_.fileid)into ((file, fileid) => file.copy(fileid = fileid))
 
   def getFilesWithPassedAntivirus(consignmentId: UUID): Future[Seq[Tables.FileRow]] = {
     val query = Avmetadata.join(File)
@@ -16,6 +17,14 @@ class FileRepository(db: Database)(implicit val executionContext: ExecutionConte
       .filter(_._2.consignmentid === consignmentId)
       .filter(_._1.result === "")
       .map(_._2)
+    db.run(query.result)
+  }
+
+  def getConsignmentForFile(fileId: UUID): Future[Seq[Tables.ConsignmentRow]] = {
+    val query = File.join(Consignment)
+      .on(_.consignmentid === _.consignmentid)
+      .filter(_._1.fileid === fileId)
+      .map(rows => rows._2)
     db.run(query.result)
   }
 

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/http/GraphQLServer.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/http/GraphQLServer.scala
@@ -92,7 +92,7 @@ object GraphQLServer {
     val clientFileMetadataService = new ClientFileMetadataService(fileMetadataRepository)
     val antivirusMetadataService = new AntivirusMetadataService(antivirusMetadataRepository, uuidSource, timeSource)
     val fileMetadataService = new FileMetadataService(fileMetadataRepository, timeSource, uuidSource)
-    val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepository, ffidMetadataMatchesRepository, timeSource, uuidSource)
+    val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepository, ffidMetadataMatchesRepository, fileRepository, timeSource, uuidSource)
     val fileService = new FileService(fileRepository,consignmentRepository,consignmentStatusRepository, fileMetadataService,
       ffidMetadataService, antivirusMetadataService, new CurrentTimeSource, uuidSource)
     val consignmentStatusService = new ConsignmentStatusService(consignmentStatusRepository, timeSource)

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FFIDMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FFIDMetadataService.scala
@@ -78,6 +78,8 @@ class FFIDMetadataService(ffidMetadataRepository: FFIDMetadataRepository,
 
   private def generateFileStatusRows(ffidMetadata: FFIDMetadataInput): Future[List[FilestatusRow]] = {
     val fileId = ffidMetadata.fileId
+    val timestamp = Timestamp.from(timeSource.now)
+
     for {
       consignments <- fileRepository.getConsignmentForFile(fileId)
       consignmentType = if (consignments.isEmpty) { throw InputDataException(s"No consignment found for file $fileId") }
@@ -85,9 +87,9 @@ class FFIDMetadataService(ffidMetadataRepository: FFIDMetadataRepository,
       uniqueStatuses: List[String] = ffidMetadata.matches.map(m => checkStatus(m.puid, consignmentType)).distinct
       rows = uniqueStatuses match {
         case s if uniqueStatuses.size == 1 =>
-          List(FilestatusRow(uuidSource.uuid, ffidMetadata.fileId, FFID, s.head, Timestamp.from(timeSource.now)))
+          List(FilestatusRow(uuidSource.uuid, fileId, FFID, s.head, timestamp))
         case _ => uniqueStatuses.filterNot(_.equals(Success)).map(
-          FilestatusRow(uuidSource.uuid, ffidMetadata.fileId, FFID, _, Timestamp.from(timeSource.now)))
+          FilestatusRow(uuidSource.uuid, fileId, FFID, _, timestamp))
       }
     } yield rows
   }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FFIDMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FFIDMetadataService.scala
@@ -3,20 +3,23 @@ package uk.gov.nationalarchives.tdr.api.service
 import com.typesafe.scalalogging.Logger
 import uk.gov.nationalarchives
 import uk.gov.nationalarchives.Tables
-
 import java.sql.{SQLException, Timestamp}
 import java.util.UUID
+
 import uk.gov.nationalarchives.Tables.{FfidmetadataRow, FfidmetadatamatchesRow, FilestatusRow}
-import uk.gov.nationalarchives.tdr.api.db.repository.{FFIDMetadataMatchesRepository, FFIDMetadataRepository}
+import uk.gov.nationalarchives.tdr.api.db.repository.{FFIDMetadataMatchesRepository, FFIDMetadataRepository, FileRepository}
 import uk.gov.nationalarchives.tdr.api.graphql.DataExceptions.InputDataException
 import uk.gov.nationalarchives.tdr.api.graphql.fields.FFIDMetadataFields.{FFIDMetadata, FFIDMetadataInput, FFIDMetadataMatches}
-import uk.gov.nationalarchives.tdr.api.service.FileStatusService.{FFID, PasswordProtected, Success, Zip}
+import uk.gov.nationalarchives.tdr.api.service.FileStatusService.{FFID, NonJudgmentFormat, PasswordProtected, Success, Zip}
 import net.logstash.logback.argument.StructuredArguments._
+import uk.gov.nationalarchives.tdr.api.model.consignment.ConsignmentType
 import uk.gov.nationalarchives.tdr.api.utils.LoggingUtils
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class FFIDMetadataService(ffidMetadataRepository: FFIDMetadataRepository, matchesRepository: FFIDMetadataMatchesRepository,
+class FFIDMetadataService(ffidMetadataRepository: FFIDMetadataRepository,
+                          matchesRepository: FFIDMetadataMatchesRepository,
+                          fileRepository: FileRepository,
                           timeSource: TimeSource, uuidSource: UUIDSource)(implicit val executionContext: ExecutionContext) {
 
   val loggingUtils: LoggingUtils = LoggingUtils(Logger("FFIDMetadataService"))
@@ -28,6 +31,7 @@ class FFIDMetadataService(ffidMetadataRepository: FFIDMetadataRepository, matche
     "fmt/1105", "fmt/1190", "fmt/1242", "fmt/1243", "fmt/1244", "fmt/1245", "fmt/1251", "fmt/1252", "fmt/1281", "fmt/1340",
     "fmt/1341", "fmt/1355", "fmt/1361", "fmt/1399", "x-fmt/157", "x-fmt/219", "x-fmt/263", "x-fmt/265", "x-fmt/266", "x-fmt/267",
     "x-fmt/268", "x-fmt/269", "x-fmt/412", "x-fmt/416", "x-fmt/429")
+  val judgmentPuidsAllow: List[String] = List("fmt/412", "fmt/523", "fmt/597")
 
   def addFFIDMetadata(ffidMetadata: FFIDMetadataInput): Future[FFIDMetadata] = {
 
@@ -43,16 +47,14 @@ class FFIDMetadataService(ffidMetadataRepository: FFIDMetadataRepository, matche
       ffidMetadata.containerSignatureFileVersion,
       ffidMetadata.method)
 
-    val fileStatusRows = generateFileStatusRows(ffidMetadata)
-
-    loggingUtils.logFileFormatStatus("FFID", ffidMetadata.fileId, fileStatusRows.map(_.value).mkString(","))
-
     def addFFIDMetadataMatches(ffidmetadataid: UUID): Future[Seq[Tables.FfidmetadatamatchesRow]] = {
       val matchRows = ffidMetadata.matches.map(m => FfidmetadatamatchesRow(ffidmetadataid, m.extension, m.identificationBasis, m.puid))
       matchesRepository.addFFIDMetadataMatches(matchRows)
     }
 
     (for {
+      fileStatusRows <- generateFileStatusRows(ffidMetadata)
+      _ = loggingUtils.logFileFormatStatus("FFID", ffidMetadata.fileId, fileStatusRows.map(_.value).mkString(","))
       ffidMetadataRow <- ffidMetadataRepository.addFFIDMetadata(metadataRow, fileStatusRows)
       ffidMetadataMatchesRow <- addFFIDMetadataMatches(ffidMetadataRow.ffidmetadataid)
     } yield {
@@ -74,26 +76,33 @@ class FFIDMetadataService(ffidMetadataRepository: FFIDMetadataRepository, matche
     }
   }
 
-  private def generateFileStatusRows(ffidMetadata: FFIDMetadataInput): List[FilestatusRow] = {
-    val uniqueStatuses: List[String] = ffidMetadata.matches.map(m => checkStatus(m.puid)).distinct
-
-    uniqueStatuses match {
-      case s if uniqueStatuses.size == 1 =>
-        List(FilestatusRow(uuidSource.uuid, ffidMetadata.fileId, FFID, s.head, Timestamp.from(timeSource.now)))
-      case _ => uniqueStatuses.filterNot(_.equals(Success)).map(
-        FilestatusRow(uuidSource.uuid, ffidMetadata.fileId, FFID, _, Timestamp.from(timeSource.now)))
-    }
+  private def generateFileStatusRows(ffidMetadata: FFIDMetadataInput): Future[List[FilestatusRow]] = {
+    val fileId = ffidMetadata.fileId
+    for {
+      consignments <- fileRepository.getConsignmentForFile(fileId)
+      consignmentType = if (consignments.isEmpty) { throw InputDataException(s"No consignment found for file $fileId") }
+        else { consignments.head.consignmenttype }
+      uniqueStatuses: List[String] = ffidMetadata.matches.map(m => checkStatus(m.puid, consignmentType)).distinct
+      rows = uniqueStatuses match {
+        case s if uniqueStatuses.size == 1 =>
+          List(FilestatusRow(uuidSource.uuid, ffidMetadata.fileId, FFID, s.head, Timestamp.from(timeSource.now)))
+        case _ => uniqueStatuses.filterNot(_.equals(Success)).map(
+          FilestatusRow(uuidSource.uuid, ffidMetadata.fileId, FFID, _, Timestamp.from(timeSource.now)))
+      }
+    } yield rows
   }
 
-  private def checkStatus(puid: Option[String]): String = {
+  def checkStatus(puid: Option[String], consignmentType: String): String = {
     puid.getOrElse("") match {
       case p if passwordProtectedPuids.contains(p) => PasswordProtected
       case p if zipPuids.contains(p) => Zip
+      case p if consignmentType == ConsignmentType.judgment && !judgmentPuidsAllow.contains(p) => NonJudgmentFormat
       case _ => Success
     }
   }
 
-  private def rowToFFIDMetadata(ffidMetadataRow: nationalarchives.Tables.FfidmetadataRow, ffidMetadataMatchesRow: Seq[FfidmetadatamatchesRow]) = {
+  private def rowToFFIDMetadata(ffidMetadataRow: nationalarchives.Tables.FfidmetadataRow,
+                                ffidMetadataMatchesRow: Seq[FfidmetadatamatchesRow]): FFIDMetadata = {
     FFIDMetadata(
       ffidMetadataRow.fileid,
       ffidMetadataRow.software,

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileStatusService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileStatusService.scala
@@ -4,6 +4,8 @@ import uk.gov.nationalarchives.tdr.api.db.repository.FileStatusRepository
 import uk.gov.nationalarchives.tdr.api.service.FileStatusService.{Antivirus, Checksum, FFID, Success}
 import java.util.UUID
 
+import uk.gov.nationalarchives.tdr.api.model.consignment.ConsignmentType
+
 import scala.concurrent.{ExecutionContext, Future}
 
 class FileStatusService(fileStatusRepository: FileStatusRepository)(implicit val executionContext: ExecutionContext) {
@@ -32,4 +34,5 @@ object FileStatusService {
   val VirusDetected = "VirusDetected"
   val PasswordProtected = "PasswordProtected"
   val Zip = "Zip"
+  val NonJudgmentFormat = "NonJudgmentFormat"
 }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileStatusService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileStatusService.scala
@@ -4,8 +4,6 @@ import uk.gov.nationalarchives.tdr.api.db.repository.FileStatusRepository
 import uk.gov.nationalarchives.tdr.api.service.FileStatusService.{Antivirus, Checksum, FFID, Success}
 import java.util.UUID
 
-import uk.gov.nationalarchives.tdr.api.model.consignment.ConsignmentType
-
 import scala.concurrent.{ExecutionContext, Future}
 
 class FileStatusService(fileStatusRepository: FileStatusRepository)(implicit val executionContext: ExecutionContext) {

--- a/src/test/resources/json/addffidmetadata_data_fileid_not_exists.json
+++ b/src/test/resources/json/addffidmetadata_data_fileid_not_exists.json
@@ -2,7 +2,7 @@
   "data": null,
   "errors": [
     {
-      "message": "Referential integrity constraint violation: \"CONSTRAINT_C5: PUBLIC.FFIDMetadata FOREIGN KEY(FileId) REFERENCES PUBLIC.File(FileId) ('16b8c5f9-9d72-4d12-af06-4c2749823ebd')\"; SQL statement:\ninsert into \"FFIDMetadata\" (\"FFIDMetadataId\",\"FileId\",\"Software\",\"SoftwareVersion\",\"Datetime\",\"BinarySignatureFileVersion\",\"ContainerSignatureFileVersion\",\"Method\")  values (?,?,?,?,?,?,?,?) [23506-200]",
+      "message": "No consignment found for file 16b8c5f9-9d72-4d12-af06-4c2749823ebd",
       "extensions": {
         "code": "INVALID_INPUT_DATA"
       }

--- a/src/test/resources/json/addffidmetadata_mutation_status_judgment_format.json
+++ b/src/test/resources/json/addffidmetadata_mutation_status_judgment_format.json
@@ -1,0 +1,3 @@
+{
+  "query": "mutation { addFFIDMetadata(addFFIDMetadataInput:  { fileId: \"07a3a4bd-0281-4a6d-a4c1-8fa3239e1313\",  software: \"pronom\",  softwareVersion: \"1.8.0\", binarySignatureFileVersion: \"DROID_SignatureFile_V96.xml\", containerSignatureFileVersion: \"container-signature-20200121.xml\",method: \"pronom\"matches: [    {        extension: \"txt\", identificationBasis: \"Some basis\", puid: \"fmt/412\"     }    ]    }) { fileId software softwareVersion binarySignatureFileVersion containerSignatureFileVersion method datetime matches {identificationBasis puid extension} } }"
+}

--- a/src/test/resources/json/addffidmetadata_mutation_status_judgment_format_zip.json
+++ b/src/test/resources/json/addffidmetadata_mutation_status_judgment_format_zip.json
@@ -1,0 +1,3 @@
+{
+  "query": "mutation { addFFIDMetadata(addFFIDMetadataInput:  { fileId: \"07a3a4bd-0281-4a6d-a4c1-8fa3239e1313\",  software: \"pronom\",  softwareVersion: \"1.8.0\", binarySignatureFileVersion: \"DROID_SignatureFile_V96.xml\", containerSignatureFileVersion: \"container-signature-20200121.xml\",method: \"pronom\"matches: [  {        extension: \"txt\", identificationBasis: \"Some basis\", puid: \"fmt/289\"     },  {        extension: \"txt\", identificationBasis: \"Some basis\", puid: \"fmt/412\"     }    ]    }) { fileId software softwareVersion binarySignatureFileVersion containerSignatureFileVersion method datetime matches {identificationBasis puid extension} } }"
+}

--- a/src/test/resources/json/addffidmetadata_mutation_status_judgment_multiple_success.json
+++ b/src/test/resources/json/addffidmetadata_mutation_status_judgment_multiple_success.json
@@ -1,0 +1,3 @@
+{
+  "query": "mutation { addFFIDMetadata(addFFIDMetadataInput:  { fileId: \"07a3a4bd-0281-4a6d-a4c1-8fa3239e1313\",  software: \"pronom\",  softwareVersion: \"1.8.0\", binarySignatureFileVersion: \"DROID_SignatureFile_V96.xml\", containerSignatureFileVersion: \"container-signature-20200121.xml\",method: \"pronom\"matches: [    {        extension: \"txt\", identificationBasis: \"Some basis\", puid: \"fmt/412\"     }, {        extension: \"txt\", identificationBasis: \"Some basis\", puid: \"fmt/523\"     }    ]    }) { fileId software softwareVersion binarySignatureFileVersion containerSignatureFileVersion method datetime matches {identificationBasis puid extension} } }"
+}

--- a/src/test/resources/json/addffidmetadata_mutation_status_judgment_password_protected_success.json
+++ b/src/test/resources/json/addffidmetadata_mutation_status_judgment_password_protected_success.json
@@ -1,0 +1,3 @@
+{
+  "query": "mutation { addFFIDMetadata(addFFIDMetadataInput:  { fileId: \"07a3a4bd-0281-4a6d-a4c1-8fa3239e1313\",  software: \"pronom\",  softwareVersion: \"1.8.0\", binarySignatureFileVersion: \"DROID_SignatureFile_V96.xml\", containerSignatureFileVersion: \"container-signature-20200121.xml\",method: \"pronom\"matches: [    {        extension: \"txt\", identificationBasis: \"Some basis\", puid: \"fmt/494\"     }, {       extension: \"txt\", identificationBasis: \"Some basis\", puid: \"fmt/412\"    }    ]    }) { fileId software softwareVersion binarySignatureFileVersion containerSignatureFileVersion method datetime matches {identificationBasis puid extension} } }"
+}

--- a/src/test/resources/json/addffidmetadata_mutation_status_judgment_zip_success.json
+++ b/src/test/resources/json/addffidmetadata_mutation_status_judgment_zip_success.json
@@ -1,0 +1,3 @@
+{
+  "query": "mutation { addFFIDMetadata(addFFIDMetadataInput:  { fileId: \"07a3a4bd-0281-4a6d-a4c1-8fa3239e1313\",  software: \"pronom\",  softwareVersion: \"1.8.0\", binarySignatureFileVersion: \"DROID_SignatureFile_V96.xml\", containerSignatureFileVersion: \"container-signature-20200121.xml\",method: \"pronom\"matches: [    {        extension: \"txt\", identificationBasis: \"Some basis\", puid: \"fmt/289\"     }, {       extension: \"txt\", identificationBasis: \"Some basis\", puid: \"fmt/412\"    }    ]    }) { fileId software softwareVersion binarySignatureFileVersion containerSignatureFileVersion method datetime matches {identificationBasis puid extension} } }"
+}

--- a/src/test/resources/json/addffidmetadata_mutation_status_non_judgment_format.json
+++ b/src/test/resources/json/addffidmetadata_mutation_status_non_judgment_format.json
@@ -1,0 +1,3 @@
+{
+  "query": "mutation { addFFIDMetadata(addFFIDMetadataInput:  { fileId: \"07a3a4bd-0281-4a6d-a4c1-8fa3239e1313\",  software: \"pronom\",  softwareVersion: \"1.8.0\", binarySignatureFileVersion: \"DROID_SignatureFile_V96.xml\", containerSignatureFileVersion: \"container-signature-20200121.xml\",method: \"pronom\"matches: [    {        extension: \"txt\", identificationBasis: \"Some basis\", puid: \"x-fmt/111\"     }    ]    }) { fileId software softwareVersion binarySignatureFileVersion containerSignatureFileVersion method datetime matches {identificationBasis puid extension} } }"
+}

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileRepositorySpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileRepositorySpec.scala
@@ -157,6 +157,21 @@ class FileRepositorySpec extends AnyFlatSpec with TestDatabase with ScalaFutures
     files.head.fileid shouldBe fileOneId
   }
 
+  "getConsignmentForFile" should "return the correct consignment for the given file id" in {
+    val db = DbConnection.db
+    val fileRepository = new FileRepository(db)
+    val consignmentId = UUID.fromString("dba4515f-474c-4a5a-a297-260b6ba1ffa3")
+    val fileOneId = UUID.fromString("92756098-b394-4f46-8b4d-bbd1953660c9")
+
+    TestUtils.createConsignment(consignmentId, userId)
+    TestUtils.createFile(fileOneId, consignmentId)
+
+    val files = fileRepository.getConsignmentForFile(fileOneId).futureValue
+
+    files.size shouldBe 1
+    files.head.consignmentid shouldBe consignmentId
+  }
+
   private def checkConsignmentStatusExists(consignmentId: UUID): Unit = {
     val sql = "SELECT * FROM ConsignmentStatus WHERE ConsignmentId = ?"
     val ps:PreparedStatement = DbConnection.db.source.createConnection().prepareStatement(sql)

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FFIDMetadataRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FFIDMetadataRouteSpec.scala
@@ -10,7 +10,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import uk.gov.nationalarchives.tdr.api.db.DbConnection
 import uk.gov.nationalarchives.tdr.api.graphql.fields.FFIDMetadataFields.FFIDMetadata
-import uk.gov.nationalarchives.tdr.api.service.FileStatusService.{FFID, PasswordProtected, Success, Zip}
+import uk.gov.nationalarchives.tdr.api.service.FileStatusService.{FFID, NonJudgmentFormat, PasswordProtected, Success, Zip}
 import uk.gov.nationalarchives.tdr.api.utils.TestUtils._
 import uk.gov.nationalarchives.tdr.api.utils.{TestDatabase, TestRequest}
 
@@ -31,11 +31,11 @@ class FFIDMetadataRouteSpec extends AnyFlatSpec with Matchers with TestRequest w
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-
-    seedDatabaseWithDefaultEntries()
   }
 
   "addFFIDMetadata" should "return all requested fields from inserted file format object" in {
+    seedDatabaseWithDefaultEntries()
+
     val expectedResponse: GraphqlMutationData = expectedMutationResponse("data_all")
     val response: GraphqlMutationData = runTestMutation("mutation_alldata", validBackendChecksToken("file_format"))
     val metadata: FFIDMetadata = response.data.get.addFFIDMetadata
@@ -58,7 +58,9 @@ class FFIDMetadataRouteSpec extends AnyFlatSpec with Matchers with TestRequest w
     checkFFIDMetadataExists(response.data.get.addFFIDMetadata.fileId)
   }
 
-  "addFFIDMetadata" should "set a single file status to success when a success match only is found" in {
+  "addFFIDMetadata" should "set a single file status to 'Success' when a success match only is found for 'standard' consignment type" in {
+    seedDatabaseWithDefaultEntries()
+
     runTestMutation("mutation_alldata", validBackendChecksToken("file_format"))
 
     val result = getFileStatusResult(defaultFileId, FFID)
@@ -66,7 +68,42 @@ class FFIDMetadataRouteSpec extends AnyFlatSpec with Matchers with TestRequest w
     result.head should equal(Success)
   }
 
-  "addFFIDMetadata" should "set a single file status of success when there are multiple success matches only found" in {
+  "addFFIDMetadata" should "set a single file status to 'Success' when a success match only is found for 'judgment' consignment type" in {
+    seedDatabaseWithDefaultEntries("judgment")
+
+    runTestMutation("mutation_status_judgment_format", validBackendChecksToken("file_format"))
+
+    val result = getFileStatusResult(defaultFileId, FFID)
+    result.size should be(1)
+    result.head should equal(Success)
+  }
+
+  "addFFIDMetadata" should
+      "set a single file status to 'Success' when a non judgment match only is found for 'standard' consignment type" in {
+    seedDatabaseWithDefaultEntries()
+
+    runTestMutation("mutation_status_non_judgment_format", validBackendChecksToken("file_format"))
+
+    val result = getFileStatusResult(defaultFileId, FFID)
+    result.size should be(1)
+    result.head should equal(Success)
+  }
+
+  "addFFIDMetadata" should
+      "set a single file status to 'NonJudgmentRecord' when a non judgment match only is found for 'judgment' consignment type" in {
+    seedDatabaseWithDefaultEntries("judgment")
+
+    runTestMutation("mutation_status_non_judgment_format", validBackendChecksToken("file_format"))
+
+    val result = getFileStatusResult(defaultFileId, FFID)
+    result.size should be(1)
+    result.head should equal(NonJudgmentFormat)
+  }
+
+  "addFFIDMetadata" should
+      "set a single file status of 'Success' when there are multiple success matches only found for 'standard' consignment type" in {
+    seedDatabaseWithDefaultEntries()
+
     runTestMutation("mutation_status_multiple_success", validBackendChecksToken("file_format"))
 
     val result = getFileStatusResult(defaultFileId, FFID)
@@ -74,7 +111,21 @@ class FFIDMetadataRouteSpec extends AnyFlatSpec with Matchers with TestRequest w
     result.head should equal(Success)
   }
 
-  "addFFIDMetadata" should "set a single file status of password protected when a password protected match only is found" in {
+  "addFFIDMetadata" should
+      "set a single file status of 'Success' when there are multiple success matches only found for 'judgment' consignment type" in {
+    seedDatabaseWithDefaultEntries("judgment")
+
+    runTestMutation("mutation_status_judgment_multiple_success", validBackendChecksToken("file_format"))
+
+    val result = getFileStatusResult(defaultFileId, FFID)
+    result.size should be(1)
+    result.head should equal(Success)
+  }
+
+  "addFFIDMetadata" should
+      "set a single file status of 'PasswordProtected' when a password protected match only is found for 'standard' consignment type" in {
+    seedDatabaseWithDefaultEntries()
+
     runTestMutation("mutation_status_password_protected", validBackendChecksToken("file_format"))
 
     val result = getFileStatusResult(defaultFileId, FFID)
@@ -82,7 +133,21 @@ class FFIDMetadataRouteSpec extends AnyFlatSpec with Matchers with TestRequest w
     result.head should equal(PasswordProtected)
   }
 
-  "addFFIDMetadata" should "set a single file status of password protected when multiple password protected matches are found" in {
+  "addFFIDMetadata" should
+      "set a single file status of 'PasswordProtected' when a password protected match only is found for 'judgment' consignment type" in {
+    seedDatabaseWithDefaultEntries("judgment")
+
+    runTestMutation("mutation_status_password_protected", validBackendChecksToken("file_format"))
+
+    val result = getFileStatusResult(defaultFileId, FFID)
+    result.size should be(1)
+    result.head should equal(PasswordProtected)
+  }
+
+  "addFFIDMetadata" should
+      "set a single file status of 'PasswordProtected' when multiple password protected matches are found for 'standard' consignment type" in {
+    seedDatabaseWithDefaultEntries()
+
     runTestMutation("mutation_status_multiple_password_protected", validBackendChecksToken("file_format"))
 
     val result = getFileStatusResult(defaultFileId, FFID)
@@ -90,7 +155,21 @@ class FFIDMetadataRouteSpec extends AnyFlatSpec with Matchers with TestRequest w
     result.head should equal(PasswordProtected)
   }
 
-  "addFFIDMetadata" should "set a single status of password protected when password protected and success matches are found" in {
+  "addFFIDMetadata" should
+      "set a single file status of 'PasswordProtected' when multiple password protected matches are found for 'judgment' consignment type" in {
+    seedDatabaseWithDefaultEntries("judgment")
+
+    runTestMutation("mutation_status_multiple_password_protected", validBackendChecksToken("file_format"))
+
+    val result = getFileStatusResult(defaultFileId, FFID)
+    result.size should be(1)
+    result.head should equal(PasswordProtected)
+  }
+
+  "addFFIDMetadata" should
+      "set a single status of 'PasswordProtected' when password protected and success matches are found for 'standard' consignment type" in {
+    seedDatabaseWithDefaultEntries()
+
     runTestMutation("mutation_status_password_protected_success", validBackendChecksToken("file_format"))
 
     val result = getFileStatusResult(defaultFileId, FFID)
@@ -98,7 +177,21 @@ class FFIDMetadataRouteSpec extends AnyFlatSpec with Matchers with TestRequest w
     result.contains(PasswordProtected) should be(true)
   }
 
-  "addFFIDMetadata" should "set a single file status of zip when a zip match only is found" in {
+  "addFFIDMetadata" should
+      "set a single status of 'PasswordProtected' when password protected and success matches are found for 'judgment' consignment type" in {
+    seedDatabaseWithDefaultEntries("judgment")
+
+    runTestMutation("mutation_status_judgment_password_protected_success", validBackendChecksToken("file_format"))
+
+    val result = getFileStatusResult(defaultFileId, FFID)
+    result.size should be(1)
+    result.contains(PasswordProtected) should be(true)
+  }
+
+  "addFFIDMetadata" should
+      "set a single file status of 'Zip' when a zip match only is found for 'standard' consignment type" in {
+    seedDatabaseWithDefaultEntries()
+
     runTestMutation("mutation_status_zip", validBackendChecksToken("file_format"))
 
     val result = getFileStatusResult(defaultFileId, FFID)
@@ -106,7 +199,21 @@ class FFIDMetadataRouteSpec extends AnyFlatSpec with Matchers with TestRequest w
     result.contains(Zip) should be(true)
   }
 
-  "addFFIDMetadata" should "set a single file status of zip when multiple zip matches are found" in {
+  "addFFIDMetadata" should
+      "set a single file status of 'Zip' when a zip match only is found for 'judgment' consignment type" in {
+    seedDatabaseWithDefaultEntries("judgment")
+
+    runTestMutation("mutation_status_zip", validBackendChecksToken("file_format"))
+
+    val result = getFileStatusResult(defaultFileId, FFID)
+    result.size should be(1)
+    result.contains(Zip) should be(true)
+  }
+
+  "addFFIDMetadata" should
+      "set a single file status of 'Zip' when multiple zip matches are found for 'standard' consignment type" in {
+    seedDatabaseWithDefaultEntries()
+
     runTestMutation("mutation_status_multiple_zip", validBackendChecksToken("file_format"))
 
     val result = getFileStatusResult(defaultFileId, FFID)
@@ -114,7 +221,21 @@ class FFIDMetadataRouteSpec extends AnyFlatSpec with Matchers with TestRequest w
     result.head should equal(Zip)
   }
 
-  "addFFIDMetadata" should "set a single file status of zip when zip and success matches are found" in {
+  "addFFIDMetadata" should
+      "set a single file status of 'Zip' when multiple zip matches are found for 'judgment' consignment type" in {
+    seedDatabaseWithDefaultEntries("judgment")
+
+    runTestMutation("mutation_status_multiple_zip", validBackendChecksToken("file_format"))
+
+    val result = getFileStatusResult(defaultFileId, FFID)
+    result.size should be(1)
+    result.head should equal(Zip)
+  }
+
+  "addFFIDMetadata" should
+      "set a single file status of 'Zip' when zip and success matches are found for 'standard' consignment type" in {
+    seedDatabaseWithDefaultEntries()
+
     runTestMutation("mutation_status_zip_success", validBackendChecksToken("file_format"))
 
     val result = getFileStatusResult(defaultFileId, FFID)
@@ -122,7 +243,33 @@ class FFIDMetadataRouteSpec extends AnyFlatSpec with Matchers with TestRequest w
     result.head should equal(Zip)
   }
 
-  "addFFIDMetadata" should "set multiple file statuses when zip and password protected matches are found" in {
+  "addFFIDMetadata" should
+      "set a single file status of 'Zip' when zip and success matches are found for 'judgment' consignment type" in {
+    seedDatabaseWithDefaultEntries("judgment")
+
+    runTestMutation("mutation_status_judgment_zip_success", validBackendChecksToken("file_format"))
+
+    val result = getFileStatusResult(defaultFileId, FFID)
+    result.size should be(1)
+    result.head should equal(Zip)
+  }
+
+  "addFFIDMetadata" should
+      "set multiple file statuses when zip and password protected matches are found for 'standard' consignment type" in {
+    seedDatabaseWithDefaultEntries()
+
+    runTestMutation("mutation_status_zip_password_protected", validBackendChecksToken("file_format"))
+
+    val result = getFileStatusResult(defaultFileId, FFID)
+    result.size should be(2)
+    result.contains(Zip) should be(true)
+    result.contains(PasswordProtected) should be(true)
+  }
+
+  "addFFIDMetadata" should
+      "set multiple file statuses when zip and password protected matches are found for 'judgment' consignment type" in {
+    seedDatabaseWithDefaultEntries("judgment")
+
     runTestMutation("mutation_status_zip_password_protected", validBackendChecksToken("file_format"))
 
     val result = getFileStatusResult(defaultFileId, FFID)
@@ -132,6 +279,7 @@ class FFIDMetadataRouteSpec extends AnyFlatSpec with Matchers with TestRequest w
   }
 
   "addFFIDMetadata" should "not allow updating of file format metadata with incorrect authorisation" in {
+    seedDatabaseWithDefaultEntries()
     val response: GraphqlMutationData = runTestMutation("mutation_alldata", invalidBackendChecksToken())
 
     response.errors should have size 1
@@ -140,6 +288,8 @@ class FFIDMetadataRouteSpec extends AnyFlatSpec with Matchers with TestRequest w
   }
 
   "addFFIDMetadata" should "not allow updating of file format metadata with incorrect client role" in {
+    seedDatabaseWithDefaultEntries()
+
     val response: GraphqlMutationData = runTestMutation("mutation_alldata", validBackendChecksToken("antivirus"))
 
     response.errors should have size 1
@@ -148,6 +298,8 @@ class FFIDMetadataRouteSpec extends AnyFlatSpec with Matchers with TestRequest w
   }
 
   "addFFIDMetadata" should "throw an error if mandatory fields are missing" in {
+    seedDatabaseWithDefaultEntries()
+
     val expectedResponse: GraphqlMutationData = expectedMutationResponse("data_mandatory_missing")
     val response: GraphqlMutationData = runTestMutation("mutation_mandatorymissing", validBackendChecksToken("file_format"))
     response.errors.map(e => e.message.trim) should equal (expectedResponse.errors.map(_.message.trim))
@@ -155,6 +307,8 @@ class FFIDMetadataRouteSpec extends AnyFlatSpec with Matchers with TestRequest w
   }
 
   "addFFIDMetadata" should "throw an error if the file id does not exist" in {
+    seedDatabaseWithDefaultEntries()
+
     val expectedResponse: GraphqlMutationData = expectedMutationResponse("data_fileid_not_exists")
     val response: GraphqlMutationData = runTestMutation("mutation_fileidnotexists", validBackendChecksToken("file_format"))
     response.errors.head.message should equal (expectedResponse.errors.head.message)
@@ -162,6 +316,8 @@ class FFIDMetadataRouteSpec extends AnyFlatSpec with Matchers with TestRequest w
   }
 
   "addFFIDMetadata" should "throw an error if there are no ffid matches" in {
+    seedDatabaseWithDefaultEntries()
+
     val expectedResponse: GraphqlMutationData = expectedMutationResponse("data_no_ffid_matches")
     val response: GraphqlMutationData = runTestMutation("mutation_no_ffid_matches", validBackendChecksToken("file_format"))
     response.errors.head.extensions should equal (expectedResponse.errors.head.extensions)

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FFIDMetadataServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FFIDMetadataServiceSpec.scala
@@ -1,16 +1,16 @@
 package uk.gov.nationalarchives.tdr.api.service
 
 import org.mockito.ArgumentMatchers.any
-
 import java.sql.Timestamp
 import java.util.UUID
+
 import org.mockito.{ArgumentCaptor, MockitoSugar}
 import org.scalatest.Assertion
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import uk.gov.nationalarchives.Tables.{FfidmetadataRow, FfidmetadatamatchesRow, FilestatusRow}
-import uk.gov.nationalarchives.tdr.api.db.repository.{FFIDMetadataMatchesRepository, FFIDMetadataRepository}
+import uk.gov.nationalarchives.Tables.{ConsignmentRow, FfidmetadataRow, FfidmetadatamatchesRow, FilestatusRow}
+import uk.gov.nationalarchives.tdr.api.db.repository.{FFIDMetadataMatchesRepository, FFIDMetadataRepository, FileRepository}
 import uk.gov.nationalarchives.tdr.api.graphql.fields.FFIDMetadataFields.{FFIDMetadata, FFIDMetadataInput, FFIDMetadataInputMatches, FFIDMetadataMatches}
 import uk.gov.nationalarchives.tdr.api.utils.{FixedTimeSource, FixedUUIDSource}
 
@@ -22,7 +22,8 @@ class FFIDMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
   "passwordProtectedPuids list" should "match the expected list of pronom ids for password protected files" in {
     val expectedPuids = List("fmt/494", "fmt/754", "fmt/755")
 
-    val service = new FFIDMetadataService(mock[FFIDMetadataRepository], mock[FFIDMetadataMatchesRepository], FixedTimeSource, new FixedUUIDSource())
+    val service = new FFIDMetadataService(mock[FFIDMetadataRepository],
+      mock[FFIDMetadataMatchesRepository], mock[FileRepository], FixedTimeSource, new FixedUUIDSource())
     service.passwordProtectedPuids should equal(expectedPuids)
   }
 
@@ -34,22 +35,106 @@ class FFIDMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
       "fmt/1361", "fmt/1399", "x-fmt/157", "x-fmt/219", "x-fmt/263", "x-fmt/265", "x-fmt/266", "x-fmt/267", "x-fmt/268", "x-fmt/269",
       "x-fmt/412", "x-fmt/416", "x-fmt/429")
 
-    val service = new FFIDMetadataService(mock[FFIDMetadataRepository], mock[FFIDMetadataMatchesRepository], FixedTimeSource, new FixedUUIDSource())
+    val service = new FFIDMetadataService(mock[FFIDMetadataRepository], mock[FFIDMetadataMatchesRepository],
+      mock[FileRepository], FixedTimeSource, new FixedUUIDSource())
     service.zipPuids should equal(expectedPuids)
+  }
+
+  "judgmentPuidsAllow list" should "match the expected list of pronom ids for word file" in {
+    val expectedPuids = List("fmt/412", "fmt/523", "fmt/597")
+
+    val service = new FFIDMetadataService(mock[FFIDMetadataRepository], mock[FFIDMetadataMatchesRepository],
+      mock[FileRepository], FixedTimeSource, new FixedUUIDSource())
+    service.judgmentPuidsAllow should equal(expectedPuids)
+  }
+
+  "checkStatus" should "return 'Success' status for a valid puid value on 'standard' consignment type" in {
+    val validPuid = "fmt/1"
+
+    val service = new FFIDMetadataService(mock[FFIDMetadataRepository], mock[FFIDMetadataMatchesRepository],
+      mock[FileRepository], FixedTimeSource, new FixedUUIDSource())
+
+    val status = service.checkStatus(Some(validPuid), "standard")
+    status shouldBe FileStatusService.Success
+  }
+
+  "checkStatus" should "return 'PasswordProtected' status for a password protected puid value on 'standard' consignment type" in {
+    val passwordProtectedPuid = "fmt/494"
+
+    val service = new FFIDMetadataService(mock[FFIDMetadataRepository], mock[FFIDMetadataMatchesRepository],
+      mock[FileRepository], FixedTimeSource, new FixedUUIDSource())
+
+    val status = service.checkStatus(Some(passwordProtectedPuid), "standard")
+    status shouldBe FileStatusService.PasswordProtected
+  }
+
+  "checkStatus" should "return 'Zip' status for a zip puid value on 'standard' consignment type" in {
+    val zipPuid = "fmt/289"
+
+    val service = new FFIDMetadataService(mock[FFIDMetadataRepository], mock[FFIDMetadataMatchesRepository],
+      mock[FileRepository], FixedTimeSource, new FixedUUIDSource())
+
+    val status = service.checkStatus(Some(zipPuid), "standard")
+    status shouldBe FileStatusService.Zip
+  }
+
+  "checkStatus" should "return 'Success' status for a valid judgment puid value on 'judgment' consignment type" in {
+    val validJudgmentPuid = "fmt/412"
+
+    val service = new FFIDMetadataService(mock[FFIDMetadataRepository], mock[FFIDMetadataMatchesRepository],
+      mock[FileRepository], FixedTimeSource, new FixedUUIDSource())
+
+    val status = service.checkStatus(Some(validJudgmentPuid), "judgment")
+    status shouldBe FileStatusService.Success
+  }
+
+  "checkStatus" should "return 'NonJudgmentFormat' status for a non-judgment puid value on 'judgment' consignment type" in {
+    val nonJudgmentPuid = "fmt/1"
+
+    val service = new FFIDMetadataService(mock[FFIDMetadataRepository], mock[FFIDMetadataMatchesRepository],
+      mock[FileRepository], FixedTimeSource, new FixedUUIDSource())
+
+    val status = service.checkStatus(Some(nonJudgmentPuid), "judgment")
+    status shouldBe FileStatusService.NonJudgmentFormat
+  }
+
+  "checkStatus" should "return 'PasswordProtected' status for a password protected puid value on 'judgment' consignment type" in {
+    val passwordProtectedPuid = "fmt/494"
+
+    val service = new FFIDMetadataService(mock[FFIDMetadataRepository], mock[FFIDMetadataMatchesRepository],
+      mock[FileRepository], FixedTimeSource, new FixedUUIDSource())
+
+    val status = service.checkStatus(Some(passwordProtectedPuid), "judgment")
+    status shouldBe FileStatusService.PasswordProtected
+  }
+
+  "checkStatus" should "return 'Zip' status for a zip puid value on 'judgment' consignment type" in {
+    val zipPuid = "fmt/289"
+
+    val service = new FFIDMetadataService(mock[FFIDMetadataRepository], mock[FFIDMetadataMatchesRepository],
+      mock[FileRepository], FixedTimeSource, new FixedUUIDSource())
+
+    val status = service.checkStatus(Some(zipPuid), "judgment")
+    status shouldBe FileStatusService.Zip
   }
 
   "addFFIDMetadata" should "call the repositories with the correct values" in {
     val fixedFileUuid = UUID.fromString("07a3a4bd-0281-4a6d-a4c1-8fa3239e1313")
     val fixedUUIDSource = new FixedUUIDSource
     val fixedFileMetadataId = fixedUUIDSource.uuid
+    val fixedConsignmentId = fixedUUIDSource.uuid
+    val fixedUserId = fixedUUIDSource.uuid
+    val fixedBodyId = fixedUUIDSource.uuid
     fixedUUIDSource.reset
 
     val metadataRepository = mock[FFIDMetadataRepository]
     val matchesRepository = mock[FFIDMetadataMatchesRepository]
+    val fileRepository = mock[FileRepository]
 
     val metadataCaptor: ArgumentCaptor[FfidmetadataRow] = ArgumentCaptor.forClass(classOf[FfidmetadataRow])
     val fileStatusCaptor: ArgumentCaptor[List[FilestatusRow]] = ArgumentCaptor.forClass(classOf[List[FilestatusRow]])
     val matchCaptor: ArgumentCaptor[List[FfidmetadatamatchesRow]] = ArgumentCaptor.forClass(classOf[List[FfidmetadatamatchesRow]])
+    val fileIdCaptor: ArgumentCaptor[UUID] = ArgumentCaptor.forClass(classOf[UUID])
 
     val mockMetadataRow: FfidmetadataRow = getMockMetadataRow(fixedFileMetadataId, fixedFileUuid, Timestamp.from(FixedTimeSource.now))
     val mockMetadataMatchesRow = getMatchesRow(mockMetadataRow.ffidmetadataid)
@@ -57,11 +142,16 @@ class FFIDMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     val mockMetadataResponse = Future(mockMetadataRow)
     val mockMetadataMatchesResponse = Future(List(mockMetadataMatchesRow))
 
+    val mockConsignmentRow = getMockConsignmentRow(fixedConsignmentId, fixedUserId, bodyId = fixedBodyId)
+    val mockGetConsignmentResponse = Future(List(mockConsignmentRow))
+
+    when(fileRepository.getConsignmentForFile(fileIdCaptor.capture())).thenReturn(mockGetConsignmentResponse)
     when(metadataRepository.addFFIDMetadata(metadataCaptor.capture(), fileStatusCaptor.capture())).thenReturn(mockMetadataResponse)
     when(matchesRepository.addFFIDMetadataMatches(matchCaptor.capture())).thenReturn(mockMetadataMatchesResponse)
 
-    val service = new FFIDMetadataService(metadataRepository, matchesRepository, FixedTimeSource, new FixedUUIDSource())
-    service.addFFIDMetadata(getMetadataInput(fixedFileUuid))
+    val service = new FFIDMetadataService(metadataRepository, matchesRepository, fileRepository, FixedTimeSource, new FixedUUIDSource())
+    service.addFFIDMetadata(getMetadataInput(fixedFileUuid)).futureValue
+    fileIdCaptor.getValue shouldBe fixedFileUuid
     metadataCaptor.getValue should equal(mockMetadataRow)
   }
 
@@ -69,14 +159,19 @@ class FFIDMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     val fixedFileUuid = UUID.fromString("07a3a4bd-0281-4a6d-a4c1-8fa3239e1313")
     val fixedUUIDSource = new FixedUUIDSource
     val fixedFileMetadataId = fixedUUIDSource.uuid
+    val fixedConsignmentId = fixedUUIDSource.uuid
+    val fixedUserId = fixedUUIDSource.uuid
+    val fixedBodyId = fixedUUIDSource.uuid
     fixedUUIDSource.reset
 
     val metadataRepository = mock[FFIDMetadataRepository]
     val matchesRepository = mock[FFIDMetadataMatchesRepository]
+    val fileRepository = mock[FileRepository]
 
-    val metadataCaptor: ArgumentCaptor[FfidmetadataRow] =  ArgumentCaptor.forClass(classOf[FfidmetadataRow])
+    val metadataCaptor: ArgumentCaptor[FfidmetadataRow] = ArgumentCaptor.forClass(classOf[FfidmetadataRow])
     val fileStatusCaptor: ArgumentCaptor[List[FilestatusRow]] = ArgumentCaptor.forClass(classOf[List[FilestatusRow]])
-    val matchCaptor: ArgumentCaptor[List[FfidmetadatamatchesRow]] =  ArgumentCaptor.forClass(classOf[List[FfidmetadatamatchesRow]])
+    val matchCaptor: ArgumentCaptor[List[FfidmetadatamatchesRow]] = ArgumentCaptor.forClass(classOf[List[FfidmetadatamatchesRow]])
+    val fileIdCaptor: ArgumentCaptor[UUID] = ArgumentCaptor.forClass(classOf[UUID])
 
     val mockMetadataRow: FfidmetadataRow = getMockMetadataRow(fixedFileMetadataId, fixedFileUuid, Timestamp.from(FixedTimeSource.now))
     val mockMetadataMatchesRow = getMatchesRow(mockMetadataRow.ffidmetadataid)
@@ -84,10 +179,14 @@ class FFIDMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     val mockMetadataResponse = Future(mockMetadataRow)
     val mockMetadataMatchesResponse = Future(List(mockMetadataMatchesRow))
 
+    val mockConsignmentRow = getMockConsignmentRow(fixedConsignmentId, fixedUserId, bodyId = fixedBodyId)
+    val mockGetConsignmentResponse = Future(List(mockConsignmentRow))
+
+    when(fileRepository.getConsignmentForFile(fileIdCaptor.capture())).thenReturn(mockGetConsignmentResponse)
     when(metadataRepository.addFFIDMetadata(metadataCaptor.capture(), fileStatusCaptor.capture())).thenReturn(mockMetadataResponse)
     when(matchesRepository.addFFIDMetadataMatches(matchCaptor.capture())).thenReturn(mockMetadataMatchesResponse)
 
-    val service = new FFIDMetadataService(metadataRepository, matchesRepository, FixedTimeSource, new FixedUUIDSource())
+    val service = new FFIDMetadataService(metadataRepository, matchesRepository, fileRepository, FixedTimeSource, new FixedUUIDSource())
     val result = service.addFFIDMetadata(getMetadataInput(fixedFileUuid)).futureValue
     result.fileId shouldEqual fixedFileUuid
     result.software shouldEqual "software"
@@ -108,6 +207,8 @@ class FFIDMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     val fixedFileUuid = UUID.fromString("07a3a4bd-0281-4a6d-a4c1-8fa3239e1313")
     val metadataRepository = mock[FFIDMetadataRepository]
     val matchesRepository = mock[FFIDMetadataMatchesRepository]
+    val fileRepository = mock[FileRepository]
+
     val inputWithNoMatches = FFIDMetadataInput(
       fixedFileUuid,
       "software",
@@ -118,7 +219,7 @@ class FFIDMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
       List()
     )
 
-    val service = new FFIDMetadataService(metadataRepository, matchesRepository, FixedTimeSource, new FixedUUIDSource())
+    val service = new FFIDMetadataService(metadataRepository, matchesRepository, fileRepository, FixedTimeSource, new FixedUUIDSource())
 
     val thrownException = intercept[Exception] {
       service.addFFIDMetadata(inputWithNoMatches)
@@ -137,7 +238,8 @@ class FFIDMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
 
     when(ffidMetadataRepositoryMock.getFFIDMetadata(consignmentIdCaptor.capture())).thenReturn(Future(Seq()))
 
-    val service = new FFIDMetadataService(ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, new FixedUUIDSource())
+    val service = new FFIDMetadataService(ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository],
+      mock[FileRepository], FixedTimeSource, new FixedUUIDSource())
     service.getFFIDMetadata(consignmentId)
 
     consignmentIdCaptor.getValue should equal(consignmentId)
@@ -175,11 +277,12 @@ class FFIDMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
 
     when(ffidMetadataRepositoryMock.getFFIDMetadata(any[UUID])).thenReturn(
       Future(Seq(
-        (metadataRowOne,matchesRowOneMatchOne ), (metadataRowOne, matchesRowOneMatchTwo), (metadataRowTwo, matchesRowTwoMatchOne)
+        (metadataRowOne, matchesRowOneMatchOne), (metadataRowOne, matchesRowOneMatchTwo), (metadataRowTwo, matchesRowTwoMatchOne)
       ))
     )
 
-    val service = new FFIDMetadataService(ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, new FixedUUIDSource())
+    val service = new FFIDMetadataService(ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository],
+      mock[FileRepository], FixedTimeSource, new FixedUUIDSource())
     val response = service.getFFIDMetadata(consignmentId).futureValue
 
     val ffidMetadataRowOne = response.find(_.fileId == fileIdOne).get
@@ -223,6 +326,21 @@ class FFIDMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
   }
 
   private def getMockMetadataRow(ffidMetadataId: UUID, fixedFileUuid: UUID, dummyTimestamp: Timestamp): FfidmetadataRow = {
-    FfidmetadataRow(ffidMetadataId, fixedFileUuid, "software", "softwareVersion",dummyTimestamp, "binaryVersion", "containerVersion", "method")
+    FfidmetadataRow(ffidMetadataId, fixedFileUuid, "software", "softwareVersion", dummyTimestamp, "binaryVersion", "containerVersion", "method")
+  }
+
+  private def getMockConsignmentRow(
+                                     consignmentId: UUID,
+                                     userId: UUID,
+                                     consignmentType: String = "standard",
+                                     bodyId: UUID): ConsignmentRow = {
+    ConsignmentRow(
+      consignmentId,
+      userid = userId,
+      datetime = Timestamp.from(FixedTimeSource.now),
+      consignmentsequence = 1L,
+      consignmentreference = "consignmentRef",
+      consignmenttype = consignmentType,
+      bodyid = bodyId)
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
@@ -65,7 +65,8 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     )
 
     val fileMetadataService = new FileMetadataService(fileMetadataRepositoryMock, FixedTimeSource, fixedUuidSource)
-    val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
+    val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository],
+      mock[FileRepository], FixedTimeSource, fixedUuidSource)
     val antivirusMetadataService = new AntivirusMetadataService(antivirusMetadataRepositoryMock, fixedUuidSource, FixedTimeSource)
 
     val fileService = new FileService(
@@ -90,6 +91,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
   "getFileMetadata" should "return the correct metadata" in {
     val fileMetadataRepositoryMock = mock[FileMetadataRepository]
     val ffidMetadataRepositoryMock = mock[FFIDMetadataRepository]
+    val fileRepositoryMock = mock[FileRepository]
     val antivirusRepositoryMock = mock[AntivirusMetadataRepository]
     val fixedUuidSource = new FixedUUIDSource()
 
@@ -123,7 +125,8 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     when(antivirusRepositoryMock.getAntivirusMetadata(consignmentId)).thenReturn(mockAvMetadataResponse)
 
     val fileMetadataService = new FileMetadataService(fileMetadataRepositoryMock, FixedTimeSource, fixedUuidSource)
-    val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
+    val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository],
+      fileRepositoryMock, FixedTimeSource, fixedUuidSource)
     val antivirusMetadataService = new AntivirusMetadataService(antivirusRepositoryMock, fixedUuidSource, FixedTimeSource)
 
     val service = new FileService(
@@ -164,6 +167,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
   "getFileMetadata" should "return empty fields if the metadata has an unexpected property name" in {
     val fileMetadataRepositoryMock = mock[FileMetadataRepository]
     val ffidMetadataRepositoryMock = mock[FFIDMetadataRepository]
+    val fileRepositoryMock = mock[FileRepository]
     val antivirusRepositoryMock = mock[AntivirusMetadataRepository]
     val fixedUuidSource = new FixedUUIDSource()
 
@@ -185,7 +189,8 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     when(fileMetadataRepositoryMock.getFileMetadata(consignmentId)).thenReturn(Future(fileMetadataRows))
 
     val fileMetadataService = new FileMetadataService(fileMetadataRepositoryMock, FixedTimeSource, fixedUuidSource)
-    val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository], FixedTimeSource, fixedUuidSource)
+    val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepositoryMock, mock[FFIDMetadataMatchesRepository],
+      fileRepositoryMock, FixedTimeSource, fixedUuidSource)
     val antivirusMetadataService = new AntivirusMetadataService(antivirusRepositoryMock, fixedUuidSource, FixedTimeSource)
 
     val service = new FileService(

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestUtils.scala
@@ -117,10 +117,10 @@ object TestUtils {
     }
   })
 
-  def seedDatabaseWithDefaultEntries(): Unit = {
+  def seedDatabaseWithDefaultEntries(consignmentType: String = "standard"): Unit = {
     val consignmentId = UUID.fromString("eb197bfb-43f7-40ca-9104-8f6cbda88506")
     val seriesId = UUID.fromString("1436ad43-73a2-4489-a774-85fa95daff32")
-    createConsignment(consignmentId, userId, seriesId)
+    createConsignment(consignmentId, userId, seriesId, consignmentType = consignmentType)
     createFile(defaultFileId, consignmentId)
     createClientFileMetadata(defaultFileId)
   }


### PR DESCRIPTION
To support court judgment transfers only a limited number of file formats are permissble to allow downstream processes to function

Limit court judgment files to permitted puids values

Make call to DB to determine whether file being checked belongs to a 'judgment' consignment, and apply appropriate test