### PR TITLE
TDR-3367 - Update file format lambda to pass mismatch value 

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -239,6 +239,7 @@ input FFIDMetadataInputMatches {
   extension: String
   identificationBasis: String!
   puid: String
+  fileExtensionMismatch: Boolean = false
 }
 
 input FFIDMetadataInputValues {
@@ -256,6 +257,7 @@ type FFIDMetadataMatches {
   extension: String
   identificationBasis: String!
   puid: String
+  fileExtensionMismatch: Boolean
 }
 
 type FFIDProgress {

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/FFIDMetadataFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/FFIDMetadataFields.scala
@@ -35,8 +35,8 @@ object FFIDMetadataFields {
       fileExtensionMismatch: Option[Boolean] = Some(false)
   )
 
-  case class FFIDMetadataInputMatches(extension: Option[String] = None, identificationBasis: String, puid: Option[String])
-  case class FFIDMetadataMatches(extension: Option[String] = None, identificationBasis: String, puid: Option[String])
+  case class FFIDMetadataInputMatches(extension: Option[String] = None, identificationBasis: String, puid: Option[String], fileExtensionMismatch: Option[Boolean] = Some(false))
+  case class FFIDMetadataMatches(extension: Option[String] = None, identificationBasis: String, puid: Option[String], fileExtensionMismatch: Option[Boolean] = Some(false))
 
   implicit val FFIDMetadataInputMatchesType: ObjectType[Unit, FFIDMetadataMatches] = deriveObjectType[Unit, FFIDMetadataMatches]()
   implicit val FFIDMetadataInputMatchesInputType: InputObjectType[FFIDMetadataInputMatches] = deriveInputObjectType[FFIDMetadataInputMatches]()


### PR DESCRIPTION
[ticket TDR-3367](https://national-archives.atlassian.net/browse/TDR-3367?atlOrigin=eyJpIjoiNzBlNTY4NzgzNWMwNGNjNmFiMDZlZDhhNzk3MzA3OGEiLCJwIjoiaiJ9) 

- [x] Proposed further changes to graphql schema based on object used by the file format api.

[Example of object used in context here](https://github.com/nationalarchives/tdr-file-format/blob/c916b61de60f9751a8fa1be93f92928ae62daa05/src/main/scala/uk/gov/nationalarchives/fileformat/FFIDExtractor.scala#L27C44-L27C68)