### PR TITLE
Fix for the redacted files.

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileRepository.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileRepository.scala
@@ -47,7 +47,7 @@ class FileRepository(db: Database)(implicit val executionContext: ExecutionConte
     }
     val idString = consignmentId.toString
     val regexp = "(_R\\d*$)"
-    val similarTo = "%_R\\d*"
+    val similarTo = "%\\_R\\d*"
     val sql = sql"""SELECT "RedactedFileId", "RedactedFileName", "FileId", "FileName" FROM "File" RIGHT JOIN
         (
         select "ConsignmentId"::text AS "RedactedConsignmentId",

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileRepositorySpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileRepositorySpec.scala
@@ -608,6 +608,22 @@ class FileRepositorySpec extends TestContainerUtils with ScalaFutures with Match
     response.head.fileId.get should equal(fileId)
   }
 
+  "getRedactedFilePairs" should "return no results if the last character before the file extension is an R" in withContainers { case container: PostgreSQLContainer =>
+    val db = container.database
+    val utils = TestUtils(db)
+    val consignmentId = UUID.randomUUID()
+    val parentId = UUID.randomUUID()
+    val fileId = UUID.randomUUID()
+    utils.createConsignment(consignmentId)
+    utils.createFile(parentId, consignmentId, NodeType.directoryTypeIdentifier, "folderName")
+    utils.createFile(fileId, consignmentId, fileName = "UnrelatedFileR.txt", parentId = Option(parentId))
+    val fileRepository = new FileRepository(db)
+
+    val response = fileRepository.getRedactedFilePairs(consignmentId).futureValue
+
+    response.size should equal(0)
+  }
+
   "getRedactedFilePairs" should "return only the failed row if onlyNullValues is true" in withContainers { case container: PostgreSQLContainer =>
     val db = container.database
     val utils = TestUtils(db)


### PR DESCRIPTION
The underscore character is a wildcard character in postgres
https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-SIMILARTO-REGEXP

The similar to is then looking for anything which ends with R.extension
instead of looking for something that ends in _R.extension. The
filenames which were failing all ended in R.

I've added another test to check for this which I think should cover it.
