### PR TITLE
Wait for metadata to be added

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ValidateFileMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ValidateFileMetadataService.scala
@@ -1,5 +1,7 @@
 package uk.gov.nationalarchives.tdr.api.service
 
+import uk.gov.nationalarchives
+import uk.gov.nationalarchives.Tables
 import uk.gov.nationalarchives.Tables.{FilemetadataRow, FilestatusRow}
 import uk.gov.nationalarchives.tdr.api.db.repository.{FileMetadataRepository, FileStatusRepository}
 import uk.gov.nationalarchives.tdr.api.graphql.fields.CustomMetadataFields.{CustomMetadataField, CustomMetadataValues}
@@ -36,43 +38,50 @@ class ValidateFileMetadataService(
     for {
       customMetadataFields <- customMetadataService.getCustomMetadata
       existingMetadataProperties: Seq[FilemetadataRow] <- fileMetadataRepository.getFileMetadata(consignmentId, Some(fileIds), Some(toPropertyNames(customMetadataFields)))
+      rows <- addMetadataFileStatuses(fileIds, propertiesToValidate, customMetadataFields, existingMetadataProperties)
     } yield {
-      val additionalMetadataFieldGroups: Seq[FieldGroup] = toAdditionalMetadataFieldGroups(customMetadataFields)
-      val additionalMetadataPropertyNames: Set[String] = additionalMetadataFieldGroups.flatMap(g => toPropertyNames(g.fields)).toSet
+      rows
+    }
+  }
 
-      if (!propertiesToValidate.subsetOf(additionalMetadataPropertyNames)) {
-        List()
-      } else {
-        val additionalMetadataStatuses = {
-          additionalMetadataFieldGroups
-            .flatMap(group => {
-              val states = group.fields.flatMap(f => checkPropertyState(fileIds, f, existingMetadataProperties))
-              val filesWithNoAdditionalMetadataStatuses = fileIds
-                .filter(id => !states.map(_.fileId).contains(id))
-                .map(id => {
-                  FilestatusRow(uuidSource.uuid, id, group.groupName, NotEntered, Timestamp.from(timeSource.now))
-                })
+  private def addMetadataFileStatuses(fileIds: Set[UUID], propertiesToValidate: Set[String], customMetadataFields: Seq[CustomMetadataField], existingMetadataProperties: Seq[Tables.FilemetadataRow]): Future[List[nationalarchives.Tables.FilestatusRow]] = {
+    val additionalMetadataFieldGroups: Seq[FieldGroup] = toAdditionalMetadataFieldGroups(customMetadataFields)
+    val additionalMetadataPropertyNames: Set[String] = additionalMetadataFieldGroups.flatMap(g => toPropertyNames(g.fields)).toSet
 
-              val statuses = states
-                .groupBy(_.fileId)
-                .map(s => {
-                  val (fileId, fileStates) = s
-                  val status: String = s match {
-                    case _ if fileStates.forall(_.existingValueMatchesDefault == true) => NotEntered
-                    case _ if fileStates.forall(_.missingDependencies == false)        => Completed
-                    case _                                                             => Incomplete
-                  }
-                  FilestatusRow(uuidSource.uuid, fileId, group.groupName, status, Timestamp.from(timeSource.now))
-                })
-              statuses ++ filesWithNoAdditionalMetadataStatuses
-            })
-            .toList
-        }
+    if (!propertiesToValidate.subsetOf(additionalMetadataPropertyNames)) {
+      Future.successful(List())
+    } else {
+      val additionalMetadataStatuses = {
+        additionalMetadataFieldGroups
+          .flatMap(group => {
+            val states = group.fields.flatMap(f => checkPropertyState(fileIds, f, existingMetadataProperties))
+            val filesWithNoAdditionalMetadataStatuses = fileIds
+              .filter(id => !states.map(_.fileId).contains(id))
+              .map(id => {
+                FilestatusRow(uuidSource.uuid, id, group.groupName, NotEntered, Timestamp.from(timeSource.now))
+              })
 
-        fileStatusRepository.deleteFileStatus(fileIds, Set(ClosureMetadata, DescriptiveMetadata))
-        fileStatusRepository.addFileStatuses(additionalMetadataStatuses)
-        additionalMetadataStatuses
+            val statuses = states
+              .groupBy(_.fileId)
+              .map(s => {
+                val (fileId, fileStates) = s
+                val status: String = s match {
+                  case _ if fileStates.forall(_.existingValueMatchesDefault == true) => NotEntered
+                  case _ if fileStates.forall(_.missingDependencies == false) => Completed
+                  case _ => Incomplete
+                }
+                FilestatusRow(uuidSource.uuid, fileId, group.groupName, status, Timestamp.from(timeSource.now))
+              })
+            statuses ++ filesWithNoAdditionalMetadataStatuses
+          })
+          .toList
       }
+
+      for {
+        _ <- fileStatusRepository.deleteFileStatus(fileIds, Set(ClosureMetadata, DescriptiveMetadata))
+        _ <- fileStatusRepository.addFileStatuses(additionalMetadataStatuses)
+      } yield additionalMetadataStatuses
+
     }
   }
 

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ValidateFileMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ValidateFileMetadataService.scala
@@ -44,7 +44,12 @@ class ValidateFileMetadataService(
     }
   }
 
-  private def addMetadataFileStatuses(fileIds: Set[UUID], propertiesToValidate: Set[String], customMetadataFields: Seq[CustomMetadataField], existingMetadataProperties: Seq[Tables.FilemetadataRow]): Future[List[nationalarchives.Tables.FilestatusRow]] = {
+  private def addMetadataFileStatuses(
+      fileIds: Set[UUID],
+      propertiesToValidate: Set[String],
+      customMetadataFields: Seq[CustomMetadataField],
+      existingMetadataProperties: Seq[Tables.FilemetadataRow]
+  ): Future[List[nationalarchives.Tables.FilestatusRow]] = {
     val additionalMetadataFieldGroups: Seq[FieldGroup] = toAdditionalMetadataFieldGroups(customMetadataFields)
     val additionalMetadataPropertyNames: Set[String] = additionalMetadataFieldGroups.flatMap(g => toPropertyNames(g.fields)).toSet
 
@@ -67,8 +72,8 @@ class ValidateFileMetadataService(
                 val (fileId, fileStates) = s
                 val status: String = s match {
                   case _ if fileStates.forall(_.existingValueMatchesDefault == true) => NotEntered
-                  case _ if fileStates.forall(_.missingDependencies == false) => Completed
-                  case _ => Incomplete
+                  case _ if fileStates.forall(_.missingDependencies == false)        => Completed
+                  case _                                                             => Incomplete
                 }
                 FilestatusRow(uuidSource.uuid, fileId, group.groupName, status, Timestamp.from(timeSource.now))
               })

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ValidateFileMetadataServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ValidateFileMetadataServiceSpec.scala
@@ -428,6 +428,8 @@ class ValidateFileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with
     val mockFields = mockCustomMetadataFields()
 
     def stubMockResponses(metadataRows: List[FilemetadataRow] = List()): Unit = {
+      when(mockFileStatusRepository.addFileStatuses(any[List[FilestatusRow]])).thenReturn(Future.successful(Nil))
+      when(mockFileStatusRepository.deleteFileStatus(any[Set[UUID]], any[Set[String]])).thenReturn(Future.successful(1))
       when(mockCustomMetadataService.getCustomMetadata).thenReturn(Future(mockFields))
       when(mockFileMetadataRepository.getFileMetadata(any[UUID], any[Option[Set[UUID]]], any[Option[Set[String]]])).thenReturn(Future(metadataRows))
     }


### PR DESCRIPTION
Wait for metadata to be added.
    
`deleteFileStatus` and `addFileStatuses` were not flatMapped so sometimes they weren't completing before we were reading the file statuses to  determine the consignment statuses which lead to wrong results.
    
This adds these two methods into the for comprehension and this seems to be ok now.

I've also updated a couple of tests to mock out the calls to the methods.

