### PR TITLE
Add Filename and FileType to the metadata.

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
@@ -268,6 +268,8 @@ object FileMetadataService {
   val ClientSideFileSize = "ClientSideFileSize"
   val ClosurePeriod = "ClosurePeriod"
   val ClosureStartDate = "ClosureStartDate"
+  val Filename = "Filename"
+  val FileType = "FileType"
   val FoiExemptionAsserted = "FoiExemptionAsserted"
   val TitleClosed = "TitleClosed"
   val DescriptionClosed = "DescriptionPublic"
@@ -282,7 +284,7 @@ object FileMetadataService {
   val HeldBy: StaticMetadata = StaticMetadata("HeldBy", "TNA")
   val Language: StaticMetadata = StaticMetadata("Language", "English")
   val FoiExemptionCode: StaticMetadata = StaticMetadata("FoiExemptionCode", "open")
-  val clientSideProperties: List[String] = List(SHA256ClientSideChecksum, ClientSideOriginalFilepath, ClientSideFileLastModifiedDate, ClientSideFileSize)
+  val clientSideProperties: List[String] = List(SHA256ClientSideChecksum, ClientSideOriginalFilepath, ClientSideFileLastModifiedDate, ClientSideFileSize, Filename, FileType)
 
   def getFileMetadataValues(fileMetadataRow: Seq[FilemetadataRow]): FileMetadataValues = {
     val propertyNameMap: Map[String, String] = fileMetadataRow.groupBy(_.propertyname).transform { (_, value) =>

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileService.scala
@@ -58,8 +58,13 @@ class FileService(
         val parentId = treeNode.parentPath.map(path => allFileNodes.getOrElse(path, allEmptyDirectoryNodes(path)).id)
         val fileId = treeNode.id
         val fileRow = FileRow(fileId, consignmentId, userId, now, filetype = Some(treeNode.treeNodeType), filename = Some(treeNode.name), parentid = parentId)
-        val commonMetadataRows = row(fileId, path, ClientSideOriginalFilepath) ::
-          filePropertyValue.map(fileProperty => row(fileId, fileProperty.propertyvalue, fileProperty.propertyname)).toList
+
+        val commonMetadataRows = List(
+          row(fileId, path, ClientSideOriginalFilepath),
+          row(fileId, treeNode.treeNodeType, FileType),
+          row(fileId, treeNode.name, Filename)
+        ) ++ filePropertyValue.map(fileProperty => row(fileId, fileProperty.propertyvalue, fileProperty.propertyname)).toList
+
         if (treeNode.treeNodeType.isFileType) {
           val input = addFileAndMetadataInput.metadataInput
             .filter(m => {

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
@@ -6,7 +6,7 @@ import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.auto._
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
-import uk.gov.nationalarchives.tdr.api.service.FileMetadataService.clientSideProperties
+import uk.gov.nationalarchives.tdr.api.service.FileMetadataService.{FileType, Filename, clientSideProperties}
 import uk.gov.nationalarchives.tdr.api.service.FileStatusService.{ClientChecks, InProgress}
 import uk.gov.nationalarchives.tdr.api.utils.TestAuthUtils._
 import uk.gov.nationalarchives.tdr.api.utils.TestContainerUtils._
@@ -58,7 +58,7 @@ class FileRouteSpec extends TestContainerUtils with Matchers with TestRequest {
     val res = runTestMutationFileMetadata("mutation_alldata_2", validUserToken())
     val distinctDirectoryCount = 3
     val fileCount = 5
-    val expectedCount = (staticMetadataProperties.size * distinctDirectoryCount) +
+    val expectedCount = ((Filename :: FileType :: staticMetadataProperties).size * distinctDirectoryCount) +
       (staticMetadataProperties.size * fileCount) +
       (clientSideProperties.size * fileCount) +
       distinctDirectoryCount

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
@@ -628,7 +628,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
         row.consignmentid should equal(consignmentId)
         row.userid should equal(userId)
       })
-      val expectedSize = 36
+      val expectedSize = 46
       metadataRows.size should equal(expectedSize)
       staticMetadataProperties.foreach(prop => {
         metadataRows.count(r => r.propertyname == prop.name && r.value == prop.value) should equal(5)
@@ -637,8 +637,8 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
       clientSideProperties.foreach(prop => {
         val count = metadataRows.count(r => r.propertyname == prop)
         prop match {
-          case ClientSideOriginalFilepath => count should equal(5) // Directories have this set
-          case _                          => count should equal(2)
+          case ClientSideOriginalFilepath | Filename | FileType => count should equal(5) // Directories have this set
+          case _                                                => count should equal(2)
         }
       })
       val rows = fileStatusRowCaptor.getAllValues.asScala.flatten.toList
@@ -725,7 +725,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
         row.consignmentid should equal(consignmentId)
         row.userid should equal(userId)
       })
-      val expectedSize = 24
+      val expectedSize = 30
       metadataRows.size should equal(expectedSize)
       staticMetadataProperties.foreach(prop => {
         metadataRows.count(r => r.propertyname == prop.name && r.value == prop.value) should equal(3)
@@ -734,8 +734,8 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
       clientSideProperties.foreach(prop => {
         val count = metadataRows.count(r => r.propertyname == prop)
         prop match {
-          case ClientSideOriginalFilepath => count should equal(3) // Directories have this set
-          case _                          => count should equal(2)
+          case ClientSideOriginalFilepath | Filename | FileType => count should equal(3) // Directories have this set
+          case _                                                => count should equal(2)
         }
       })
       val rows = fileStatusRowCaptor.getAllValues.asScala.flatten.toList


### PR DESCRIPTION
This happens when the file is added along with all the other metadata
with a default value.

We already have a few tests which are checking the right number of
metadata rows is inserted so I've updated these.
