### PR TITLE
Rename mergify check.

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,7 +1,7 @@
 queue_rules:
   - name: default
     conditions:
-      - check-success=test
+      - "check-success=test / test"
       - "check-success=security/snyk (nationalarchives)"
 pull_request_rules:
   - name: automatic merge for Scala Steward

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -7,7 +7,7 @@ pull_request_rules:
   - name: automatic merge for Scala Steward
     conditions:
       - author=scala-steward
-      - check-success=test
+      - "check-success=test / test"
       - "check-success=security/snyk (nationalarchives)"
       - or:
           - files=build.sbt


### PR DESCRIPTION
The name of the check is now test / test so needs to be updated to
allow mergify to work.

Needs https://github.com/nationalarchives/tdr-github-actions/pull/5
to be merged first.
