### PR TITLE
TDR-2255 - add deleteFileMetadata mutation

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -198,6 +198,15 @@ enum DataType {
   Decimal
 }
 
+type DeleteFileMetadata {
+  fileIds: [UUID!]!
+  filePropertyNames: [String!]!
+}
+
+input DeleteFileMetadataInput {
+  fileIds: [UUID!]!
+}
+
 type FFIDMetadata {
   fileId: UUID!
   software: String!
@@ -353,6 +362,7 @@ type Mutation {
   addAntivirusMetadata(addAntivirusMetadataInput: AddAntivirusMetadataInput!): AntivirusMetadata!
   addFileMetadata(addFileMetadataWithFileIdInput: AddFileMetadataWithFileIdInput!): FileMetadataWithFileId!
   updateBulkFileMetadata(updateBulkFileMetadataInput: UpdateBulkFileMetadataInput!): BulkFileMetadata!
+  deleteFileMetadata(deleteFileMetadataInput: DeleteFileMetadataInput!): DeleteFileMetadata!
   addFFIDMetadata(addFFIDMetadataInput: FFIDMetadataInput!): FFIDMetadata!
   addFinalTransferConfirmation(addFinalTransferConfirmationInput: AddFinalTransferConfirmationInput!): FinalTransferConfirmation!
   addFinalJudgmentTransferConfirmation(addFinalJudgmentTransferConfirmationInput: AddFinalJudgmentTransferConfirmationInput!): FinalJudgmentTransferConfirmation!

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileMetadataRepository.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileMetadataRepository.scala
@@ -55,11 +55,11 @@ class FileMetadataRepository(db: Database)(implicit val executionContext: Execut
     db.run(query.result)
   }
 
-  def updateFileMetadataProperties(updatesByPropertyName: Map[String, FileMetadataUpdate]): Future[Seq[Int]] = {
+  def updateFileMetadataProperties(selectedFileIds: Set[UUID], updatesByPropertyName: Map[String, FileMetadataUpdate]): Future[Seq[Int]] = {
     val dbUpdate: Seq[ProfileAction[Int, NoStream, Effect.Write]] = updatesByPropertyName.map {
       case (propertyName, update) => Filemetadata
+        .filter(fm => fm.fileid inSetBind selectedFileIds)
         .filter(fm => fm.propertyname === propertyName)
-        .filter(fm => fm.metadataid inSet update.metadataIds)
         .map(fm => (fm.value, fm.userid, fm.datetime))
         .update((update.value, update.userId, update.dateTime))
     }.toSeq

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/FileMetadataFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/FileMetadataFields.scala
@@ -5,7 +5,7 @@ import io.circe.generic.auto._
 import sangria.macros.derive.{deriveInputObjectType, deriveObjectType}
 import sangria.marshalling.circe._
 import sangria.schema.{Argument, Field, InputObjectType, ObjectType, fields}
-import uk.gov.nationalarchives.tdr.api.auth.{ValidateHasChecksumMetadataAccess, ValidateUserOwnsFiles}
+import uk.gov.nationalarchives.tdr.api.auth.{ValidateHasChecksumMetadataAccess, ValidateUserOwnsFiles, ValidateUserOwnsFilesForDeleteMetadataInput}
 import uk.gov.nationalarchives.tdr.api.graphql.ConsignmentApiContext
 import FieldTypes._
 
@@ -16,13 +16,21 @@ object FileMetadataFields {
   }
 
   val SHA256ServerSideChecksum = "SHA256ServerSideChecksum"
+
   case class FileMetadata(filePropertyName: String, value: String) extends FileMetadataBase
   case class UpdateFileMetadataInput(filePropertyIsMultiValue: Boolean, filePropertyName: String, value: String) extends FileMetadataBase
 
   case class FileMetadataWithFileId(filePropertyName: String, fileId: UUID, value: String) extends FileMetadataBase
+
   case class BulkFileMetadata(fileIds: Seq[UUID], metadataProperties: Seq[FileMetadata])
+
   case class AddFileMetadataWithFileIdInput(filePropertyName: String, fileId: UUID, value: String) extends FileMetadataBase
+
   case class UpdateBulkFileMetadataInput(consignmentId: UUID, fileIds: Seq[UUID], metadataProperties: Seq[UpdateFileMetadataInput])
+
+  case class DeleteFileMetadata(fileIds: Seq[UUID], filePropertyNames: Seq[String])
+
+  case class DeleteFileMetadataInput(fileIds: Seq[UUID])
 
   implicit val FileMetadataType: ObjectType[Unit, FileMetadata] = deriveObjectType[Unit, FileMetadata]()
   implicit val InputFileMetadataType: InputObjectType[UpdateFileMetadataInput] = deriveInputObjectType[UpdateFileMetadataInput]()
@@ -30,23 +38,32 @@ object FileMetadataFields {
   implicit val FileMetadataWithFileIdType: ObjectType[Unit, FileMetadataWithFileId] = deriveObjectType[Unit, FileMetadataWithFileId]()
   implicit val AddFileMetadataInputType: InputObjectType[AddFileMetadataWithFileIdInput] = deriveInputObjectType[AddFileMetadataWithFileIdInput]()
 
+  implicit val DeleteFileMetadataType: ObjectType[Unit, DeleteFileMetadata] = deriveObjectType[Unit, DeleteFileMetadata]()
+  val DeleteFileMetadataInputType: InputObjectType[DeleteFileMetadataInput] = deriveInputObjectType[DeleteFileMetadataInput]()
+
   val BulkFileMetadataType: ObjectType[Unit, BulkFileMetadata] = deriveObjectType[Unit, BulkFileMetadata]()
   val UpdateBulkFileMetadataInputType: InputObjectType[UpdateBulkFileMetadataInput] = deriveInputObjectType[UpdateBulkFileMetadataInput]()
 
   implicit val FileMetadataWithFileIdInputArg: Argument[AddFileMetadataWithFileIdInput] = Argument("addFileMetadataWithFileIdInput", AddFileMetadataInputType)
   implicit val BulkFileMetadataInputArg: Argument[UpdateBulkFileMetadataInput] =
     Argument("updateBulkFileMetadataInput", UpdateBulkFileMetadataInputType)
+  implicit val DeleteFileMetadataInputArg: Argument[DeleteFileMetadataInput] = Argument("deleteFileMetadataInput", DeleteFileMetadataInputType)
 
   val mutationFields: List[Field[ConsignmentApiContext, Unit]] = fields[ConsignmentApiContext, Unit](
     Field("addFileMetadata", FileMetadataWithFileIdType,
-      arguments=FileMetadataWithFileIdInputArg :: Nil,
+      arguments = FileMetadataWithFileIdInputArg :: Nil,
       resolve = ctx => ctx.ctx.fileMetadataService.addFileMetadata(ctx.arg(FileMetadataWithFileIdInputArg), ctx.ctx.accessToken.userId),
-      tags=List(ValidateHasChecksumMetadataAccess)
+      tags = List(ValidateHasChecksumMetadataAccess)
     ),
     Field("updateBulkFileMetadata", BulkFileMetadataType,
-      arguments=BulkFileMetadataInputArg :: Nil,
+      arguments = BulkFileMetadataInputArg :: Nil,
       resolve = ctx => ctx.ctx.fileMetadataService.updateBulkFileMetadata(ctx.arg(BulkFileMetadataInputArg), ctx.ctx.accessToken.userId),
-      tags=List(ValidateUserOwnsFiles)
+      tags = List(ValidateUserOwnsFiles)
+    ),
+    Field("deleteFileMetadata", DeleteFileMetadataType,
+      arguments = DeleteFileMetadataInputArg :: Nil,
+      resolve = ctx => ctx.ctx.fileMetadataService.deleteFileMetadata(ctx.arg(DeleteFileMetadataInputArg), ctx.ctx.accessToken.userId),
+      tags = List(ValidateUserOwnsFilesForDeleteMetadataInput)
     )
   )
 }

--- a/src/test/resources/json/deletefilemetadata_data_all.json
+++ b/src/test/resources/json/deletefilemetadata_data_all.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "deleteFileMetadata": {
+      "fileIds": [
+        "51c55218-1322-4453-9ef8-2300ef1c0fef",
+        "7076f399-b596-4161-a95d-e686c6435710"
+      ],
+      "filePropertyNames": [
+        "TestDependency1",
+        "TestDependency2"
+      ]
+    }
+  }
+}

--- a/src/test/resources/json/deletefilemetadata_data_empty_fileids.json
+++ b/src/test/resources/json/deletefilemetadata_data_empty_fileids.json
@@ -1,0 +1,14 @@
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "'fileIds' is empty. Please provide at least one fileId.",
+      "locations": [
+        {
+          "column": 33,
+          "line": 1
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/json/deletefilemetadata_data_error_not_file_owner.json
+++ b/src/test/resources/json/deletefilemetadata_data_error_not_file_owner.json
@@ -1,0 +1,8 @@
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "User '29f65c4e-0eb8-4719-afdb-ace1bcbae4b6' does not own the files they are trying to access:\n7076f399-b596-4161-a95d-e686c6435710\nd74650ff-21b1-402d-8c59-b114698a8341"
+    }
+  ]
+}

--- a/src/test/resources/json/deletefilemetadata_data_missing_fileids.json
+++ b/src/test/resources/json/deletefilemetadata_data_missing_fileids.json
@@ -1,0 +1,14 @@
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "Variable '$deleteFileMetadataInput' expected value of type 'DeleteFileMetadataInput!' but got: {}. Reason: 'fileIds' Expected non-null value, found null. (line 1, column 29):\nmutation deleteFileMetadata($deleteFileMetadataInput: DeleteFileMetadataInput!) {deleteFileMetadata(deleteFileMetadataInput:$deleteFileMetadataInput) {fileIds,filePropertyNames}}\n                            ^",
+      "locations": [
+        {
+          "column": 33,
+          "line": 1
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/json/deletefilemetadata_mutation_alldata.json
+++ b/src/test/resources/json/deletefilemetadata_mutation_alldata.json
@@ -1,0 +1,11 @@
+{
+  "query": "mutation deleteFileMetadata($deleteFileMetadataInput: DeleteFileMetadataInput!) {deleteFileMetadata(deleteFileMetadataInput:$deleteFileMetadataInput) {fileIds,filePropertyNames}}",
+  "variables": {
+    "deleteFileMetadataInput" : {
+      "fileIds": [
+        "7076f399-b596-4161-a95d-e686c6435710",
+        "d74650ff-21b1-402d-8c59-b114698a8341"
+      ]
+    }
+  }
+}

--- a/src/test/resources/json/deletefilemetadata_mutation_empty_fileids.json
+++ b/src/test/resources/json/deletefilemetadata_mutation_empty_fileids.json
@@ -1,0 +1,9 @@
+{
+  "query": "mutation deleteFileMetadata($deleteFileMetadataInput: DeleteFileMetadataInput!) {deleteFileMetadata(deleteFileMetadataInput:$deleteFileMetadataInput) {fileIds,filePropertyNames}}",
+  "variables": {
+    "deleteFileMetadataInput" : {
+      "fileIds": [
+      ]
+    }
+  }
+}

--- a/src/test/resources/json/deletefilemetadata_mutation_missing_fileids.json
+++ b/src/test/resources/json/deletefilemetadata_mutation_missing_fileids.json
@@ -1,0 +1,7 @@
+{
+  "query": "mutation deleteFileMetadata($deleteFileMetadataInput: DeleteFileMetadataInput!) {deleteFileMetadata(deleteFileMetadataInput:$deleteFileMetadataInput) {fileIds,filePropertyNames}}",
+  "variables": {
+    "deleteFileMetadataInput" : {
+    }
+  }
+}

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileMetadataRepositorySpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileMetadataRepositorySpec.scala
@@ -28,7 +28,7 @@ class FileMetadataRepositorySpec extends TestContainerUtils with ScalaFutures wi
   private def getFileStatusValue(fileId: UUID, utils: TestUtils): String =
     utils.getFileStatusResult(fileId, "Status Type").head
 
-  private def checkFileMetadataExists(fileId: UUID, utils: TestUtils, numberOfFileMetadataRows: Int=1): Assertion = {
+  private def checkFileMetadataExists(fileId: UUID, utils: TestUtils, numberOfFileMetadataRows: Int = 1): Assertion = {
     utils.countFileMetadata(fileId) should be(numberOfFileMetadataRows)
   }
 
@@ -285,7 +285,7 @@ class FileMetadataRepositorySpec extends TestContainerUtils with ScalaFutures wi
       )
   }
 
-  "updateFileMetadataProperties" should "update the value and userId for the correct metadata rows and return the number of rows it updated" in withContainers {
+  "updateFileMetadataProperties" should "update the value and userId for the selected file ids only and return the number of rows it updated" in withContainers {
     case container: PostgreSQLContainer =>
       val db = container.database
       val utils = TestUtils(db)
@@ -294,11 +294,11 @@ class FileMetadataRepositorySpec extends TestContainerUtils with ScalaFutures wi
       val fileIdOne = UUID.fromString("4d5a5a00-77b4-4a97-aa3f-a75f7b13f284")
       val fileIdTwo = UUID.fromString("664f07a5-ab1d-4d66-abea-d97d81cd7bec")
       val fileIdThree = UUID.fromString("f2e8a105-a251-41ce-89a0-a03c2b321277")
+      val fileIdFour = UUID.randomUUID()
       val userId2 = UUID.randomUUID()
       utils.createConsignment(consignmentId, userId)
-      List(fileIdOne, fileIdTwo, fileIdThree).foreach(
-        fileId => utils.createFile(fileId, consignmentId)
-      )
+      List(fileIdOne, fileIdTwo, fileIdThree, fileIdFour).foreach(utils.createFile(_, consignmentId))
+
       utils.addFileProperty("FilePropertyOne")
       utils.addFileProperty("FilePropertyTwo")
       utils.addFileProperty("FilePropertyThree")
@@ -310,9 +310,10 @@ class FileMetadataRepositorySpec extends TestContainerUtils with ScalaFutures wi
       utils.addFileMetadata(metadataId2.toString, fileIdOne.toString, "FilePropertyTwo")
       utils.addFileMetadata(metadataId3.toString, fileIdTwo.toString, "FilePropertyOne")
       utils.addFileMetadata(metadataId4.toString, fileIdThree.toString, "FilePropertyThree")
+      utils.addFileMetadata(UUID.randomUUID().toString, fileIdFour.toString, "FilePropertyOne", "test value")
       val newValue = "newValue"
 
-      val updateResponse: Seq[Int] = fileMetadataRepository.updateFileMetadataProperties(
+      val updateResponse: Seq[Int] = fileMetadataRepository.updateFileMetadataProperties(Set(fileIdOne, fileIdTwo, fileIdThree),
         Map(
           "FilePropertyOne" -> FileMetadataUpdate(Seq(metadataId1, metadataId3), "FilePropertyOne", newValue, Timestamp.from(Instant.now()), userId2),
           "FilePropertyThree" -> FileMetadataUpdate(Seq(metadataId4), "FilePropertyThree", newValue, Timestamp.from(Instant.now()), userId2))
@@ -329,6 +330,9 @@ class FileMetadataRepositorySpec extends TestContainerUtils with ScalaFutures wi
       )
 
       checkCorrectMetadataPropertiesAdded(fileMetadataRepository: FileMetadataRepository, filePropertyUpdates: ExpectedFilePropertyUpdates)
+
+      val fileMetadata = fileMetadataRepository.getFileMetadataByProperty(fileIdFour, "FilePropertyOne").futureValue
+      fileMetadata.head.value should equal("test value")
   }
 
   "updateFileMetadataProperties" should "return 0 if a file property that does not exist on the rows passed to it" in withContainers {
@@ -357,7 +361,7 @@ class FileMetadataRepositorySpec extends TestContainerUtils with ScalaFutures wi
 
       val response = fileMetadataRepository.getFileMetadata(consignmentId).futureValue
 
-      val updateResponse = fileMetadataRepository.updateFileMetadataProperties(
+      val updateResponse = fileMetadataRepository.updateFileMetadataProperties(Set(fileIdOne, fileIdTwo),
         Map("NonExistentFileProperty" -> FileMetadataUpdate(
           Seq(metadataId1, metadataId3), "NonExistentFileProperty", newValue, Timestamp.from(Instant.now()), userId2)
         )
@@ -436,8 +440,8 @@ class FileMetadataRepositorySpec extends TestContainerUtils with ScalaFutures wi
     val response = fileMetadataRepository.getFileMetadata(filePropertyUpdates.consignmentId).futureValue
     val metadataRowById: Map[UUID, Seq[FilemetadataRow]] = response.groupBy(_.fileid)
 
-    filePropertyUpdates.changedProperties.foreach{
-      case(fileId, propertiesChanged) =>
+    filePropertyUpdates.changedProperties.foreach {
+      case (fileId, propertiesChanged) =>
         val fileMetadataForFile: Seq[FilemetadataRow] = metadataRowById.getOrElse(fileId, Seq())
         val fileMetadataForFileByProperty: Map[String, Seq[FilemetadataRow]] = fileMetadataForFile.groupBy(_.propertyname)
         propertiesChanged.foreach {
@@ -449,8 +453,8 @@ class FileMetadataRepositorySpec extends TestContainerUtils with ScalaFutures wi
         }
     }
 
-    filePropertyUpdates.unchangedProperties.foreach{
-      case(fileId, unchangedProperties) =>
+    filePropertyUpdates.unchangedProperties.foreach {
+      case (fileId, unchangedProperties) =>
         val fileMetadataForFile: Seq[FilemetadataRow] = metadataRowById.getOrElse(fileId, Seq())
         val fileMetadataForFileByProperty: Map[String, Seq[FilemetadataRow]] = fileMetadataForFile.groupBy(_.propertyname)
         unchangedProperties.foreach {

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileMetadataRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileMetadataRouteSpec.scala
@@ -5,7 +5,7 @@ import com.dimafeng.testcontainers.PostgreSQLContainer
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.auto._
 import org.scalatest.matchers.should.Matchers
-import uk.gov.nationalarchives.tdr.api.graphql.fields.FileMetadataFields.{BulkFileMetadata, FileMetadataWithFileId, SHA256ServerSideChecksum}
+import uk.gov.nationalarchives.tdr.api.graphql.fields.FileMetadataFields.{BulkFileMetadata, DeleteFileMetadata, FileMetadataWithFileId, SHA256ServerSideChecksum}
 import uk.gov.nationalarchives.tdr.api.model.file.NodeType
 import uk.gov.nationalarchives.tdr.api.service.FileStatusService.{ChecksumMatch, Success}
 import uk.gov.nationalarchives.tdr.api.utils.TestContainerUtils._
@@ -16,21 +16,29 @@ import uk.gov.nationalarchives.tdr.api.utils.{TestContainerUtils, TestRequest, T
 import java.sql.{PreparedStatement, ResultSet, Types}
 import java.util.UUID
 
+//scalastyle:off method.length
 class FileMetadataRouteSpec extends TestContainerUtils with Matchers with TestRequest {
   override def afterContainersStart(containers: containerDef.Container): Unit = super.afterContainersStart(containers)
 
   private val addFileMetadataJsonFilePrefix: String = "json/addfilemetadata_"
   private val updateBulkFileMetadataJsonFilePrefix: String = "json/updatebulkfilemetadata_"
+  private val deleteFileMetadataJsonFilePrefix: String = "json/deletefilemetadata_"
 
   implicit val customConfig: Configuration = Configuration.default.withDefaults
 
   val defaultFileId: UUID = UUID.fromString("07a3a4bd-0281-4a6d-a4c1-8fa3239e1313")
 
   case class GraphqlAddFileMetadataMutationData(data: Option[AddFileMetadata], errors: List[GraphqlError] = Nil)
+
   case class GraphqlUpdateBulkFileMetadataMutationData(data: Option[UpdateBulkFileMetadata], errors: List[GraphqlError] = Nil)
 
+  case class GraphqlDeleteFileMetadataMutationData(data: Option[DeletedFileMetadata], errors: List[GraphqlError] = Nil)
+
   case class AddFileMetadata(addFileMetadata: FileMetadataWithFileId)
+
   case class UpdateBulkFileMetadata(updateBulkFileMetadata: BulkFileMetadata)
+
+  case class DeletedFileMetadata(deleteFileMetadata: DeleteFileMetadata)
 
   val runAddFileMetadataTestMutation: (String, OAuth2BearerToken) => GraphqlAddFileMetadataMutationData =
     runTestRequest[GraphqlAddFileMetadataMutationData](addFileMetadataJsonFilePrefix)
@@ -43,6 +51,12 @@ class FileMetadataRouteSpec extends TestContainerUtils with Matchers with TestRe
 
   val expectedUpdateBulkFileMetadataMutationResponse: String => GraphqlUpdateBulkFileMetadataMutationData =
     getDataFromFile[GraphqlUpdateBulkFileMetadataMutationData](updateBulkFileMetadataJsonFilePrefix)
+
+  val runDeleteFileMetadataTestMutation: (String, OAuth2BearerToken) => GraphqlDeleteFileMetadataMutationData =
+    runTestRequest[GraphqlDeleteFileMetadataMutationData](deleteFileMetadataJsonFilePrefix)
+
+  val expectedDeleteFileMetadataMutationResponse: String => GraphqlDeleteFileMetadataMutationData =
+    getDataFromFile[GraphqlDeleteFileMetadataMutationData](deleteFileMetadataJsonFilePrefix)
 
   "addFileMetadata" should "return all requested fields from inserted checksum file metadata object" in withContainers {
     case container: PostgreSQLContainer =>
@@ -362,6 +376,104 @@ class FileMetadataRouteSpec extends TestContainerUtils with Matchers with TestRe
       checkNoFileMetadataAdded(utils, "property2")
   }
 
+  "deleteFileMetadata" should "delete file metadata or set the relevant default values for the given fileIds" in withContainers {
+    case container: PostgreSQLContainer =>
+      val utils = TestUtils(container.database)
+      val consignmentId = UUID.randomUUID()
+      val folderOneId = UUID.fromString("d74650ff-21b1-402d-8c59-b114698a8341")
+      val fileOneId = UUID.fromString("51c55218-1322-4453-9ef8-2300ef1c0fef")
+      val fileTwoId = UUID.fromString("7076f399-b596-4161-a95d-e686c6435710")
+      addDummyFilePropertiesAndValuesToDb(utils, consignmentId, userId)
+      createFileAndFileMetadata(utils, consignmentId, folderOneId, fileOneId, fileTwoId)
+
+      val expectedResponse: GraphqlDeleteFileMetadataMutationData = expectedDeleteFileMetadataMutationResponse("data_all")
+      val expectedResponseFileIds = expectedResponse.data.get.deleteFileMetadata.fileIds
+      val expectedResponseFileMetadata = expectedResponse.data.get.deleteFileMetadata.filePropertyNames
+      val response = runDeleteFileMetadataTestMutation("mutation_alldata", validUserToken())
+      val responseFileIds: Seq[UUID] = response.data.get.deleteFileMetadata.fileIds
+      val responseFileMetadataProperties = response.data.get.deleteFileMetadata.filePropertyNames
+
+      responseFileMetadataProperties.size should equal(expectedResponseFileMetadata.size)
+      responseFileMetadataProperties should equal(expectedResponseFileMetadata)
+
+      responseFileIds.sorted should equal(expectedResponseFileIds.sorted)
+
+      expectedResponseFileIds.foreach(id => {
+        checkFileMetadataDoesNotExist(id, utils, "TestDependency2")
+        checkFileMetadataValue(id, utils, "TestDependency1", "test")
+        checkFileMetadataValue(id, utils, "ClosureType", "Open")
+      })
+  }
+
+  "deleteFileMetadata" should "throw an error if the field fileIds is not provided" in withContainers {
+    case container: PostgreSQLContainer =>
+      val utils = TestUtils(container.database)
+      val consignmentId = UUID.randomUUID()
+      val folderOneId = UUID.fromString("d74650ff-21b1-402d-8c59-b114698a8341")
+      val fileOneId = UUID.fromString("51c55218-1322-4453-9ef8-2300ef1c0fef")
+      val fileTwoId = UUID.fromString("7076f399-b596-4161-a95d-e686c6435710")
+      addDummyFilePropertiesAndValuesToDb(utils, consignmentId, userId)
+      createFileAndFileMetadata(utils, consignmentId, folderOneId, fileOneId, fileTwoId)
+
+      val expectedResponse: GraphqlDeleteFileMetadataMutationData = expectedDeleteFileMetadataMutationResponse("data_missing_fileids")
+      val response = runDeleteFileMetadataTestMutation("mutation_missing_fileids", validUserToken(userId))
+
+      response.errors.head.message should equal(expectedResponse.errors.head.message)
+
+      List(fileOneId, fileTwoId).foreach(id => {
+        checkFileMetadataExists(id, utils, "TestDependency2")
+        checkFileMetadataValue(id, utils, "TestDependency1", "newValue")
+        checkFileMetadataValue(id, utils, "ClosureType", "Closed")
+      })
+  }
+
+  "deleteFileMetadata" should "throw an error if the field fileIds is empty" in withContainers {
+    case container: PostgreSQLContainer =>
+      val utils = TestUtils(container.database)
+      val consignmentId = UUID.randomUUID()
+      val folderOneId = UUID.fromString("d74650ff-21b1-402d-8c59-b114698a8341")
+      val fileOneId = UUID.fromString("51c55218-1322-4453-9ef8-2300ef1c0fef")
+      val fileTwoId = UUID.fromString("7076f399-b596-4161-a95d-e686c6435710")
+      addDummyFilePropertiesAndValuesToDb(utils, consignmentId, userId)
+      createFileAndFileMetadata(utils, consignmentId, folderOneId, fileOneId, fileTwoId)
+
+      val expectedResponse: GraphqlDeleteFileMetadataMutationData = expectedDeleteFileMetadataMutationResponse("data_empty_fileids")
+      val response = runDeleteFileMetadataTestMutation("mutation_empty_fileids", validUserToken(userId))
+
+      response.errors.head.message should equal(expectedResponse.errors.head.message)
+      response.errors.head.extensions.get.code should equal("INVALID_INPUT_DATA")
+
+      List(fileOneId, fileTwoId).foreach(id => {
+        checkFileMetadataExists(id, utils, "TestDependency2")
+        checkFileMetadataValue(id, utils, "TestDependency1", "newValue")
+        checkFileMetadataValue(id, utils, "ClosureType", "Closed")
+      })
+  }
+
+  "deleteFileMetadata" should "throw an error if a file id exists but belongs to another user" in withContainers {
+    case container: PostgreSQLContainer =>
+      val utils = TestUtils(container.database)
+      val consignmentId = UUID.randomUUID()
+      val folderOneId = UUID.fromString("d74650ff-21b1-402d-8c59-b114698a8341")
+      val fileOneId = UUID.fromString("51c55218-1322-4453-9ef8-2300ef1c0fef")
+      val fileTwoId = UUID.fromString("7076f399-b596-4161-a95d-e686c6435710")
+      val wrongUserId = UUID.fromString("29f65c4e-0eb8-4719-afdb-ace1bcbae4b6")
+      addDummyFilePropertiesAndValuesToDb(utils, consignmentId, userId)
+      createFileAndFileMetadata(utils, consignmentId, folderOneId, fileOneId, fileTwoId)
+
+      val expectedResponse: GraphqlDeleteFileMetadataMutationData = expectedDeleteFileMetadataMutationResponse("data_error_not_file_owner")
+      val response = runDeleteFileMetadataTestMutation("mutation_alldata", validUserToken(wrongUserId))
+
+      response.errors.head.message should equal(expectedResponse.errors.head.message)
+      response.errors.head.extensions.get.code should equal("NOT_AUTHORISED")
+
+      List(fileOneId, fileTwoId).foreach(id => {
+        checkFileMetadataExists(id, utils, "TestDependency2")
+        checkFileMetadataValue(id, utils, "TestDependency1", "newValue")
+        checkFileMetadataValue(id, utils, "ClosureType", "Closed")
+      })
+  }
+
   private def getParentId(fileId: UUID, utils: TestUtils): String = {
     val sql = """SELECT * FROM "File" WHERE "FileId" = ?;"""
     val ps: PreparedStatement = utils.connection.prepareStatement(sql)
@@ -371,7 +483,7 @@ class FileMetadataRouteSpec extends TestContainerUtils with Matchers with TestRe
     rs.getString("ParentId")
   }
 
-  private def checkFileMetadataExists(fileId: UUID, utils: TestUtils, propertyName: String=SHA256ServerSideChecksum): Unit = {
+  private def checkFileMetadataExists(fileId: UUID, utils: TestUtils, propertyName: String = SHA256ServerSideChecksum): Unit = {
     val sql = """SELECT * FROM "FileMetadata" WHERE "FileId" = ? AND "PropertyName" = ?;"""
     val ps: PreparedStatement = utils.connection.prepareStatement(sql)
     ps.setObject(1, fileId, Types.OTHER)
@@ -381,7 +493,27 @@ class FileMetadataRouteSpec extends TestContainerUtils with Matchers with TestRe
     rs.getString("FileId") should equal(fileId.toString)
   }
 
-  private def checkNoFileMetadataAdded(utils: TestUtils, propertyName: String=SHA256ServerSideChecksum): Unit = {
+  private def checkFileMetadataDoesNotExist(fileId: UUID, utils: TestUtils, propertyName: String = SHA256ServerSideChecksum): Unit = {
+    val sql = """SELECT * FROM "FileMetadata" WHERE "FileId" = ? AND "PropertyName" = ?;"""
+    val ps: PreparedStatement = utils.connection.prepareStatement(sql)
+    ps.setObject(1, fileId, Types.OTHER)
+    ps.setString(2, propertyName)
+    val rs: ResultSet = ps.executeQuery()
+    rs.next()
+    rs.getRow should equal(0)
+  }
+
+  private def checkFileMetadataValue(fileId: UUID, utils: TestUtils, propertyName: String, propertyValue: String): Unit = {
+    val sql = """SELECT * FROM "FileMetadata" WHERE "FileId" = ? AND "PropertyName" = ?;"""
+    val ps: PreparedStatement = utils.connection.prepareStatement(sql)
+    ps.setObject(1, fileId, Types.OTHER)
+    ps.setString(2, propertyName)
+    val rs: ResultSet = ps.executeQuery()
+    rs.next()
+    rs.getString("Value") should equal(propertyValue)
+  }
+
+  private def checkNoFileMetadataAdded(utils: TestUtils, propertyName: String = SHA256ServerSideChecksum): Unit = {
     val sql = """select * from "FileMetadata" WHERE "PropertyName" = ?;"""
     val ps: PreparedStatement = utils.connection.prepareStatement(sql)
     ps.setString(1, propertyName)
@@ -398,5 +530,65 @@ class FileMetadataRouteSpec extends TestContainerUtils with Matchers with TestRe
     val rs: ResultSet = ps.executeQuery()
     rs.next()
     rs.getInt(1) should be(0)
+  }
+
+  private def createFileAndFileMetadata(utils: TestUtils, consignmentId: UUID, folderOneId: UUID, fileOneId: UUID, fileTwoId: UUID): Unit = {
+    utils.createFile(folderOneId, consignmentId, NodeType.directoryTypeIdentifier, "folderName")
+    utils.createFile(fileOneId, consignmentId, NodeType.fileTypeIdentifier, "fileName", Some(folderOneId))
+    utils.createFile(fileTwoId, consignmentId, NodeType.fileTypeIdentifier)
+    List(fileOneId, fileTwoId).foreach(id => {
+      utils.addFileMetadata(UUID.randomUUID().toString, id.toString, "ClosureType", "Closed")
+      utils.addFileMetadata(UUID.randomUUID().toString, id.toString, "TestDependency1", "newValue")
+      utils.addFileMetadata(UUID.randomUUID().toString, id.toString, "TestDependency2", "someValue")
+    })
+  }
+
+  private def addDummyFilePropertiesAndValuesToDb(utils: TestUtils, consignmentId: UUID, userId: UUID, uiOrdinal: Option[Int] = None): Unit = {
+    utils.createConsignment(consignmentId, userId)
+    utils.createFileProperty("ClosureType",
+      "It's the Test Property",
+      "Defined",
+      "text",
+      editable = false, multivalue = false,
+      "Test Property Group",
+      "Test Property"
+    )
+
+    utils.createFileProperty("TestDependency1",
+      "It's the Test Dependency",
+      "Defined",
+      "text",
+      editable = false, multivalue = false,
+      "Test Dependency Group",
+      "Test Dependency",
+      2, allowExport = true
+    )
+
+    utils.createFileProperty("TestDependency2",
+      "It's the Test Dependency2",
+      "Defined",
+      "boolean",
+      editable = false, multivalue = false,
+      "Test Dependency Group",
+      "Test Dependency2",
+      2, allowExport = true
+    )
+
+    utils.createFileProperty("TestDependency4",
+      "It's the Test Dependency4",
+      "Defined",
+      "text",
+      editable = false, multivalue = false,
+      "Test Dependency Group",
+      "Test Dependency4",
+      2, allowExport = true
+    )
+
+    utils.createFilePropertyValues("ClosureType", "Closed", default = false, 3, 1, uiOrdinal)
+    utils.createFilePropertyValues("ClosureType", "Open", default = true, 4, 1, uiOrdinal)
+    utils.createFilePropertyValues("TestDependency1", "test", default = true, 0, 1, uiOrdinal)
+    utils.createFilePropertyDependencies(3, "TestDependency1", "TestDependencyValue")
+    utils.createFilePropertyDependencies(3, "TestDependency2", "TestDependencyValue")
+    utils.createFilePropertyDependencies(4, "TestDependency4", "TestDependencyValue")
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataServiceSpec.scala
@@ -1,14 +1,15 @@
 package uk.gov.nationalarchives.tdr.api.service
 
 import org.mockito.ArgumentMatchers._
-import org.mockito.{ArgumentCaptor, MockitoSugar}
+import org.mockito.{ArgumentCaptor, ArgumentMatchers, MockitoSugar}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import uk.gov.nationalarchives.Tables.{FileRow, FilemetadataRow, FilestatusRow}
+import uk.gov.nationalarchives.Tables.{FileRow, FilemetadataRow, FilepropertydependenciesRow, FilepropertyvaluesRow, FilestatusRow}
 import uk.gov.nationalarchives.tdr.api.db.repository.{CustomMetadataPropertiesRepository, FileMetadataRepository, FileMetadataUpdate, FileRepository}
 import uk.gov.nationalarchives.tdr.api.graphql.fields.FileMetadataFields._
 import uk.gov.nationalarchives.tdr.api.model.file.NodeType
+import uk.gov.nationalarchives.tdr.api.model.file.NodeType.{directoryTypeIdentifier, fileTypeIdentifier}
 import uk.gov.nationalarchives.tdr.api.service.FileMetadataService._
 import uk.gov.nationalarchives.tdr.api.service.FileStatusService.{Failed, Mismatch, Success}
 import uk.gov.nationalarchives.tdr.api.utils.{FixedTimeSource, FixedUUIDSource}
@@ -269,6 +270,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
 
     val addFileMetadataArgument = testSetUp.addFileMetadataCaptor.getValue
     val updateFileMetadataArgument: Map[String, FileMetadataUpdate] = testSetUp.updateFileMetadataPropsArgCaptor.getValue
+    val updateFileMetadataFileIdsArgument: Set[UUID] = testSetUp.updateFileMetadataFileIsArgCaptor.getValue
     val updateFileMetadataIdsArgument: Seq[UUID] = updateFileMetadataArgument.toSeq.flatMap {
       case (_, fileMetadataUpdate) => fileMetadataUpdate.metadataIds
     }
@@ -285,6 +287,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
       case (propertyName, metadataRow) => metadataRow.value.startsWith("newValue") && propertyName.last == metadataRow.value.last
     } should equal(true)
     updateFileMetadataIdsArgument.sorted should equal(existingFileMetadataRows.map(_.metadataid).sorted)
+    updateFileMetadataFileIdsArgument should equal(testSetUp.allFileIds)
   }
 
   "updateBulkFileMetadata" should "pass into 'updateFileMetadata', only the metadataIds where the " +
@@ -359,7 +362,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
 
     val addFileMetadataArgument: Seq[FilemetadataRow] = testSetUp.addFileMetadataCaptor.getValue
 
-    verify(testSetUp.metadataRepositoryMock, times(1)).updateFileMetadataProperties(any[Map[String, FileMetadataUpdate]])
+    verify(testSetUp.metadataRepositoryMock, times(1)).updateFileMetadataProperties(any[Set[UUID]], any[Map[String, FileMetadataUpdate]])
     testSetUp.updateFileMetadataPropsArgCaptor.getValue should equal(Map())
 
     addFileMetadataArgument.nonEmpty should equal(true)
@@ -448,7 +451,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     testSetUp.updateFileMetadataPropsArgCaptor.getValue should equal(Map())
 
     verify(testSetUp.metadataRepositoryMock, times(1)).addFileMetadata(any[Seq[FilemetadataRow]])
-    verify(testSetUp.metadataRepositoryMock, times(1)).updateFileMetadataProperties(any[Map[String, FileMetadataUpdate]])
+    verify(testSetUp.metadataRepositoryMock, times(1)).updateFileMetadataProperties(any[Set[UUID]], any[Map[String, FileMetadataUpdate]])
   }
 
   "updateBulkFileMetadata" should "add all submitted values as metadata rows for a multiValue property, if there are no values for the property" in {
@@ -606,7 +609,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
 
     verify(testSetUp.metadataRepositoryMock, times(1)).deleteFileMetadata(any[Set[UUID]], any[Set[String]])
     verify(testSetUp.metadataRepositoryMock, times(1)).addFileMetadata(any[Seq[FilemetadataRow]])
-    verify(testSetUp.metadataRepositoryMock, times(1)).updateFileMetadataProperties(any[Map[String, FileMetadataUpdate]])
+    verify(testSetUp.metadataRepositoryMock, times(1)).updateFileMetadataProperties(any[Set[UUID]], any[Map[String, FileMetadataUpdate]])
   }
 
   "getFileMetadata" should "call the repository with the correct arguments" in {
@@ -675,19 +678,152 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     verify(fileMetadataRepository, times(1)).getSumOfFileSizes(consignmentId)
   }
 
+  "deleteFileMetadata" should "delete and update fileMetadata properties with a default value for the selected files" in {
+    val fileMetadataRepositoryMock = mock[FileMetadataRepository]
+    val fileRepositoryMock = mock[FileRepository]
+    val customMetadataPropertiesRepositoryMock = mock[CustomMetadataPropertiesRepository]
+    val userId = UUID.randomUUID()
+    val folderId = UUID.fromString("e3fce276-2615-4a3a-aa4e-67f9a65798cf")
+    val fileInFolderId1 = UUID.fromString("104dde28-21cc-43f6-aa47-d17f120497f5")
+    val fileInFolderId2 = UUID.fromString("81643ecc-e618-43bb-829e-f7266565d0b5")
+
+    val existingFileRows: Seq[FileRow] = generateFileRows(Seq(folderId), Seq(folderId, fileInFolderId1, fileInFolderId2), userId)
+
+    val mockPropertyValuesResponse = Future(Seq(
+      FilepropertyvaluesRow("ClosureType", "Closed", None, Some(3), None, None),
+      FilepropertyvaluesRow("ClosureType", "Open", Some(true), Some(1), None, None),
+      FilepropertyvaluesRow("TitleClosed", "true", None, Some(2), None, None),
+      FilepropertyvaluesRow("TitleClosed", "false", Some(true), Some(1), None, None),
+      FilepropertyvaluesRow("Property1", "33", None, Some(1), None, None),
+    ))
+    val mockPropertyDependenciesResponse = Future(Seq(
+      FilepropertydependenciesRow(3, "ClosurePeriod", None),
+      FilepropertydependenciesRow(3, "ClosureStartDate", None),
+      FilepropertydependenciesRow(3, "TitleClosed", None),
+      FilepropertydependenciesRow(2, "Property1", None)
+    ))
+
+    val fileMetadataUpdateCaptor: ArgumentCaptor[Map[String, FileMetadataUpdate]] = ArgumentCaptor.forClass(classOf[Map[String, FileMetadataUpdate]])
+    val expectedPropertyNamesToDelete = Set("ClosurePeriod", "ClosureStartDate")
+
+    val fileIds = Seq(fileInFolderId1, fileInFolderId2)
+    when(fileRepositoryMock.getAllDescendants(ArgumentMatchers.eq(Seq(folderId)))).thenReturn(Future(existingFileRows))
+
+    when(customMetadataPropertiesRepositoryMock.getCustomMetadataValues).thenReturn(mockPropertyValuesResponse)
+    when(customMetadataPropertiesRepositoryMock.getCustomMetadataDependencies).thenReturn(mockPropertyDependenciesResponse)
+
+    when(fileMetadataRepositoryMock.deleteFileMetadata(ArgumentMatchers.eq(fileIds.toSet), ArgumentMatchers.eq(expectedPropertyNamesToDelete))).thenReturn(Future(2))
+    when(fileMetadataRepositoryMock.updateFileMetadataProperties(ArgumentMatchers.eq(fileIds.toSet), fileMetadataUpdateCaptor.capture())).thenReturn(Future(Nil))
+
+    val service = new FileMetadataService(fileMetadataRepositoryMock, fileRepositoryMock, customMetadataPropertiesRepositoryMock, FixedTimeSource, new FixedUUIDSource())
+    val response = service.deleteFileMetadata(DeleteFileMetadataInput(Seq(folderId)), userId).futureValue
+
+    response.fileIds should equal(fileIds)
+    response.filePropertyNames should equal(expectedPropertyNamesToDelete.toSeq ++ Seq("TitleClosed"))
+    val fileMetadataUpdate = fileMetadataUpdateCaptor.getValue
+    fileMetadataUpdate.size should equal(2)
+    fileMetadataUpdate.head._1 should equal(TitleClosed)
+    fileMetadataUpdate.head._2.value should equal("false")
+    fileMetadataUpdate.head._2.filePropertyName should equal(TitleClosed)
+    fileMetadataUpdate.head._2.userId should equal(userId)
+    fileMetadataUpdate.head._2.dateTime != null shouldBe true
+    fileMetadataUpdate.last._1 should equal(ClosureType)
+    fileMetadataUpdate.last._2.value should equal("Open")
+    fileMetadataUpdate.last._2.filePropertyName should equal(ClosureType)
+    fileMetadataUpdate.last._2.userId should equal(userId)
+    fileMetadataUpdate.last._2.dateTime != null shouldBe true
+  }
+
+  "deleteFileMetadata" should "update fileMetadata properties only if all of the properties have a default value" in {
+    val fileMetadataRepositoryMock = mock[FileMetadataRepository]
+    val fileRepositoryMock = mock[FileRepository]
+    val customMetadataPropertiesRepositoryMock = mock[CustomMetadataPropertiesRepository]
+    val userId = UUID.randomUUID()
+    val folderId = UUID.fromString("e3fce276-2615-4a3a-aa4e-67f9a65798cf")
+    val fileInFolderId1 = UUID.fromString("104dde28-21cc-43f6-aa47-d17f120497f5")
+    val fileInFolderId2 = UUID.fromString("81643ecc-e618-43bb-829e-f7266565d0b5")
+
+    val existingFileRows: Seq[FileRow] = generateFileRows(Seq(folderId), Seq(folderId, fileInFolderId1, fileInFolderId2), userId)
+
+    val mockPropertyValuesResponse = Future(Seq(
+      FilepropertyvaluesRow("ClosureType", "Closed", None, Some(3), None, None),
+      FilepropertyvaluesRow("ClosureType", "Open", Some(true), Some(1), None, None),
+      FilepropertyvaluesRow("TitleClosed", "true", None, Some(2), None, None),
+      FilepropertyvaluesRow("TitleClosed", "false", Some(true), Some(1), None, None),
+      FilepropertyvaluesRow("Property1", "33", None, Some(1), None, None),
+    ))
+    val mockPropertyDependenciesResponse = Future(Seq(
+      FilepropertydependenciesRow(3, "TitleClosed", None),
+      FilepropertydependenciesRow(2, "Property1", None)
+    ))
+
+    val fileMetadataUpdateCaptor: ArgumentCaptor[Map[String, FileMetadataUpdate]] = ArgumentCaptor.forClass(classOf[Map[String, FileMetadataUpdate]])
+    val expectedPropertyNamesToDelete: Set[String] = Set()
+
+    val fileIds = Seq(fileInFolderId1, fileInFolderId2)
+    when(fileRepositoryMock.getAllDescendants(ArgumentMatchers.eq(Seq(folderId)))).thenReturn(Future(existingFileRows))
+
+    when(customMetadataPropertiesRepositoryMock.getCustomMetadataValues).thenReturn(mockPropertyValuesResponse)
+    when(customMetadataPropertiesRepositoryMock.getCustomMetadataDependencies).thenReturn(mockPropertyDependenciesResponse)
+
+    when(fileMetadataRepositoryMock.updateFileMetadataProperties(ArgumentMatchers.eq(fileIds.toSet), fileMetadataUpdateCaptor.capture())).thenReturn(Future(Nil))
+    when(fileMetadataRepositoryMock.deleteFileMetadata(ArgumentMatchers.eq(fileIds.toSet), ArgumentMatchers.eq(Set()))).thenReturn(Future(2))
+
+    val service = new FileMetadataService(fileMetadataRepositoryMock, fileRepositoryMock, customMetadataPropertiesRepositoryMock, FixedTimeSource, new FixedUUIDSource())
+    val response = service.deleteFileMetadata(DeleteFileMetadataInput(Seq(folderId)), userId).futureValue
+
+    response.fileIds should equal(fileIds)
+    response.filePropertyNames should equal(expectedPropertyNamesToDelete.toSeq ++ Seq("TitleClosed"))
+    val fileMetadataUpdate = fileMetadataUpdateCaptor.getValue
+    fileMetadataUpdate.size should equal(2)
+    fileMetadataUpdate.head._1 should equal(TitleClosed)
+    fileMetadataUpdate.last._1 should equal(ClosureType)
+  }
+
+  "deleteFileMetadata" should "throw an exception if a CustomMetadata property is missing in the db" in {
+    val fileMetadataRepositoryMock = mock[FileMetadataRepository]
+    val fileRepositoryMock = mock[FileRepository]
+    val customMetadataPropertiesRepositoryMock = mock[CustomMetadataPropertiesRepository]
+    val userId = UUID.randomUUID()
+    val folderId = UUID.fromString("e3fce276-2615-4a3a-aa4e-67f9a65798cf")
+    val fileInFolderId1 = UUID.fromString("104dde28-21cc-43f6-aa47-d17f120497f5")
+    val fileInFolderId2 = UUID.fromString("81643ecc-e618-43bb-829e-f7266565d0b5")
+
+    val existingFileRows: Seq[FileRow] = generateFileRows(Seq(folderId), Seq(folderId, fileInFolderId1, fileInFolderId2), userId)
+
+    val mockPropertyValuesResponse = Future(Seq(
+      FilepropertyvaluesRow("ClosureType", "Open", None, Some(1), None, None),
+      FilepropertyvaluesRow("TitlePublic", "ABC", None, Some(1), None, None)
+    ))
+    when(customMetadataPropertiesRepositoryMock.getCustomMetadataValues).thenReturn(mockPropertyValuesResponse)
+    when(fileRepositoryMock.getAllDescendants(ArgumentMatchers.eq(Seq(folderId)))).thenReturn(Future(existingFileRows))
+
+    verify(fileMetadataRepositoryMock, times(0)).updateFileMetadataProperties(any[Set[UUID]], any[Map[String, FileMetadataUpdate]])
+    verify(fileMetadataRepositoryMock, times(0)).deleteFileMetadata(any[Set[UUID]], any[Set[String]])
+    verify(customMetadataPropertiesRepositoryMock, times(0)).getCustomMetadataDependencies
+
+    val service = new FileMetadataService(fileMetadataRepositoryMock, fileRepositoryMock, customMetadataPropertiesRepositoryMock, FixedTimeSource, new FixedUUIDSource())
+
+    val thrownException = intercept[Exception] {
+      service.deleteFileMetadata(DeleteFileMetadataInput(Seq(folderId)), UUID.randomUUID()).futureValue
+    }
+
+    thrownException.getMessage should include("Can't find metadata property 'ClosureType' with value 'Closed' in the db.")
+  }
+
   private def generateFileRows(fileUuids: Seq[UUID], filesInFolderFixedFileUuids: Seq[UUID], fixedUserId: UUID): Seq[FileRow] = {
     val consignmentId = UUID.randomUUID()
     val timestamp: Timestamp = Timestamp.from(FixedTimeSource.now)
 
     val folderFileRow = Seq(
       FileRow(
-        fileUuids.head, consignmentId, fixedUserId, timestamp, Some(true), Some(NodeType.directoryTypeIdentifier), Some("folderName")
+        fileUuids.head, consignmentId, fixedUserId, timestamp, Some(true), Some(directoryTypeIdentifier), Some("folderName")
       )
     )
 
     val fileRowsForFilesInFolder: Seq[FileRow] = filesInFolderFixedFileUuids.drop(1).map(fileUuid =>
       FileRow(
-        fileUuid, consignmentId, fixedUserId, timestamp, Some(true), Some(NodeType.fileTypeIdentifier), Some("fileName"), Some(fileUuids.head)
+        fileUuid, consignmentId, fixedUserId, timestamp, Some(true), Some(fileTypeIdentifier), Some("fileName"), Some(fileUuids.head)
       )
     )
 
@@ -695,7 +831,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
 
     val fileRowsExceptFirst: Seq[FileRow] = fileUuids.drop(1).map(fileUuid =>
       FileRow(
-        fileUuid, consignmentId, fixedUserId, timestamp, Some(true), Some(NodeType.fileTypeIdentifier), Some("fileName")
+        fileUuid, consignmentId, fixedUserId, timestamp, Some(true), Some(fileTypeIdentifier), Some("fileName")
       )
     )
 
@@ -711,12 +847,13 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     val fileInFolderId3: UUID = UUID.randomUUID()
     val fileId1: UUID = UUID.randomUUID()
     val fileId2: UUID = UUID.randomUUID()
-    val folderAndItsFiles = Seq(folderId, fileInFolderId1, fileInFolderId2, fileInFolderId3)
-    val inputFileIds = Seq(folderId, fileId1, fileId2)
+    val folderAndItsFiles: Seq[UUID] = Seq(folderId, fileInFolderId1, fileInFolderId2, fileInFolderId3)
+    val inputFileIds: Seq[UUID] = Seq(folderId, fileId1, fileId2)
+    val allFileIds : Set[UUID] = Set(fileId1, fileId2, fileInFolderId1, fileInFolderId2, fileInFolderId3)
 
     val propertyName1: String = "propertyName1"
 
-    val metadataPropertiesWithNewValues = Seq(
+    val metadataPropertiesWithNewValues: Seq[UpdateFileMetadataInput] = Seq(
       UpdateFileMetadataInput(filePropertyIsMultiValue = false, propertyName1, "newValue1"),
       UpdateFileMetadataInput(filePropertyIsMultiValue = false, "propertyName2", "newValue2")
     )
@@ -736,6 +873,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     val propertyNameDeleteFileMetadataCaptor: ArgumentCaptor[Set[String]] = ArgumentCaptor.forClass(classOf[Set[String]])
     val addFileMetadataCaptor: ArgumentCaptor[Seq[FilemetadataRow]] = ArgumentCaptor.forClass(classOf[Seq[FilemetadataRow]])
     val updateFileMetadataPropsArgCaptor: ArgumentCaptor[Map[String, FileMetadataUpdate]] = ArgumentCaptor.forClass(classOf[Map[String, FileMetadataUpdate]])
+    val updateFileMetadataFileIsArgCaptor: ArgumentCaptor[Set[UUID]] = ArgumentCaptor.forClass(classOf[Set[UUID]])
 
     def stubRepoResponses(getAllDescendantsResponse: Seq[FileRow] = Seq(), getFileMetadataResponse: Seq[FilemetadataRow] = Seq(),
                           deleteFileMetadataResponse: Int = 0, addFileMetadataResponse: Seq[FilemetadataRow] = Seq(),
@@ -749,9 +887,8 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
         .thenReturn(Future(deleteFileMetadataResponse))
       when(metadataRepositoryMock.addFileMetadata(addFileMetadataCaptor.capture()))
         .thenReturn(Future(addFileMetadataResponse))
-      when(metadataRepositoryMock.updateFileMetadataProperties(updateFileMetadataPropsArgCaptor.capture()))
+      when(metadataRepositoryMock.updateFileMetadataProperties(updateFileMetadataFileIsArgCaptor.capture(), updateFileMetadataPropsArgCaptor.capture()))
         .thenReturn(Future(updateFileMetadataPropertiesResponse))
-      ()
     }
   }
 }


### PR DESCRIPTION
added deleteFileMetadata mutation
It will delete or update closure metadata properties with a default value.

Currently, it supports closure metadata only, but we can extend it to support other metadata types as well in the future (i.e descriptive metadata).