### PR TITLE
Include consignment id as a delete metadata argument

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -211,6 +211,7 @@ type DeleteFileMetadata {
 input DeleteFileMetadataInput {
   fileIds: [UUID!]!
   propertyNames: [String!]!
+  consignmentId: UUID
 }
 
 type DisplayAttribute {

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/FileMetadataFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/FileMetadataFields.scala
@@ -36,7 +36,8 @@ object FileMetadataFields {
 
   case class DeleteFileMetadataInput(
       fileIds: Seq[UUID],
-      propertyNames: Seq[String]
+      propertyNames: Seq[String],
+      consignmentId: Option[UUID] = None
   )
 
   implicit val FileMetadataType: ObjectType[Unit, FileMetadata] = deriveObjectType[Unit, FileMetadata]()


### PR DESCRIPTION
This will negate the need to retrieve the consignment id from the first file data