### PR TITLE
Return an error for non judgment files

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileStatusService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileStatusService.scala
@@ -51,8 +51,9 @@ class FileStatusService(
       ffidStatuses = ffidStatusRows.map(_.value)
       failedFFIDStatuses <- disallowedPuidsRepository.activeReasons()
     } yield {
+      val failedFileStatuses = ffidStatuses.filter((failedFFIDStatuses :+ NonJudgmentFormat).contains(_))
       checksumMatchStatus.nonEmpty && avStatus.nonEmpty && ffidStatuses.nonEmpty &&
-        (checksumMatchStatus.filter(_.value != Success) ++ avStatus.filter(_.value != Success) ++ ffidStatuses.filter((failedFFIDStatuses :+ NonJudgmentFormat).contains(_))).isEmpty
+        (checksumMatchStatus.filter(_.value != Success) ++ avStatus.filter(_.value != Success) ++ failedFileStatuses).isEmpty
     }
   }
 }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileStatusService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileStatusService.scala
@@ -4,7 +4,7 @@ import uk.gov.nationalarchives.Tables.FilestatusRow
 import uk.gov.nationalarchives.tdr.api.db.repository.{DisallowedPuidsRepository, FileStatusRepository}
 import uk.gov.nationalarchives.tdr.api.graphql.DataExceptions.InputDataException
 import uk.gov.nationalarchives.tdr.api.graphql.fields.FileStatusFields.{AddFileStatusInput, FileStatus}
-import uk.gov.nationalarchives.tdr.api.service.FileStatusService.{Antivirus, ChecksumMatch, FFID, Failed, Success, Upload}
+import uk.gov.nationalarchives.tdr.api.service.FileStatusService.{Antivirus, ChecksumMatch, FFID, Failed, NonJudgmentFormat, Success, Upload}
 
 import java.sql.Timestamp
 import java.time.Instant
@@ -52,7 +52,7 @@ class FileStatusService(
       failedFFIDStatuses <- disallowedPuidsRepository.activeReasons()
     } yield {
       checksumMatchStatus.nonEmpty && avStatus.nonEmpty && ffidStatuses.nonEmpty &&
-        (checksumMatchStatus.filter(_.value != Success) ++ avStatus.filter(_.value != Success) ++ ffidStatuses.filter(failedFFIDStatuses.contains(_))).isEmpty
+        (checksumMatchStatus.filter(_.value != Success) ++ avStatus.filter(_.value != Success) ++ ffidStatuses.filter((failedFFIDStatuses :+ NonJudgmentFormat).contains(_))).isEmpty
     }
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileStatusServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileStatusServiceSpec.scala
@@ -243,6 +243,14 @@ class FileStatusServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers 
     response should equal(false)
   }
 
+  "allChecksSucceeded" should "return false if the FFID status is NonJudgmentFormat" in {
+    mockResponse(ChecksumMatch, Seq(fileStatusRow(ChecksumMatch, Success), fileStatusRow(ChecksumMatch, Success)))
+    mockResponse(Antivirus, Seq(fileStatusRow(Antivirus, Success), fileStatusRow(Antivirus, Success)))
+    mockResponse(FFID, Seq(fileStatusRow(FFID, NonJudgmentFormat)))
+    val response = new FileStatusService(fileStatusRepositoryMock, disallowedPuidsRepositoryMock, fixedUuidSource).allChecksSucceeded(consignmentId).futureValue
+    response should equal(false)
+  }
+
   "getFileStatus" should "return a Map Consisting of a FileId key and status value" in {
     mockResponse(FFID, Seq(FilestatusRow(UUID.randomUUID(), consignmentId, FFID, Success, Timestamp.from(Instant.now))))
     val response = new FileStatusService(fileStatusRepositoryMock, disallowedPuidsRepositoryMock, fixedUuidSource).getFileStatus(consignmentId).futureValue


### PR DESCRIPTION
The allChecksSucceeded method was only returning an error for the FFID
status if it was contained in DisallowedPuids but that table doesn't
have NonJudgmentFormat in the table so if the status was
NonJudgmentFormat, it was returning allChecksSucceeded=true.

This checks for the statuses in that table and the NonJudgmentFormat.
I've added in a unit test to check for it.
