### PR TITLE
Fix the file metadata matching.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       repo-name: tdr-consignment-api
       test-command: |
         docker build -f Dockerfile-tests -t tests .
-        sbt test
+        sbt test scalastyle test:scalastyle 'graphqlValidateSchema "build" "consignmentApi"'
     secrets:
       MANAGEMENT_ACCOUNT: ${{ secrets.MANAGEMENT_ACCOUNT }}
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileService.scala
@@ -47,7 +47,7 @@ class FileService(fileRepository: FileRepository,
           staticMetadataProperties.map(property => row(fileId, property.value, property.name))
         if (treeNode.treeNodeType.isFileType) {
           val input = addFileAndMetadataInput.metadataInput.filter(m => {
-            val pathWithoutSlash = if (m.originalPath.startsWith("/")) m.originalPath.tail else path
+            val pathWithoutSlash = if (m.originalPath.startsWith("/")) m.originalPath.tail else m.originalPath
             pathWithoutSlash == path
           }).head
           val fileMetadataRows = List(

--- a/src/test/resources/json/addfileandmetadata_data_all.json
+++ b/src/test/resources/json/addfileandmetadata_data_all.json
@@ -2,23 +2,23 @@
   "data": {
     "addFilesAndMetadata": [
       {
-        "fileId": "8b5bae20-5f12-11eb-ae93-0242ac130002",
+        "fileId": "6e3b76c4-1745-4467-8ac5-b4dd736e1b3e",
         "matchId": 1
       },
       {
-        "fileId": "6e3b76c4-1745-4467-8ac5-b4dd736e1b3e",
+        "fileId": "8e3b76c4-1745-4467-8ac5-b4dd736e1b3e",
         "matchId": 3
       },
       {
-        "fileId": "8b5bb226-5f12-11eb-ae93-0242ac130002",
+        "fileId": "0824d319-9c58-4b15-81eb-b71fb460fa36",
         "matchId": 4
       },
       {
-        "fileId": "15eddae1-f319-4da1-b2da-cda3bd8f840a",
+        "fileId": "8b5baaa6-5f12-11eb-ae93-0242ac130002",
         "matchId": 5
       },
       {
-        "fileId": "9e3b76c4-1745-4467-8ac5-b4dd736e1b3e",
+        "fileId": "8b5bb226-5f12-11eb-ae93-0242ac130002",
         "matchId": 2
       }
     ]

--- a/src/test/resources/json/addfileandmetadata_mutation_alldata.json
+++ b/src/test/resources/json/addfileandmetadata_mutation_alldata.json
@@ -5,35 +5,35 @@
       "consignmentId": "f1a9269d-157b-402c-98d8-1633393634c5",
       "metadataInput": [
         {
-          "originalPath": "/topDirectory/originalPath",
+          "originalPath": "topDirectory/originalPath",
           "checksum": "checksum",
           "lastModified": 1,
           "fileSize": 123,
           "matchId": 1
         },
         {
-          "originalPath": "/otherTopDirectory/originalDirectory/originalPath2",
+          "originalPath": "otherTopDirectory/originalDirectory/originalPath2",
           "checksum": "checksum2",
           "lastModified": 112,
           "fileSize": 1233,
           "matchId": 2
         },
         {
-          "originalPath": "/otherTopDirectory/originalDirectory/originalPath3",
+          "originalPath": "otherTopDirectory/originalDirectory/originalPath3",
           "checksum": "checksum2",
           "lastModified": 112,
           "fileSize": 1233,
           "matchId": 3
         },
         {
-          "originalPath": "/otherTopDirectory/originalDirectory/originalPath4",
+          "originalPath": "otherTopDirectory/originalDirectory/originalPath4",
           "checksum": "checksum2",
           "lastModified": 112,
           "fileSize": 1233,
           "matchId": 4
         },
         {
-          "originalPath": "/otherTopDirectory/originalDirectory/originalPath5",
+          "originalPath": "otherTopDirectory/originalDirectory/originalPath5",
           "checksum": "checksum2",
           "lastModified": 112,
           "fileSize": 1233,

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
@@ -84,7 +84,9 @@ class FileRouteSpec extends TestContainerUtils with Matchers with TestRequest {
   }
 
   def getFileNameAndOriginalPathMatch(fileId: UUID, utils: TestUtils): FileNameAndPath = {
-    val sql = """SELECT "FileName", "Value" FROM "FileMetadata" fm JOIN "File" f on f."FileId" = fm."FileId" WHERE f."FileId" = ? AND "PropertyName" = 'ClientSideOriginalFilepath' """
+    val sql =
+      """SELECT "FileName", "Value" FROM "FileMetadata" fm
+        |JOIN "File" f on f."FileId" = fm."FileId" WHERE f."FileId" = ? AND "PropertyName" = 'ClientSideOriginalFilepath' """.stripMargin
     val ps: PreparedStatement = utils.connection.prepareStatement(sql)
     ps.setObject(1, fileId, Types.OTHER)
     val rs = ps.executeQuery()


### PR DESCRIPTION
This line
`val pathWithoutSlash = if (m.originalPath.startsWith("/")) m.originalPath.tail else path`
seems to have been put in place in case we get a forward slash sent to the API.

The problem was that the originalPath sent from the front end has no leading slash so it was returning the calculated input `path` which we were then comparing with the calculated input `path` which always returned true.

We then called head on the list and got the same object each time.

This returned the same match id to the front end for both files so the front end uploaded the same file twice.

We have changed the tests so they match the real inputs. They have no leading slash.

We may not even need this check for the forward slash but we don't want to remove it now in case it handles an edge case somewhere.
