### PR TITLE
Rename descriptionPublic to DescriptionClosed part 1

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
@@ -304,7 +304,7 @@ object FileMetadataService {
       propertyNameMap.get(TitleClosed).map(_.toBoolean),
       (propertyNameMap.get(DescriptionClosed) match {
         case Some(value) => Some(value)
-        case None => propertyNameMap.get("DescriptionClosed")
+        case None        => propertyNameMap.get("DescriptionClosed")
       }).map(_.toBoolean)
     )
   }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
@@ -302,7 +302,10 @@ object FileMetadataService {
       propertyNameMap.get(ClosureStartDate).map(d => Timestamp.valueOf(d).toLocalDateTime),
       propertyNameMap.get(FoiExemptionAsserted).map(d => Timestamp.valueOf(d).toLocalDateTime),
       propertyNameMap.get(TitleClosed).map(_.toBoolean),
-      propertyNameMap.get(DescriptionClosed).map(_.toBoolean)
+      (propertyNameMap.get(DescriptionClosed) match {
+        case Some(value) => Some(value)
+        case None => propertyNameMap.get("DescriptionClosed")
+      }).map(_.toBoolean)
     )
   }
 

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
@@ -256,7 +256,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
       (fileRow, Some(fileMetadataRow(fileId, "ClosureStartDate", closureStartDate.toString))),
       (fileRow, Some(fileMetadataRow(fileId, "FoiExemptionAsserted", foiExemptionAsserted.toString))),
       (fileRow, Some(fileMetadataRow(fileId, "TitleClosed", "true"))),
-      (fileRow, Some(fileMetadataRow(fileId, "DescriptionPublic", "true")))
+      (fileRow, Some(fileMetadataRow(fileId, DescriptionClosed, "true")))
     )
 
     val mockAvMetadataResponse = Future(


### PR DESCRIPTION
This is a temporary change so that the migrations don't break the existing form. There will be another pr to use only "DescriptionClosed" once the migrations are in.