### PR TITLE
Update redacted files logic

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileRepository.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileRepository.scala
@@ -58,10 +58,11 @@ class FileRepository(db: Database)(implicit val executionContext: ExecutionConte
         string_to_array("FileName", '.') AS "FileNameArray"
          from "File"
          WHERE "ConsignmentId"::text = $idString) AS RedactedFiles
-            ON "ParentId"::text = "RedactedParentId"::text AND concat(
+            ON "ParentId"::text = "RedactedParentId"::text AND
              array_to_string(
                  array_append("FileNameArray"[0:"ArrayLength"-2], regexp_replace("FileNameArray"["ArrayLength"-1]::text, $regexp, '.')), '.'
-                 ), "FileNameArray"["ArrayLength"]) = "FileName"
+                 ) = concat(array_to_string((string_to_array("FileName", '.'))[0:"ArrayLength"-1], '.'), '.')
+             AND array_length(string_to_array("FileName", '.'), 1) > 1
             WHERE "FileNameArray"["ArrayLength" - 1] SIMILAR TO $similarTo  AND "ArrayLength" > 1 AND "FileNameArray"["ArrayLength"] != '' #$whereSuffix #$filterSuffix;
         """.stripMargin.as[RedactedFiles]
     db.run(sql)

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileRepositorySpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileRepositorySpec.scala
@@ -439,11 +439,17 @@ class FileRepositorySpec extends TestContainerUtils with ScalaFutures with Match
   val redactedFilesTable: TableFor2[String, String] = Table(
     ("redactedFileName", "originalFileName"),
     ("Redacted_R.txt", "Redacted.txt"),
+    ("Redacted_R.txt", "Redacted.doc"),
     ("Redacted_R200.txt", "Redacted.txt"),
+    ("Redacted_R200.txt", "Redacted.xlsx"),
     ("Anothe_RRedacted_R1.txt", "Anothe_RRedacted.txt"),
+    ("Anothe_RRedacted_R1.txt", "Anothe_RRedacted.docx"),
     ("Anothe_R13_R14edacted_R15.txt", "Anothe_R13_R14edacted.txt"),
+    ("Anothe_R13_R14edacted_R15.txt", "Anothe_R13_R14edacted.ppt"),
     ("Anothe_Redacted_R.txt", "Anothe_Redacted.txt"),
-    ("MyDocument.updated_R.doc", "MyDocument.updated.doc")
+    ("Anothe_Redacted_R.txt", "Anothe_Redacted.pdf"),
+    ("MyDocument.updated_R.doc", "MyDocument.updated.doc"),
+    ("MyDocument.updated_R.doc", "MyDocument.updated.pdf")
   )
 
   forAll(redactedFilesTable) { (redactedFileName, originalFileName) =>
@@ -567,7 +573,7 @@ class FileRepositorySpec extends TestContainerUtils with ScalaFutures with Match
     utils.createFile(parentId, consignmentId, NodeType.directoryTypeIdentifier, "folderName")
     utils.createFile(fileId, consignmentId, fileName = "OriginalFile.txt", parentId = Option(parentId))
     utils.createFile(redactedFileIdOne, consignmentId, fileName = "OriginalFile_R1.txt", parentId = Option(parentId))
-    utils.createFile(redactedFileIdTwo, consignmentId, fileName = "OriginalFile_R2.txt", parentId = Option(parentId))
+    utils.createFile(redactedFileIdTwo, consignmentId, fileName = "OriginalFile_R2.doc", parentId = Option(parentId))
     val fileRepository = new FileRepository(db)
 
     val response = fileRepository.getRedactedFilePairs(consignmentId).futureValue


### PR DESCRIPTION
It turns out that redacted and original files can have different file
extensions so I've updated the SQL query.

Instead of converting file1_R.txt to file1.txt and comparing it with
file1.txt, it now converts file1_R.txt to file1. and compares it with
file1. which will match missing extensions.

It will now filter out any original files that don't have a suffix as
well.
