### PR TITLE
Increase some timeouts.

### DIFF
--- a/src/main/resources/application.base.conf
+++ b/src/main/resources/application.base.conf
@@ -30,3 +30,11 @@ pagination {
 fileUpload {
     batchSize = 250
 }
+
+akka.http {
+  server {
+    idle-timeout = 180 s
+    request-timeout = 120 s
+  }
+}
+

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/ValidationTag.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/ValidationTag.scala
@@ -17,7 +17,7 @@ trait ValidationTag extends FieldTag {
     //
     // We are only using Await because Sangria middleware does not support Futures like the main resolvers do. We should
     // remove it when we find a way to do authorisation in a completely async way in Sangria.
-    Await.result(validationResult, 5 seconds)
+    Await.result(validationResult, 120 seconds)
   }
 
   def validateAsync(ctx: Context[ConsignmentApiContext, _])(implicit executionContext: ExecutionContext): Future[BeforeFieldResult[ConsignmentApiContext, Unit]]


### PR DESCRIPTION
This is part of TDR-2509. Uploads with large numbers of files are timing
out but the database isn't running at capacity so we just need to wait a
bit longer for results.

I've tried these timeouts with 10000 files and it's working.
