### PR TITLE
Temporarily check for file upload failures rather than successes

### DIFF
--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentStatusRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentStatusRouteSpec.scala
@@ -270,27 +270,27 @@ class ConsignmentStatusRouteSpec extends TestContainerUtils with Matchers with T
       response.errors.head.extensions should equal(expectedResponse.errors.head.extensions)
   }
 
-  "updateConsignmentStatus" should "return an error if statusType is 'Upload' and no statusValue is passed, " +
-    "where consignment has no files with 'Upload' statuses" in withContainers {
-    case container: PostgreSQLContainer =>
-      val utils = TestUtils(container.database)
-      val userId = UUID.fromString("49762121-4425-4dc4-9194-98f72e04d52e")
-      val token = validUserToken(userId)
-      val consignmentId = UUID.fromString("a8dc972d-58f9-4733-8bb2-4254b89a35f2")
-      val fileId = UUID.fromString("411e232f-bd48-4159-8fc5-7f083d406d91")
-      val statusType = "Series"
-      val statusValue = "InProgress"
-      utils.createConsignment(consignmentId, userId)
-      utils.createFile(fileId, consignmentId)
-
-      utils.createConsignmentStatus(consignmentId, statusType, statusValue)
-
-      val expectedResponse = expectedUpdateConsignmentStatusMutationResponse("data_no_files_uploaded")
-      val response = runUpdateConsignmentStatusTestMutation("mutation_no_files_uploaded", token)
-
-      response.errors.head.message should equal(expectedResponse.errors.head.message)
-      response.errors.head.extensions should equal(expectedResponse.errors.head.extensions)
-  }
+//  "updateConsignmentStatus" should "return an error if statusType is 'Upload' and no statusValue is passed, " +
+//    "where consignment has no files with 'Upload' statuses" in withContainers {
+//    case container: PostgreSQLContainer =>
+//      val utils = TestUtils(container.database)
+//      val userId = UUID.fromString("49762121-4425-4dc4-9194-98f72e04d52e")
+//      val token = validUserToken(userId)
+//      val consignmentId = UUID.fromString("a8dc972d-58f9-4733-8bb2-4254b89a35f2")
+//      val fileId = UUID.fromString("411e232f-bd48-4159-8fc5-7f083d406d91")
+//      val statusType = "Series"
+//      val statusValue = "InProgress"
+//      utils.createConsignment(consignmentId, userId)
+//      utils.createFile(fileId, consignmentId)
+//
+//      utils.createConsignmentStatus(consignmentId, statusType, statusValue)
+//
+//      val expectedResponse = expectedUpdateConsignmentStatusMutationResponse("data_no_files_uploaded")
+//      val response = runUpdateConsignmentStatusTestMutation("mutation_no_files_uploaded", token)
+//
+//      response.errors.head.message should equal(expectedResponse.errors.head.message)
+//      response.errors.head.extensions should equal(expectedResponse.errors.head.extensions)
+//  }
 
   "updateConsignmentStatus" should "update the consignment status if statusType is 'Upload' and no statusValue was passed in, " +
     "where all consignment files have 'Success' Upload statuses " in withContainers {

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentStatusServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentStatusServiceSpec.scala
@@ -607,31 +607,31 @@ class ConsignmentStatusServiceSpec extends AnyFlatSpec with MockitoSugar with Re
     statusValueCaptor.getValue should equal(expectedStatusValue)
   }
 
-  "updateConsignmentStatus" should s"throw an InputDataException for an Upload statusType with no statusValue, where no consignment files have an Upload status" in {
-    val fixedUUIDSource = new FixedUUIDSource()
-    val expectedConsignmentId = fixedUUIDSource.uuid
-    val expectedStatusType = "Upload"
-
-    val fileStatusMockRepoResponse: Future[Seq[FilestatusRow]] = Future.successful(Seq())
-
-    when(
-      fileStatusRepositoryMock.getFileStatus(
-        expectedConsignmentId,
-        Set(expectedStatusType)
-      )
-    ).thenReturn(fileStatusMockRepoResponse)
-
-    val updateConsignmentStatusInput = ConsignmentStatusInput(expectedConsignmentId, expectedStatusType, None)
-
-    val thrownException = intercept[Exception] {
-      consignmentService.updateConsignmentStatus(updateConsignmentStatusInput).futureValue
-    }
-
-    thrownException.getMessage should equal(
-      "The future returned an exception of type: uk.gov.nationalarchives.tdr.api.graphql.DataExceptions$InputDataException, " +
-        s"with message: Error: There are no Upload statuses for any files from consignment $expectedConsignmentId."
-    )
-  }
+//  "updateConsignmentStatus" should s"throw an InputDataException for an Upload statusType with no statusValue, where no consignment files have an Upload status" in {
+//    val fixedUUIDSource = new FixedUUIDSource()
+//    val expectedConsignmentId = fixedUUIDSource.uuid
+//    val expectedStatusType = "Upload"
+//
+//    val fileStatusMockRepoResponse: Future[Seq[FilestatusRow]] = Future.successful(Seq())
+//
+//    when(
+//      fileStatusRepositoryMock.getFileStatus(
+//        expectedConsignmentId,
+//        Set(expectedStatusType)
+//      )
+//    ).thenReturn(fileStatusMockRepoResponse)
+//
+//    val updateConsignmentStatusInput = ConsignmentStatusInput(expectedConsignmentId, expectedStatusType, None)
+//
+//    val thrownException = intercept[Exception] {
+//      consignmentService.updateConsignmentStatus(updateConsignmentStatusInput).futureValue
+//    }
+//
+//    thrownException.getMessage should equal(
+//      "The future returned an exception of type: uk.gov.nationalarchives.tdr.api.graphql.DataExceptions$InputDataException, " +
+//        s"with message: Error: There are no Upload statuses for any files from consignment $expectedConsignmentId."
+//    )
+//  }
 
   private def generateConsignmentStatusRow(consignmentId: UUID,
                                            statusType: String,


### PR DESCRIPTION
updateConsignmentStatus is checking that all file Upload statuses are marked as 'Success', since we are setting them later on, there are 0 files with upload statuses, causing an exception to be thrown. This is a temporary fix that will just check if the file has failed, otherwise, it will label it as 'Completed'. It also comments out the tests that check for the no file exception.