### PR TITLE
Add ordinal to metadata query

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-optics" % "0.14.1",
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-generic-extras" % "0.14.2",
-  "uk.gov.nationalarchives" %% "consignment-api-db" % "0.1.15",
+  "uk.gov.nationalarchives" %% "consignment-api-db" % "0.1.16",
   "org.postgresql" % "postgresql" % "42.4.1",
   "com.typesafe.slick" %% "slick" % "3.3.3",
   "com.typesafe.slick" %% "slick-hikaricp" % "3.3.3",

--- a/schema.graphql
+++ b/schema.graphql
@@ -172,6 +172,7 @@ type CustomMetadataField {
   multiValue: Boolean!
   defaultValue: String
   values: [CustomMetadataValues!]!
+  ordinal: Int!
 }
 
 type CustomMetadataValues {
@@ -180,11 +181,11 @@ type CustomMetadataValues {
 }
 
 enum DataType {
-  Decimal
-  Integer
-  Boolean
   Text
+  Boolean
   DateTime
+  Integer
+  Decimal
 }
 
 type FFIDMetadata {

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/CustomMetadataFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/CustomMetadataFields.scala
@@ -27,7 +27,7 @@ object CustomMetadataFields {
   case class CustomMetadataField(
                             name: String, fullName: Option[String], description: Option[String], propertyType: PropertyType,
                             propertyGroup: Option[String], dataType: DataType, editable: Boolean,
-                            multiValue: Boolean, defaultValue: Option[String], values: List[CustomMetadataValues]
+                            multiValue: Boolean, defaultValue: Option[String], values: List[CustomMetadataValues], ordinal: Int
                           )
 
   implicit val DataTypeType: EnumType[DataType] = deriveEnumType[DataType]()

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/CustomMetadataPropertiesService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/CustomMetadataPropertiesService.scala
@@ -67,7 +67,8 @@ class CustomMetadataPropertiesService(customMetadataPropertiesRepository: Custom
       fp.editable.getOrElse(false),
       fp.multivalue.getOrElse(false),
       defaultValueOption,
-      metadataValues.toList
+      metadataValues.toList,
+      fp.ordinal.getOrElse(Int.MaxValue)
     )
   }
 


### PR DESCRIPTION
This returns the ordinal value from the database where it's set. If it's not set, it returns `Int.MaxValue` This should make sure that any unordered fields show up at the end and simplifies the sorting on the client.