### PR TITLE
Account for case that there is a 'Some' of something other than 'cfm'

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
@@ -47,7 +47,7 @@ class FileMetadataService(fileMetadataRepository: FileMetadataRepository,
           cfm <- fileMetadataRepository.getSingleFileMetadata(addFileMetadataInput.fileId, SHA256ClientSideChecksum)
           fileStatus: String = cfm.headOption match {
             case Some(cfm) if cfm.value == addFileMetadataInput.value => Success
-            case Some(cfm) if cfm.value != addFileMetadataInput.value => Mismatch
+            case Some(_) => Mismatch
             case None => throw new IllegalStateException(s"Cannot find client side checksum for file ${addFileMetadataInput.fileId}")
           }
           fileStatusRow: FilestatusRow = FilestatusRow(uuidSource.uuid, addFileMetadataInput.fileId, Checksum, fileStatus, timestamp)


### PR DESCRIPTION
This should also reduce warning that appears when you run 'sbt graphqlSchemaGen'