### PR TITLE
Remove temp branch code.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,6 @@ jobs:
           git tag ${{ env.NEW_VERSION }}
           git push origin ${{ env.NEW_VERSION }}
       - name: Deploy to integration
-        run: gh workflow run deploy.yml -f environment=intg -f toDeploy=${{ env.NEW_VERSION }} -r use-github-actions
+        run: gh workflow run deploy.yml -f environment=intg -f toDeploy=${{ env.NEW_VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}


### PR DESCRIPTION
This was pointing to the branch when trying to run the deploy job which
no longer exists.
