### PR TITLE
Add write permission.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
 jobs:
   deploy:
     uses: nationalarchives/tdr-github-actions/.github/workflows/ecs_deploy.yml@main


### PR DESCRIPTION
The deploy job needs the contents write permission to be able to tag and
push the release branch. The calling job needs to have the same
permissions as the tdr-github-actions workflow.
