### PR TITLE
Use consignment id arg instead of value from file

### DIFF
--- a/src/test/resources/json/deletefilemetadata_data_error_no_consignmentid.json
+++ b/src/test/resources/json/deletefilemetadata_data_error_no_consignmentid.json
@@ -1,0 +1,14 @@
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "No consignment id",
+      "locations": [
+        {
+          "column": 33,
+          "line": 1
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/json/deletefilemetadata_data_error_not_file_owner.json
+++ b/src/test/resources/json/deletefilemetadata_data_error_not_file_owner.json
@@ -2,7 +2,7 @@
   "data": null,
   "errors": [
     {
-      "message": "User '29f65c4e-0eb8-4719-afdb-ace1bcbae4b6' does not own the files they are trying to access:\n7076f399-b596-4161-a95d-e686c6435710\n51c55218-1322-4453-9ef8-2300ef1c0fef or does not have export access"
+      "message": "User '29f65c4e-0eb8-4719-afdb-ace1bcbae4b6' does not own the files they are trying to access:\n51c55218-1322-4453-9ef8-2300ef1c0fef\n7076f399-b596-4161-a95d-e686c6435710 or does not have export access"
     }
   ]
 }

--- a/src/test/resources/json/deletefilemetadata_data_error_not_file_owner.json
+++ b/src/test/resources/json/deletefilemetadata_data_error_not_file_owner.json
@@ -2,7 +2,7 @@
   "data": null,
   "errors": [
     {
-      "message": "User '29f65c4e-0eb8-4719-afdb-ace1bcbae4b6' does not own the files they are trying to access:\n7076f399-b596-4161-a95d-e686c6435710\nd74650ff-21b1-402d-8c59-b114698a8341 or does not have export access"
+      "message": "User '29f65c4e-0eb8-4719-afdb-ace1bcbae4b6' does not own the files they are trying to access:\n7076f399-b596-4161-a95d-e686c6435710\n51c55218-1322-4453-9ef8-2300ef1c0fef or does not have export access"
     }
   ]
 }

--- a/src/test/resources/json/deletefilemetadata_mutation_alldata.json
+++ b/src/test/resources/json/deletefilemetadata_mutation_alldata.json
@@ -4,13 +4,14 @@
     "deleteFileMetadataInput" : {
       "fileIds": [
         "7076f399-b596-4161-a95d-e686c6435710",
-        "d74650ff-21b1-402d-8c59-b114698a8341"
+        "51c55218-1322-4453-9ef8-2300ef1c0fef"
       ],
       "propertyNames": [
         "TestDependency1",
         "TestDependency2",
         "ClosureType"
-      ]
+      ],
+      "consignmentId": "57a0b4cd-4dc1-4be4-a8c1-2d93fce54413"
     }
   }
 }

--- a/src/test/resources/json/deletefilemetadata_mutation_no_consignmentid.json
+++ b/src/test/resources/json/deletefilemetadata_mutation_no_consignmentid.json
@@ -1,0 +1,16 @@
+{
+  "query": "mutation deleteFileMetadata($deleteFileMetadataInput: DeleteFileMetadataInput!) {deleteFileMetadata(deleteFileMetadataInput:$deleteFileMetadataInput) {fileIds,filePropertyNames}}",
+  "variables": {
+    "deleteFileMetadataInput" : {
+      "fileIds": [
+        "7076f399-b596-4161-a95d-e686c6435710",
+        "51c55218-1322-4453-9ef8-2300ef1c0fef"
+      ],
+      "propertyNames": [
+        "TestDependency1",
+        "TestDependency2",
+        "ClosureType"
+      ]
+    }
+  }
+}

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileMetadataRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileMetadataRouteSpec.scala
@@ -402,7 +402,7 @@ class FileMetadataRouteSpec extends TestContainerUtils with Matchers with TestRe
 
   "deleteFileMetadata" should "delete file metadata or set the relevant default values for the given fileIds" in withContainers { case container: PostgreSQLContainer =>
     val utils = TestUtils(container.database)
-    val consignmentId = UUID.randomUUID()
+    val consignmentId = UUID.fromString("57a0b4cd-4dc1-4be4-a8c1-2d93fce54413")
     val folderOneId = UUID.fromString("d74650ff-21b1-402d-8c59-b114698a8341")
     val fileOneId = UUID.fromString("51c55218-1322-4453-9ef8-2300ef1c0fef")
     val fileTwoId = UUID.fromString("7076f399-b596-4161-a95d-e686c6435710")
@@ -439,7 +439,7 @@ class FileMetadataRouteSpec extends TestContainerUtils with Matchers with TestRe
   forAll(statusValues)(statusValue => {
     "deleteFileMetadata" should s"set the consignment status to $statusValue if an existing file is $statusValue" in withContainers { case container: PostgreSQLContainer =>
       val utils = TestUtils(container.database)
-      val consignmentId = UUID.randomUUID()
+      val consignmentId = UUID.fromString("57a0b4cd-4dc1-4be4-a8c1-2d93fce54413")
       val folderOneId = UUID.fromString("d74650ff-21b1-402d-8c59-b114698a8341")
       val fileOneId = UUID.fromString("51c55218-1322-4453-9ef8-2300ef1c0fef")
       val fileTwoId = UUID.fromString("7076f399-b596-4161-a95d-e686c6435710")


### PR DESCRIPTION
Requires PR: https://github.com/nationalarchives/tdr-transfer-frontend/pull/3094

To remove the need to make an extra call to the DB use the consignment id arg passed into the mutation