### PR TITLE
Update ClientChecks status.

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileService.scala
@@ -96,7 +96,7 @@ class FileService(fileRepository: FileRepository,
       rowsWithMatchId <- rows
       _ <- rowsWithMatchId.grouped(fileUploadBatchSize).map(row => fileRepository.addFiles(row.map(_.fileRow), row.flatMap(_.metadataRows))).toList.head
       consignmentCheckStatus = rowsWithMatchId.find(_.clientChecks != Completed).map(_.clientChecks).getOrElse(Completed)
-      _ <- consignmentStatusService.addConsignmentStatus(ConsignmentStatusInput(consignmentId, ClientChecks, consignmentCheckStatus))
+      _ <- consignmentStatusService.updateConsignmentStatus(ConsignmentStatusInput(consignmentId, ClientChecks, consignmentCheckStatus))
     } yield rowsWithMatchId.flatMap {
       case MatchedFileRows(fileRow, _, matchId, _) => FileMatches(fileRow.fileid, matchId) :: Nil
       case _ => Nil

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
@@ -95,6 +95,7 @@ class FileRouteSpec extends TestContainerUtils with Matchers with TestRequest {
       val consignmentId = UUID.fromString("f1a9269d-157b-402c-98d8-1633393634c5")
       (clientSideProperties ++ staticMetadataProperties.map(_.name)).foreach(utils.addFileProperty)
       utils.createConsignment(consignmentId)
+      utils.createConsignmentStatus(consignmentId, ClientChecks, InProgress)
       utils.createFile(UUID.randomUUID(), consignmentId)
 
       runTestMutationFileMetadata("mutation_metadatawitherrors", validUserToken())
@@ -122,6 +123,7 @@ class FileRouteSpec extends TestContainerUtils with Matchers with TestRequest {
       val consignmentId = UUID.fromString("f1a9269d-157b-402c-98d8-1633393634c5")
       (clientSideProperties ++ staticMetadataProperties.map(_.name)).foreach(utils.addFileProperty)
       utils.createConsignment(consignmentId)
+      utils.createConsignmentStatus(consignmentId, ClientChecks, InProgress)
       utils.createFile(UUID.randomUUID(), consignmentId)
 
       runTestMutationFileMetadata("mutation_alldata_1", validUserToken())

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
@@ -680,15 +680,14 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
       when(fileRepositoryMock.addFiles(any[Seq[FileRow]], any[Seq[FilemetadataRow]])).thenReturn(Future(Nil))
       val consignmentStatusService = mock[ConsignmentStatusService]
       val statusCaptor: ArgumentCaptor[ConsignmentStatusInput] = ArgumentCaptor.forClass(classOf[ConsignmentStatusInput])
-      val consignmentStatusResponse = ConsignmentStatus(UUID.randomUUID(), UUID.randomUUID(), "statusType", "value", ZonedDateTime.now(), None)
-      when(consignmentStatusService.addConsignmentStatus(statusCaptor.capture())).thenReturn(Future(consignmentStatusResponse))
+      when(consignmentStatusService.updateConsignmentStatus(statusCaptor.capture())).thenReturn(Future(1))
 
       val fileService = new FileService(fileRepositoryMock, fileStatusRepositoryMock, consignmentRepositoryMock, consignmentStatusService,
         mock[FFIDMetadataService], mock[AntivirusMetadataService], mock[FileStatusService], fileMetadataService, FixedTimeSource, uuidSource, ConfigFactory.load)
 
       fileService.addFile(AddFileAndMetadataInput(UUID.randomUUID(), List(metadataInput)), userId).futureValue
 
-      verify(consignmentStatusService, times(1)).addConsignmentStatus(any[ConsignmentStatusInput])
+      verify(consignmentStatusService, times(1)).updateConsignmentStatus(any[ConsignmentStatusInput])
       val consignmentStatus = statusCaptor.getAllValues.asScala.filter(_.statusType == "ClientChecks").head
       consignmentStatus.statusValue should equal(status)
     }
@@ -1112,8 +1111,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
 
   private def mockConsignmentStatusService(): ConsignmentStatusService = {
     val consignmentStatusService = mock[ConsignmentStatusService]
-    val consignmentStatusResponse = ConsignmentStatus(UUID.randomUUID(), UUID.randomUUID(), "statusType", "value", ZonedDateTime.now(), None)
-    when(consignmentStatusService.addConsignmentStatus(any[ConsignmentStatusInput])).thenReturn(Future(consignmentStatusResponse))
+    when(consignmentStatusService.updateConsignmentStatus(any[ConsignmentStatusInput])).thenReturn(Future(1))
     consignmentStatusService
   }
 }


### PR DESCRIPTION
I was adding the ClientChecks status row to the ConsignmentStatus table
on startUpload and I was trying to add it again when the metadata was
complete.

This doesn't work as there should only be one ConsignmentStatus row so
I've called updateConsignmentStatus.

I've added a test to check for this.
