### PR TITLE
TDR-3064 Remove Depreciated addFileMetaData Method

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -390,7 +390,6 @@ type Mutation {
   updateConsignmentStatus(updateConsignmentStatusInput: ConsignmentStatusInput!): Int
   addAntivirusMetadata(addAntivirusMetadataInput: AddAntivirusMetadataInputValues!): AntivirusMetadata!
   addBulkAntivirusMetadata(addBulkAntivirusMetadataInput: AddAntivirusMetadataInput!): [AntivirusMetadata!]!
-  addFileMetadata(addFileMetadataWithFileIdInput: AddFileMetadataWithFileIdInputValues!): FileMetadataWithFileId!
   addMultipleFileMetadata(addMultipleFileMetadataInput: AddFileMetadataWithFileIdInput!): [FileMetadataWithFileId!]!
   updateBulkFileMetadata(updateBulkFileMetadataInput: UpdateBulkFileMetadataInput!): BulkFileMetadata!
   deleteFileMetadata(deleteFileMetadataInput: DeleteFileMetadataInput!): DeleteFileMetadata!

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/FileMetadataFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/FileMetadataFields.scala
@@ -60,13 +60,6 @@ object FileMetadataFields {
 
   val mutationFields: List[Field[ConsignmentApiContext, Unit]] = fields[ConsignmentApiContext, Unit](
     Field(
-      "addFileMetadata",
-      FileMetadataWithFileIdType,
-      arguments = FileMetadataWithFileIdInputValuesArg :: Nil,
-      resolve = ctx => ctx.ctx.fileMetadataService.addFileMetadata(ctx.arg(FileMetadataWithFileIdInputValuesArg), ctx.ctx.accessToken.userId),
-      tags = List(ValidateHasChecksumMetadataAccess)
-    ),
-    Field(
       "addMultipleFileMetadata",
       ListType(FileMetadataWithFileIdType),
       arguments = FileMetadataWithFileIdInputArg :: Nil,

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
@@ -35,10 +35,6 @@ class FileMetadataService(
 
   def getSumOfFileSizes(consignmentId: UUID): Future[Int] = fileMetadataRepository.getSumOfFileSizes(consignmentId)
 
-  @deprecated("Use addFileMetadata(input: AddFileMetadataWithFileIdInput): Future[List[FileMetadataWithFileId]]")
-  def addFileMetadata(addFileMetadataInput: AddFileMetadataWithFileIdInputValues, userId: UUID): Future[FileMetadataWithFileId] =
-    addFileMetadata(AddFileMetadataWithFileIdInput(addFileMetadataInput :: Nil), userId).map(_.head)
-
   def addFileMetadata(input: AddFileMetadataWithFileIdInput, userId: UUID): Future[List[FileMetadataWithFileId]] = {
     val metadataRow = input.metadataInputValues
       .map(addFileMetadataInput => {


### PR DESCRIPTION
[TDR-3064](https://national-archives.atlassian.net/browse/TDR-3064?atlOrigin=eyJpIjoiMzE2OGUyODYzNGFmNDZjM2I4ZjBjNDJlNjgzN2RkMDkiLCJwIjoiaiJ9)

Ticket is to remove a depreciated method in such a way as to not impact other services. This method seems to only be referenced internally, and tests pass locally.

- [x] Method removed
- [x] Graphql schema updated 


[TDR-3064]: https://national-archives.atlassian.net/browse/TDR-3064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ