### PR TITLE
TDR-3063 Remove Depreciated FFIDMetaservice

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -394,7 +394,6 @@ type Mutation {
   addMultipleFileMetadata(addMultipleFileMetadataInput: AddFileMetadataWithFileIdInput!): [FileMetadataWithFileId!]!
   updateBulkFileMetadata(updateBulkFileMetadataInput: UpdateBulkFileMetadataInput!): BulkFileMetadata!
   deleteFileMetadata(deleteFileMetadataInput: DeleteFileMetadataInput!): DeleteFileMetadata!
-  addFFIDMetadata(addFFIDMetadataInput: FFIDMetadataInputValues!): FFIDMetadata!
   addBulkFFIDMetadata(addBulkFFIDMetadataInput: FFIDMetadataInput!): [FFIDMetadata!]!
   addFinalTransferConfirmation(addFinalTransferConfirmationInput: AddFinalTransferConfirmationInput!): FinalTransferConfirmation!
   addFinalJudgmentTransferConfirmation(addFinalJudgmentTransferConfirmationInput: AddFinalJudgmentTransferConfirmationInput!): FinalJudgmentTransferConfirmation!

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/FFIDMetadataFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/FFIDMetadataFields.scala
@@ -44,16 +44,8 @@ object FFIDMetadataFields {
   implicit val FFIDMetadataType: ObjectType[Unit, FFIDMetadata] = deriveObjectType[Unit, FFIDMetadata]()
 
   val FileFormatMetadataInputArg: Argument[FFIDMetadataInput] = Argument("addBulkFFIDMetadataInput", AddFFFIDMetadataInputType)
-  val FileFormatMetadataValuesInputArg: Argument[FFIDMetadataInputValues] = Argument("addFFIDMetadataInput", AddFFFIDMetadataInputValuesType)
 
   val mutationFields: List[Field[ConsignmentApiContext, Unit]] = fields[ConsignmentApiContext, Unit](
-    Field(
-      "addFFIDMetadata",
-      FFIDMetadataType,
-      arguments = FileFormatMetadataValuesInputArg :: Nil,
-      resolve = ctx => ctx.ctx.ffidMetadataService.addFFIDMetadata(ctx.arg(FileFormatMetadataValuesInputArg)),
-      tags = List(ValidateHasFFIDMetadataAccess)
-    ),
     Field(
       "addBulkFFIDMetadata",
       ListType(FFIDMetadataType),

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FFIDMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FFIDMetadataService.scala
@@ -5,7 +5,7 @@ import uk.gov.nationalarchives
 import uk.gov.nationalarchives.Tables.{FfidmetadataRow, FfidmetadatamatchesRow}
 import uk.gov.nationalarchives.tdr.api.db.repository._
 import uk.gov.nationalarchives.tdr.api.graphql.DataExceptions.InputDataException
-import uk.gov.nationalarchives.tdr.api.graphql.fields.FFIDMetadataFields.{FFIDMetadata, FFIDMetadataInput, FFIDMetadataInputValues, FFIDMetadataMatches}
+import uk.gov.nationalarchives.tdr.api.graphql.fields.FFIDMetadataFields.{FFIDMetadata, FFIDMetadataInput, FFIDMetadataMatches}
 import uk.gov.nationalarchives.tdr.api.utils.LoggingUtils
 
 import java.sql.Timestamp
@@ -20,11 +20,6 @@ class FFIDMetadataService(
 )(implicit val executionContext: ExecutionContext) {
 
   val loggingUtils: LoggingUtils = LoggingUtils(Logger("FFIDMetadataService"))
-
-  @deprecated("Use addFFIDMetadata(ffidMetadataInput: FFIDMetadataInput)")
-  def addFFIDMetadata(ffidMetadataInputValues: FFIDMetadataInputValues): Future[FFIDMetadata] = {
-    addFFIDMetadata(FFIDMetadataInput(ffidMetadataInputValues :: Nil)).map(_.head)
-  }
 
   def addFFIDMetadata(ffidMetadataInput: FFIDMetadataInput): Future[List[FFIDMetadata]] = {
     val (metadataRows, matchRows) = ffidMetadataInput.metadataInputValues


### PR DESCRIPTION
[TDR-3063](https://national-archives.atlassian.net/browse/TDR-3063?atlOrigin=eyJpIjoiYzk3YzcyYmQ5ZGFmNDIxNGJhNDYwNDRmZjk0YWVkMGQiLCJwIjoiaiJ9)

Ticket is to remove a depreciated method in such a way as to not impact other services. This method seems to only be referenced internally, and tests pass locally.

- [x] Method removed
- [x] Graphql schema updated 
- [x] Downstream repos merged 


[TDR-3063]: https://national-archives.atlassian.net/browse/TDR-3063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ