### PR TITLE
TDR-3062 Remove deprecated method addAntivirusMetadata 

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/AntivirusMetadataFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/AntivirusMetadataFields.scala
@@ -21,16 +21,8 @@ object AntivirusMetadataFields {
   implicit val AddAntivirusMetadataInputValuesType: InputObjectType[AddAntivirusMetadataInputValues] = deriveInputObjectType[AddAntivirusMetadataInputValues]()
 
   val AntivirusBulkMetadataInputArg: Argument[AddAntivirusMetadataInput] = Argument("addBulkAntivirusMetadataInput", AddAntivirusMetadataInputType)
-  val AntivirusMetadataInputArg: Argument[AddAntivirusMetadataInputValues] = Argument("addAntivirusMetadataInput", AddAntivirusMetadataInputValuesType)
 
   val mutationFields: List[Field[ConsignmentApiContext, Unit]] = fields[ConsignmentApiContext, Unit](
-    Field(
-      "addAntivirusMetadata",
-      AntivirusMetadataType,
-      arguments = AntivirusMetadataInputArg :: Nil,
-      resolve = ctx => ctx.ctx.antivirusMetadataService.addAntivirusMetadata(ctx.arg(AntivirusMetadataInputArg)),
-      tags = List(ValidateHasAntiVirusMetadataAccess)
-    ),
     Field(
       "addBulkAntivirusMetadata",
       ListType(AntivirusMetadataType),

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/AntivirusMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/AntivirusMetadataService.scala
@@ -2,7 +2,7 @@ package uk.gov.nationalarchives.tdr.api.service
 
 import uk.gov.nationalarchives.Tables.AvmetadataRow
 import uk.gov.nationalarchives.tdr.api.db.repository.AntivirusMetadataRepository
-import uk.gov.nationalarchives.tdr.api.graphql.fields.AntivirusMetadataFields.{AddAntivirusMetadataInput, AddAntivirusMetadataInputValues, AntivirusMetadata}
+import uk.gov.nationalarchives.tdr.api.graphql.fields.AntivirusMetadataFields.{AddAntivirusMetadataInput, AntivirusMetadata}
 
 import java.sql.Timestamp
 import java.time.Instant
@@ -12,10 +12,6 @@ import scala.concurrent.{ExecutionContext, Future}
 class AntivirusMetadataService(antivirusMetadataRepository: AntivirusMetadataRepository, uuidSource: UUIDSource, timeSource: TimeSource)(implicit
     val executionContext: ExecutionContext
 ) {
-
-  @deprecated("Use addAntivirusMetadata(input: AddAntivirusMetadataInput): Future[List[AntivirusMetadata]] instead")
-  def addAntivirusMetadata(values: AddAntivirusMetadataInputValues): Future[AntivirusMetadata] =
-    addAntivirusMetadata(AddAntivirusMetadataInput(values :: Nil)).map(_.head)
 
   def addAntivirusMetadata(input: AddAntivirusMetadataInput): Future[List[AntivirusMetadata]] = {
     val inputRows = input.antivirusMetadata


### PR DESCRIPTION
[Ticker TDR-3062](https://national-archives.atlassian.net/browse/TDR-3062?atlOrigin=eyJpIjoiZjMyMjFhNzZiNmI0NDQyMmE2MmRlNzY1NjBiOTFjYTQiLCJwIjoiaiJ9)

Ticket is to remove a depreciated method in such a way as to not impact other services. This method seems to only be referenced internally, and tests pass locally. 

- [x] Method Removed
