### PR TITLE
Fix mismatched file ids

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileService.scala
@@ -2,9 +2,10 @@ package uk.gov.nationalarchives.tdr.api.service
 
 import uk.gov.nationalarchives.Tables.{FileRow, FilemetadataRow}
 import uk.gov.nationalarchives.tdr.api.db.repository._
-import uk.gov.nationalarchives.tdr.api.graphql.fields.FileFields.{AddFileAndMetadataInput, ClientSideMetadataInput, FileMatches}
-import uk.gov.nationalarchives.tdr.api.model.file.NodeType.{FileTypeHelper, fileTypeIdentifier, directoryTypeIdentifier}
+import uk.gov.nationalarchives.tdr.api.graphql.fields.FileFields.{AddFileAndMetadataInput, FileMatches}
+import uk.gov.nationalarchives.tdr.api.model.file.NodeType.{FileTypeHelper, directoryTypeIdentifier, fileTypeIdentifier}
 import uk.gov.nationalarchives.tdr.api.service.FileMetadataService._
+import uk.gov.nationalarchives.tdr.api.service.FileService._
 import uk.gov.nationalarchives.tdr.api.utils.TimeUtils.LongUtils
 import uk.gov.nationalarchives.tdr.api.utils.TreeNodesUtils
 import uk.gov.nationalarchives.tdr.api.utils.TreeNodesUtils._
@@ -25,14 +26,6 @@ class FileService(
                    uuidSource: UUIDSource
                  )(implicit val executionContext: ExecutionContext) {
 
-  implicit class FileRowHelper(fr: Option[FileRow]) {
-    def fileType: Option[String] = fr.flatMap(_.filetype)
-
-    def fileName: Option[String] = fr.flatMap(_.filename)
-
-    def parentId: Option[UUID] = fr.flatMap(_.parentid)
-  }
-
   private val treeNodesUtils: TreeNodesUtils = TreeNodesUtils(uuidSource)
 
   def addFile(addFileAndMetadataInput: AddFileAndMetadataInput, userId: UUID): Future[List[FileMatches]] = {
@@ -42,37 +35,38 @@ class FileService(
     val allFileNodes: Map[String, TreeNode] = treeNodesUtils.generateNodes(filePaths, fileTypeIdentifier)
     val allEmptyDirectoryNodes: Map[String, TreeNode] = treeNodesUtils.generateNodes(addFileAndMetadataInput.emptyDirectories.toSet, directoryTypeIdentifier)
 
-    val folderIdToPath: Map[UUID, String] = (allEmptyDirectoryNodes ++ allFileNodes.filter(_._2.treeNodeType == directoryTypeIdentifier))
-      .map(f => f._2.id -> f._1)
-
-    val fileRows: List[FileRow] = ((allEmptyDirectoryNodes ++ allFileNodes) map {
-      case (_, treeNode) =>
-        val parentId = treeNode.parentPath.map(v => allFileNodes.getOrElse(v, allEmptyDirectoryNodes(v)).id)
-        FileRow(treeNode.id, consignmentId, userId, now, filetype = Some(treeNode.treeNodeType), filename = Some(treeNode.name), parentid = parentId)
-    }).toList
-
-    val metadataWithIds: List[(UUID, ClientSideMetadataInput)] =
-      fileRows.filter(_.filetype.get.isFileType).map(_.fileid).zip(addFileAndMetadataInput.metadataInput)
     val row: (UUID, String, String) => FilemetadataRow = FilemetadataRow(uuidSource.uuid, _, _, now, userId, _)
 
-    val fileMetadataRows: Seq[FilemetadataRow] = metadataWithIds.flatMap {
-      case (fileId, input) =>
-        Seq(
-          row(fileId, input.originalPath, ClientSideOriginalFilepath),
-          row(fileId, input.lastModified.toTimestampString, ClientSideFileLastModifiedDate),
-          row(fileId, input.fileSize.toString, ClientSideFileSize),
-          row(fileId, input.checksum, SHA256ClientSideChecksum)
-        ) ++ staticMetadataProperties.map(property => {
-          row(fileId, property.value, property.name)
-        })
-      case _ => Seq()
-    } ++ fileRows.filter(_.filetype.get.isDirectoryType).flatMap(directory => {
-      row(directory.fileid, folderIdToPath(directory.fileid), ClientSideOriginalFilepath) ::
-        staticMetadataProperties.map(property => row(directory.fileid, property.value, property.name))
-    })
+    val rowsWithMatchId: List[Rows] = ((allEmptyDirectoryNodes ++ allFileNodes) map {
+      case (path, treeNode) =>
+        val parentId = treeNode.parentPath.map(v => allFileNodes.getOrElse(v, allEmptyDirectoryNodes(v)).id)
+        val fileId = treeNode.id
+        val fileRow = FileRow(fileId, consignmentId, userId, now, filetype = Some(treeNode.treeNodeType), filename = Some(treeNode.name), parentid = parentId)
+        val commonMetadataRows = row(fileId, path, ClientSideOriginalFilepath) ::
+          staticMetadataProperties.map(property => row(fileId, property.value, property.name))
+        if (treeNode.treeNodeType.isFileType) {
+          val input = addFileAndMetadataInput.metadataInput.filter(m => {
+            val pathWithoutSlash = if (m.originalPath.startsWith("/")) m.originalPath.tail else path
+            pathWithoutSlash == path
+          }).head
+          val fileMetadataRows = List(
+            row(fileId, input.lastModified.toTimestampString, ClientSideFileLastModifiedDate),
+            row(fileId, input.fileSize.toString, ClientSideFileSize),
+            row(fileId, input.checksum, SHA256ClientSideChecksum)
+          )
+          MatchedFileRows(fileRow, fileMetadataRows ++ commonMetadataRows, input.matchId)
+        } else {
+          DirectoryRows(fileRow, commonMetadataRows)
+        }
+    }).toList
+    val fileRows: List[FileRow] = rowsWithMatchId.map(_.fileRow)
+    val fileMetadataRows: List[FilemetadataRow] = rowsWithMatchId.flatMap(_.metadataRows)
     for {
       _ <- fileRepository.addFiles(fileRows, fileMetadataRows)
-    } yield metadataWithIds.map(m => (m._1, m._2.matchId)).map(f => FileMatches(f._1, f._2))
+    } yield rowsWithMatchId.flatMap {
+      case MatchedFileRows(fileRow, _, matchId) => FileMatches(fileRow.fileid, matchId) :: Nil
+      case _ => Nil
+    }
   }
 
   def getOwnersOfFiles(fileIds: Seq[UUID]): Future[Seq[FileOwnership]] = {
@@ -110,4 +104,24 @@ class FileService(
   }
 }
 
-case class FileOwnership(fileId: UUID, userId: UUID)
+
+object FileService {
+  implicit class FileRowHelper(fr: Option[FileRow]) {
+    def fileType: Option[String] = fr.flatMap(_.filetype)
+
+    def fileName: Option[String] = fr.flatMap(_.filename)
+
+    def parentId: Option[UUID] = fr.flatMap(_.parentid)
+  }
+
+  trait Rows {
+    val fileRow: FileRow
+    val metadataRows: List[FilemetadataRow]
+  }
+
+  case class MatchedFileRows(fileRow: FileRow, metadataRows: List[FilemetadataRow], matchId: Long) extends Rows
+
+  case class DirectoryRows(fileRow: FileRow, metadataRows: List[FilemetadataRow]) extends Rows
+
+  case class FileOwnership(fileId: UUID, userId: UUID)
+}

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileService.scala
@@ -39,7 +39,7 @@ class FileService(
 
     val rowsWithMatchId: List[Rows] = ((allEmptyDirectoryNodes ++ allFileNodes) map {
       case (path, treeNode) =>
-        val parentId = treeNode.parentPath.map(v => allFileNodes.getOrElse(v, allEmptyDirectoryNodes(v)).id)
+        val parentId = treeNode.parentPath.map(path => allFileNodes.getOrElse(path, allEmptyDirectoryNodes(path)).id)
         val fileId = treeNode.id
         val fileRow = FileRow(fileId, consignmentId, userId, now, filetype = Some(treeNode.treeNodeType), filename = Some(treeNode.name), parentid = parentId)
         val commonMetadataRows = row(fileId, path, ClientSideOriginalFilepath) ::

--- a/src/test/resources/json/addfileandmetadata_data_all.json
+++ b/src/test/resources/json/addfileandmetadata_data_all.json
@@ -2,11 +2,23 @@
   "data": {
     "addFilesAndMetadata": [
       {
-        "fileId": "6e3b76c4-1745-4467-8ac5-b4dd736e1b3e",
+        "fileId": "8b5bae20-5f12-11eb-ae93-0242ac130002",
         "matchId": 1
       },
       {
-        "fileId": "8e3b76c4-1745-4467-8ac5-b4dd736e1b3e",
+        "fileId": "6e3b76c4-1745-4467-8ac5-b4dd736e1b3e",
+        "matchId": 3
+      },
+      {
+        "fileId": "8b5bb226-5f12-11eb-ae93-0242ac130002",
+        "matchId": 4
+      },
+      {
+        "fileId": "15eddae1-f319-4da1-b2da-cda3bd8f840a",
+        "matchId": 5
+      },
+      {
+        "fileId": "9e3b76c4-1745-4467-8ac5-b4dd736e1b3e",
         "matchId": 2
       }
     ]

--- a/src/test/resources/json/addfileandmetadata_mutation_alldata.json
+++ b/src/test/resources/json/addfileandmetadata_mutation_alldata.json
@@ -17,6 +17,27 @@
           "lastModified": 112,
           "fileSize": 1233,
           "matchId": 2
+        },
+        {
+          "originalPath": "/otherTopDirectory/originalDirectory/originalPath3",
+          "checksum": "checksum2",
+          "lastModified": 112,
+          "fileSize": 1233,
+          "matchId": 3
+        },
+        {
+          "originalPath": "/otherTopDirectory/originalDirectory/originalPath4",
+          "checksum": "checksum2",
+          "lastModified": 112,
+          "fileSize": 1233,
+          "matchId": 4
+        },
+        {
+          "originalPath": "/otherTopDirectory/originalDirectory/originalPath5",
+          "checksum": "checksum2",
+          "lastModified": 112,
+          "fileSize": 1233,
+          "matchId": 5
         }
 
       ]

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
@@ -2,8 +2,10 @@ package uk.gov.nationalarchives.tdr.api.routes
 
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import com.dimafeng.testcontainers.PostgreSQLContainer
+import io.circe.Printer
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.auto._
+import io.circe.syntax.EncoderOps
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
 import uk.gov.nationalarchives.tdr.api.service.FileMetadataService.{clientSideProperties, staticMetadataProperties}
@@ -17,6 +19,8 @@ import java.util.UUID
 
 class FileRouteSpec extends TestContainerUtils with Matchers with TestRequest {
   override def afterContainersStart(containers: containerDef.Container): Unit = super.afterContainersStart(containers)
+
+  case class FileNameAndPath(fileName: String, path: String)
 
   private val addFilesAndMetadataJsonFilePrefix: String = "json/addfileandmetadata_"
 
@@ -46,7 +50,6 @@ class FileRouteSpec extends TestContainerUtils with Matchers with TestRequest {
 
       val expectedResponse = expectedFilesAndMetadataMutationResponse("data_all")
       val response = runTestMutationFileMetadata("mutation_alldata", validUserToken())
-
       expectedResponse.data.get.addFilesAndMetadata should equal(response.data.get.addFilesAndMetadata)
   }
 
@@ -59,14 +62,39 @@ class FileRouteSpec extends TestContainerUtils with Matchers with TestRequest {
 
       runTestMutationFileMetadata("mutation_alldata", validUserToken())
       val distinctDirectoryCount = 3
-      val fileCount = 2
+      val fileCount = 5
       val expectedCount = (staticMetadataProperties.size * distinctDirectoryCount) +
         (staticMetadataProperties.size * fileCount) +
         (clientSideProperties.size * fileCount) +
         distinctDirectoryCount
 
       utils.countAllFileMetadata() should equal(expectedCount)
- }
+  }
+
+  "The api" should "add files and metadata entries with matching file name and path" in withContainers {
+    case container: PostgreSQLContainer =>
+      val consignmentId = UUID.fromString("f1a9269d-157b-402c-98d8-1633393634c5")
+      val utils = TestUtils(container.database)
+      (clientSideProperties ++ staticMetadataProperties.map(_.name)).foreach(utils.addFileProperty)
+      utils.createConsignment(consignmentId, userId)
+
+      val res = runTestMutationFileMetadata("mutation_alldata", validUserToken())
+      res.data.get.addFilesAndMetadata.map(_.fileId).foreach(fileId => {
+        val nameAndPath = getFileNameAndOriginalPathMatch(fileId, utils)
+        nameAndPath.fileName should equal(nameAndPath.path.split("/").last)
+      })
+  }
+
+  def getFileNameAndOriginalPathMatch(fileId: UUID, utils: TestUtils): FileNameAndPath = {
+    val sql = """SELECT "FileName", "Value" FROM "FileMetadata" fm JOIN "File" f on f."FileId" = fm."FileId" WHERE f."FileId" = ? AND "PropertyName" = 'ClientSideOriginalFilepath' """
+    val ps: PreparedStatement = utils.connection.prepareStatement(sql)
+    ps.setObject(1, fileId, Types.OTHER)
+    val rs = ps.executeQuery()
+    rs.next()
+    val fileName = rs.getString("FileName")
+    val value = rs.getString("Value")
+    FileNameAndPath(fileName, value)
+  }
 
   def checkStaticMetadataExists(fileId: UUID, utils: TestUtils): List[Assertion] = {
     staticMetadataProperties.map(property => {

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
@@ -2,10 +2,8 @@ package uk.gov.nationalarchives.tdr.api.routes
 
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import com.dimafeng.testcontainers.PostgreSQLContainer
-import io.circe.Printer
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.auto._
-import io.circe.syntax.EncoderOps
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
 import uk.gov.nationalarchives.tdr.api.service.FileMetadataService.{clientSideProperties, staticMetadataProperties}

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
@@ -274,10 +274,10 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val metadataRows: List[FilemetadataRow] = metadataRowCaptor.getValue
 
     response.head.fileId should equal(UUID.fromString("47e365a4-fc1e-4375-b2f6-dccb6d361f5f"))
-    response.head.matchId should equal(1)
+    response.head.matchId should equal(2)
 
     response.last.fileId should equal(UUID.fromString("6e3b76c4-1745-4467-8ac5-b4dd736e1b3e"))
-    response.last.matchId should equal(2)
+    response.last.matchId should equal(1)
 
     val expectedFileRows = 5
     fileRows.size should equal(expectedFileRows)


### PR DESCRIPTION
Originally, we were creating files and then assigning an arbitrary file
ID to add the metadata. This worked because there was nothing in the
file table which identified the file it came from.

We now have a file name but we're still arbitrarily assigning IDs to the
FileMetadata table so sometimes, the file name and the original path
don't match up.

I've updated this to create the file rows and the fileMetadata rows
together with each loop through the values from the generateNodes
method.

I've added a test to check that the file name and original path match
and updated a couple of other tests where this has broken them.
