### PR TITLE
Add a total items field.

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -180,11 +180,11 @@ type CustomMetadataValues {
 }
 
 enum DataType {
+  Boolean
+  DateTime
   Decimal
   Integer
-  Boolean
   Text
-  DateTime
 }
 
 type FFIDMetadata {
@@ -249,6 +249,7 @@ type FileConnection {
   "A list of edges."
   edges: [FileEdge]
   totalPages: Int
+  totalItems: Int
 }
 
 "An edge in a connection."

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentFields.scala
@@ -91,6 +91,11 @@ object ConsignmentFields {
           "totalPages",
           OptionType(IntType),
           resolve = ctx => ctx.value.totalPages
+        ),
+        Field(
+          "totalItems",
+          OptionType(IntType),
+          resolve = ctx => ctx.value.totalItems
         )
       )
     )

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileService.scala
@@ -119,7 +119,7 @@ class FileService(fileRepository: FileRepository,
 
     for {
       response: Seq[FileRow] <- fileRepository.getPaginatedFiles(consignmentId, maxFiles, offset, currentCursor, filters)
-      numberOfFilesInFolder: Int <- fileRepository.countFilesInConsignment(consignmentId, filters.parentId, filters.fileTypeIdentifier)
+      totalItems: Int <- fileRepository.countFilesInConsignment(consignmentId, filters.parentId, filters.fileTypeIdentifier)
       fileIds = Some(response.map(_.fileid).toSet)
       fileMetadata <- fileMetadataService.getFileMetadata(consignmentId, fileIds)
       ffidMetadataList <- ffidMetadataService.getFFIDMetadata(consignmentId, fileIds)
@@ -129,7 +129,7 @@ class FileService(fileRepository: FileRepository,
       val lastCursor: Option[String] = response.lastOption.map(_.fileid.toString)
       val files: Seq[File] = response.toFiles(fileMetadata, avList, ffidMetadataList, ffidStatus)
       val edges: Seq[FileEdge] = files.map(_.toFileEdge)
-      val totalPages = Math.ceil(numberOfFilesInFolder.toDouble/limit.toDouble).toInt
+      val totalPages = Math.ceil(totalItems.toDouble/limit.toDouble).toInt
       TDRConnection(
         PageInfo(
           startCursor = edges.headOption.map(_.cursor),
@@ -138,7 +138,7 @@ class FileService(fileRepository: FileRepository,
           hasPreviousPage = currentCursor.isDefined
         ),
         edges,
-        numberOfFilesInFolder,
+        totalItems,
         totalPages
       )
     }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileService.scala
@@ -138,6 +138,7 @@ class FileService(fileRepository: FileRepository,
           hasPreviousPage = currentCursor.isDefined
         ),
         edges,
+        numberOfFilesInFolder,
         totalPages
       )
     }
@@ -209,5 +210,5 @@ object FileService {
 
   case class FileOwnership(fileId: UUID, userId: UUID)
 
-  case class TDRConnection[T](pageInfo: PageInfo, edges: Seq[Edge[T]], totalPages: Int) extends Connection[T]
+  case class TDRConnection[T](pageInfo: PageInfo, edges: Seq[Edge[T]], totalItems: Int, totalPages: Int) extends Connection[T]
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
@@ -642,6 +642,8 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     pageInfo.hasPreviousPage shouldBe false
 
     edges.size shouldBe 2
+    response.totalItems shouldBe 2
+
     val firstEdge = edges.head
     firstEdge.cursor shouldBe fileId2.toString
     firstEdge.node.fileId shouldBe fileId2
@@ -696,6 +698,8 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     pageInfo.hasPreviousPage shouldBe true
 
     edges.size shouldBe 2
+    response.totalItems shouldBe 2
+
     val firstEdge = edges.head
     firstEdge.cursor shouldBe fileId2.toString
     firstEdge.node.fileId shouldBe fileId2
@@ -736,6 +740,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     pageInfo.hasPreviousPage shouldBe true
 
     edges.size shouldBe 0
+    response.totalItems shouldBe 0
   }
 
   "getPaginatedFiles" should "return an error if no pagination input argument provided" in {


### PR DESCRIPTION
In this query, it is populated with total files which is used on the
front end to display the total number of files for that folder.

I kept the name slightly more generic because this case class can be
used for other non-file things.

Instead of writing whole new tests I've added a couple of assertions
about the new totalItems field.
