### PR TITLE
Add mergify yaml and scala steward config.

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,20 @@
+queue_rules:
+  - name: default
+    conditions:
+      - check-success=test
+      - "check-success=security/snyk (nationalarchives)"
+pull_request_rules:
+  - name: automatic merge for Scala Steward
+    conditions:
+      - author=scala-steward
+      - check-success=test
+      - "check-success=security/snyk (nationalarchives)"
+      - or:
+          - files=build.sbt
+          - files~=^(!?project/)
+    actions:
+      review:
+        type: APPROVE
+        message: Automatically approving Scala Steward
+      queue:
+        name: default

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: TDR Run API tests
 on:
-  pull_request:
+  pull_request_target:
   push:
     branches-ignore:
       - main

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,1 @@
+updates.ignore = [ { groupId = "uk.gov.nationalarchives", artifactId = "consignment-api-db" } ]


### PR DESCRIPTION
I've signed this repo up to get the scala steward updates. We also want
these to be auto merged because we don't want more dependency updates to
worry about.

I've added in the mergify config and got scalastyle to ignore the
consignment-api-db changes as there's an ancient version in maven.

I've also change the test trigger from pull_request to
pull_request_target. This means that the code for the github actions
always comes from master but this is fine because there's a push trigger
as well which will catch any errors if we do make changes to the action
files.
