### PR TITLE
Add fileReference and parentReference to fileMetadata

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
@@ -138,6 +138,8 @@ object FileMetadataService {
   val ClosureStartDate = "ClosureStartDate"
   val Filename = "Filename"
   val FileType = "FileType"
+  val FileReference = "FileReference"
+  val ParentReference = "ParentReference"
   val FoiExemptionAsserted = "FoiExemptionAsserted"
   val TitleClosed = "TitleClosed"
   val DescriptionClosed = "DescriptionClosed"
@@ -154,7 +156,8 @@ object FileMetadataService {
   val HeldBy: StaticMetadata = StaticMetadata("HeldBy", "TNA")
   val Language: StaticMetadata = StaticMetadata("Language", "English")
   val FoiExemptionCode: StaticMetadata = StaticMetadata("FoiExemptionCode", "open")
-  val clientSideProperties: List[String] = List(SHA256ClientSideChecksum, ClientSideOriginalFilepath, ClientSideFileLastModifiedDate, ClientSideFileSize, Filename, FileType)
+  val clientSideProperties: List[String] =
+    List(SHA256ClientSideChecksum, ClientSideOriginalFilepath, ClientSideFileLastModifiedDate, ClientSideFileSize, Filename, FileType, FileReference, ParentReference)
 
   def getFileMetadataValues(fileMetadataRow: Seq[FilemetadataRow]): FileMetadataValues = {
     val propertyNameMap: Map[String, String] = fileMetadataRow.groupBy(_.propertyname).transform { (_, value) =>

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
@@ -157,7 +157,8 @@ object FileMetadataService {
   val Language: StaticMetadata = StaticMetadata("Language", "English")
   val FoiExemptionCode: StaticMetadata = StaticMetadata("FoiExemptionCode", "open")
   val clientSideProperties: List[String] =
-    List(SHA256ClientSideChecksum, ClientSideOriginalFilepath, ClientSideFileLastModifiedDate, ClientSideFileSize, Filename, FileType, FileReference, ParentReference)
+    List(SHA256ClientSideChecksum, ClientSideOriginalFilepath, ClientSideFileLastModifiedDate, ClientSideFileSize, Filename, FileType)
+  val serverSideProperties: List[String] = List(FileReference, ParentReference)
 
   def getFileMetadataValues(fileMetadataRow: Seq[FilemetadataRow]): FileMetadataValues = {
     val propertyNameMap: Map[String, String] = fileMetadataRow.groupBy(_.propertyname).transform { (_, value) =>

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileService.scala
@@ -73,7 +73,9 @@ class FileService(
         val commonMetadataRows = List(
           row(fileId, path, ClientSideOriginalFilepath),
           row(fileId, treeNode.treeNodeType, FileType),
-          row(fileId, treeNode.name, Filename)
+          row(fileId, treeNode.name, Filename),
+          row(fileId, treeNode.reference.getOrElse(""), FileReference),
+          row(fileId, parentFileReference.getOrElse(""), ParentReference)
         ) ++ filePropertyValue.map(fileProperty => row(fileId, fileProperty.propertyvalue, fileProperty.propertyname)).toList
 
         if (treeNode.treeNodeType.isFileType) {

--- a/src/test/resources/json/getconsignment_data_all.json
+++ b/src/test/resources/json/getconsignment_data_all.json
@@ -66,6 +66,14 @@
             {
               "name": "FoiExemptionCode",
               "value": "FoiExemptionCode value"
+            },
+            {
+              "name": "FileReference",
+              "value": "FileReference value"
+            },
+            {
+              "name": "ParentReference",
+              "value": "ParentReference value"
             }
           ],
           "metadata": {

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
@@ -6,7 +6,7 @@ import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.auto._
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
-import uk.gov.nationalarchives.tdr.api.service.FileMetadataService.{FileReference, FileType, Filename, ParentReference, clientSideProperties}
+import uk.gov.nationalarchives.tdr.api.service.FileMetadataService.{FileReference, FileType, Filename, ParentReference, clientSideProperties, serverSideProperties}
 import uk.gov.nationalarchives.tdr.api.utils.TestAuthUtils._
 import uk.gov.nationalarchives.tdr.api.utils.TestContainerUtils._
 import uk.gov.nationalarchives.tdr.api.utils.TestUtils._
@@ -50,7 +50,7 @@ class FileRouteSpec extends TestContainerUtils with Matchers with TestRequest {
   "The api" should "add files and metadata entries for files and directories" in withContainers { case container: PostgreSQLContainer =>
     val consignmentId = UUID.fromString("c44f1b9b-1275-4bc3-831c-808c50a0222d")
     val utils = TestUtils(container.database)
-    (clientSideProperties ++ staticMetadataProperties.map(_.name)).foreach(utils.addFileProperty)
+    (clientSideProperties ++ serverSideProperties ++ staticMetadataProperties.map(_.name)).foreach(utils.addFileProperty)
     utils.createConsignment(consignmentId, userId)
 
     staticMetadataProperties.foreach(staticMetadata => utils.createFilePropertyValues(staticMetadata.name, staticMetadata.value, default = true, 1, 1))
@@ -60,6 +60,7 @@ class FileRouteSpec extends TestContainerUtils with Matchers with TestRequest {
     val expectedCount = ((Filename :: FileType :: FileReference :: ParentReference :: staticMetadataProperties).size * distinctDirectoryCount) +
       (staticMetadataProperties.size * fileCount) +
       (clientSideProperties.size * fileCount) +
+      (serverSideProperties.size * fileCount) +
       distinctDirectoryCount
 
     utils.countAllFileMetadata() should equal(expectedCount)
@@ -76,7 +77,7 @@ class FileRouteSpec extends TestContainerUtils with Matchers with TestRequest {
   "The api" should "return file ids matched with sequence ids for addFilesAndMetadata" in withContainers { case container: PostgreSQLContainer =>
     val consignmentId = UUID.fromString("1cd5e07a-34c8-4751-8e81-98edd17d1729")
     val utils = TestUtils(container.database)
-    (clientSideProperties ++ staticMetadataProperties.map(_.name)).foreach(utils.addFileProperty)
+    (clientSideProperties ++ serverSideProperties ++ staticMetadataProperties.map(_.name)).foreach(utils.addFileProperty)
     utils.createConsignment(consignmentId, userId)
 
     val expectedResponse = expectedFilesAndMetadataMutationResponse("data_all")

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
@@ -6,7 +6,7 @@ import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.auto._
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
-import uk.gov.nationalarchives.tdr.api.service.FileMetadataService.{FileType, Filename, clientSideProperties}
+import uk.gov.nationalarchives.tdr.api.service.FileMetadataService.{FileReference, FileType, Filename, ParentReference, clientSideProperties}
 import uk.gov.nationalarchives.tdr.api.utils.TestAuthUtils._
 import uk.gov.nationalarchives.tdr.api.utils.TestContainerUtils._
 import uk.gov.nationalarchives.tdr.api.utils.TestUtils._
@@ -57,7 +57,7 @@ class FileRouteSpec extends TestContainerUtils with Matchers with TestRequest {
     val res = runTestMutationFileMetadata("mutation_alldata_2", validUserToken())
     val distinctDirectoryCount = 3
     val fileCount = 5
-    val expectedCount = ((Filename :: FileType :: staticMetadataProperties).size * distinctDirectoryCount) +
+    val expectedCount = ((Filename :: FileType :: FileReference :: ParentReference :: staticMetadataProperties).size * distinctDirectoryCount) +
       (staticMetadataProperties.size * fileCount) +
       (clientSideProperties.size * fileCount) +
       distinctDirectoryCount

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataServiceSpec.scala
@@ -606,6 +606,36 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     FileMetadataFields.SHA256ServerSideChecksum should equal("SHA256ServerSideChecksum")
   }
 
+  "The FileMetadataService property names" should "have the correct values" in {
+    FileMetadataService.SHA256ClientSideChecksum shouldEqual "SHA256ClientSideChecksum"
+    FileMetadataService.ClientSideOriginalFilepath shouldEqual "ClientSideOriginalFilepath"
+    FileMetadataService.OriginalFilepath shouldEqual "OriginalFilepath"
+    FileMetadataService.ClientSideFileLastModifiedDate shouldEqual "ClientSideFileLastModifiedDate"
+    FileMetadataService.ClientSideFileSize shouldEqual "ClientSideFileSize"
+    FileMetadataService.ClosurePeriod shouldEqual "ClosurePeriod"
+    FileMetadataService.ClosureStartDate shouldEqual "ClosureStartDate"
+    FileMetadataService.Filename shouldEqual "Filename"
+    FileMetadataService.FileType shouldEqual "FileType"
+    FileMetadataService.FileReference shouldEqual "FileReference"
+    FileMetadataService.ParentReference shouldEqual "ParentReference"
+    FileMetadataService.FoiExemptionAsserted shouldEqual "FoiExemptionAsserted"
+    FileMetadataService.TitleClosed shouldEqual "TitleClosed"
+    FileMetadataService.DescriptionClosed shouldEqual "DescriptionClosed"
+    FileMetadataService.ClosureType shouldEqual "ClosureType"
+    FileMetadataService.Description shouldEqual "description"
+    FileMetadataService.DescriptionAlternate shouldEqual "DescriptionAlternate"
+    FileMetadataService.RightsCopyright.name shouldEqual "RightsCopyright"
+    FileMetadataService.RightsCopyright.value shouldEqual "Crown Copyright"
+    FileMetadataService.LegalStatus.name shouldEqual "LegalStatus"
+    FileMetadataService.LegalStatus.value shouldEqual "Public Record"
+    FileMetadataService.HeldBy.name shouldEqual "HeldBy"
+    FileMetadataService.HeldBy.value shouldEqual "TNA"
+    FileMetadataService.Language.name shouldEqual "Language"
+    FileMetadataService.Language.value shouldEqual "English"
+    FileMetadataService.FoiExemptionCode.name shouldEqual "FoiExemptionCode"
+    FileMetadataService.FoiExemptionCode.value shouldEqual "open"
+  }
+
   private def generateFileStatusRows(fileIds: Seq[UUID]) = {
     fileIds.map(id => FilestatusRow(UUID.randomUUID(), id, "statusType", "value", Timestamp.from(FixedTimeSource.now)))
   }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
@@ -784,7 +784,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
       row.consignmentid should equal(consignmentId)
       row.userid should equal(userId)
     })
-    val expectedSize = 46
+    val expectedSize = 56
     metadataRows.size should equal(expectedSize)
     staticMetadataProperties.foreach(prop => {
       metadataRows.count(r => r.propertyname == prop.name && r.value == prop.value) should equal(5)
@@ -878,7 +878,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     })
     val file = fileRows.find(_.filereference.contains("ref4"))
     file.get.parentreference should equal(Some("ref2"))
-    val expectedSize = 46
+    val expectedSize = 56
     metadataRows.size should equal(expectedSize)
     staticMetadataProperties.foreach(prop => {
       metadataRows.count(r => r.propertyname == prop.name && r.value == prop.value) should equal(5)
@@ -971,7 +971,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
       row.consignmentid should equal(consignmentId)
       row.userid should equal(userId)
     })
-    val expectedSize = 30
+    val expectedSize = 36
     metadataRows.size should equal(expectedSize)
     staticMetadataProperties.foreach(prop => {
       metadataRows.count(r => r.propertyname == prop.name && r.value == prop.value) should equal(3)

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
@@ -793,8 +793,8 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     clientSideProperties.foreach(prop => {
       val count = metadataRows.count(r => r.propertyname == prop)
       prop match {
-        case ClientSideOriginalFilepath | Filename | FileType => count should equal(5) // Directories have this set
-        case _                                                => count should equal(2)
+        case ClientSideOriginalFilepath | Filename | FileType | FileReference | ParentReference => count should equal(5) // Directories have this set
+        case _                                                                                  => count should equal(2)
       }
     })
     verify(consignmentStatusRepositoryMock, times(0)).updateConsignmentStatus(any[UUID], any[String], any[String], any[Timestamp])
@@ -887,8 +887,8 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     clientSideProperties.foreach(prop => {
       val count = metadataRows.count(r => r.propertyname == prop)
       prop match {
-        case ClientSideOriginalFilepath | Filename | FileType => count should equal(5) // Directories have this set
-        case _                                                => count should equal(2)
+        case ClientSideOriginalFilepath | Filename | FileType | FileReference | ParentReference => count should equal(5) // Directories have this set
+        case _                                                                                  => count should equal(2)
       }
     })
     verify(consignmentStatusRepositoryMock, times(0)).updateConsignmentStatus(any[UUID], any[String], any[String], any[Timestamp])
@@ -980,8 +980,8 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     clientSideProperties.foreach(prop => {
       val count = metadataRows.count(r => r.propertyname == prop)
       prop match {
-        case ClientSideOriginalFilepath | Filename | FileType => count should equal(3) // Directories have this set
-        case _                                                => count should equal(2)
+        case ClientSideOriginalFilepath | Filename | FileType | FileReference | ParentReference => count should equal(3) // Directories have this set
+        case _                                                                                  => count should equal(2)
       }
     })
     verify(consignmentStatusRepositoryMock, times(0)).updateConsignmentStatus(any[UUID], any[String], any[String], any[Timestamp])


### PR DESCRIPTION
FileReference and ParentReference needs to be inserted into the FileMetadata table in order to included in the export bagit.