### PR TITLE
Remove MANAGEMENT_ACCOUNT

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,5 +17,4 @@ jobs:
         docker build -f Dockerfile-tests -t tests .
         sbt test scalastyle test:scalastyle 'graphqlValidateSchema "build" "consignmentApi"'
     secrets:
-      MANAGEMENT_ACCOUNT: ${{ secrets.MANAGEMENT_ACCOUNT }}
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
This is now optional in tdr-github-actions. Once all the repos have removed it, we can take it out of that repo.