### PR TITLE
TDR-3536 Remove `metadataid` creation for FileMetadata table

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-generic-extras" % "0.14.3",
   "com.softwaremill.sttp.client3" %% "core" % "3.9.0",
-  "uk.gov.nationalarchives" %% "consignment-api-db" % "0.1.38",
+  "uk.gov.nationalarchives" %% "consignment-api-db" % "0.1.39",
   "org.postgresql" % "postgresql" % "42.6.0",
   "com.typesafe.slick" %% "slick" % "3.4.1",
   "com.typesafe.slick" %% "slick-hikaricp" % "3.4.1",

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileMetadataRepository.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileMetadataRepository.scala
@@ -3,8 +3,7 @@ package uk.gov.nationalarchives.tdr.api.db.repository
 import slick.jdbc.H2Profile.ProfileAction
 import slick.jdbc.PostgresProfile.api._
 import uk.gov.nationalarchives.Tables.{Filemetadata, _}
-import uk.gov.nationalarchives.tdr.api.graphql.fields.FileMetadataFields.AddFileMetadataInput
-import uk.gov.nationalarchives.tdr.api.service.FileMetadataService.ClientSideFileSize
+import uk.gov.nationalarchives.tdr.api.service.FileMetadataService.{AddFileMetadataInput, ClientSideFileSize}
 
 import java.sql.Timestamp
 import java.util.UUID

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileMetadataRepository.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileMetadataRepository.scala
@@ -17,7 +17,7 @@ class FileMetadataRepository(db: Database)(implicit val executionContext: Execut
     FilemetadataRow(dbGeneratedValues._1, fileMetadata._1, fileMetadata._2, dbGeneratedValues._2, fileMetadata._3, fileMetadata._4)
   )
 
-  def getSumOfFileSizes(consignmentId: UUID): Future[Int] = {
+  def getSumOfFileSizes(consignmentId: UUID): Future[Long] = {
     val query = Filemetadata
       .join(File)
       .on(_.fileid === _.fileid)
@@ -29,7 +29,7 @@ class FileMetadataRepository(db: Database)(implicit val executionContext: Execut
     db.run(query.result)
   }
 
-  def addFileMetadata(rows: Seq[AddFileMetadataInput]): Future[Seq[Tables.FilemetadataRow]] = {
+  def addFileMetadata(rows: Seq[AddFileMetadataInput]): Future[Seq[FilemetadataRow]] = {
     db.run(insertFileMetadataQuery ++= rows.map(i => (i.fileId, i.value, i.userId, i.filePropertyName)))
   }
 

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/FileMetadataFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/FileMetadataFields.scala
@@ -19,7 +19,6 @@ object FileMetadataFields {
 
   val SHA256ServerSideChecksum = "SHA256ServerSideChecksum"
 
-  case class AddFileMetadataInput(fileId: UUID, value: String, userId: UUID, filePropertyName: String)
   case class FileMetadata(filePropertyName: String, value: String) extends FileMetadataBase
   case class UpdateFileMetadataInput(filePropertyIsMultiValue: Boolean, filePropertyName: String, value: String) extends FileMetadataBase
   // Option[String] instead of String in case you want to delete all values of property or in case value does not have properties

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/FileMetadataFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/FileMetadataFields.scala
@@ -19,6 +19,7 @@ object FileMetadataFields {
 
   val SHA256ServerSideChecksum = "SHA256ServerSideChecksum"
 
+  case class AddFileMetadataInput(fileId: UUID, value: String, userId: UUID, filePropertyName: String)
   case class FileMetadata(filePropertyName: String, value: String) extends FileMetadataBase
   case class UpdateFileMetadataInput(filePropertyIsMultiValue: Boolean, filePropertyName: String, value: String) extends FileMetadataBase
   // Option[String] instead of String in case you want to delete all values of property or in case value does not have properties

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/http/GraphQLServerBase.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/http/GraphQLServerBase.scala
@@ -72,16 +72,8 @@ trait GraphQLServerBase {
     val customMetadataPropertiesService = new CustomMetadataPropertiesService(customMetadataPropertiesRepository)
     val validateFileMetadataService = new ValidateFileMetadataService(customMetadataPropertiesService, fileMetadataRepository, fileStatusRepository)
     val consignmentStatusService = new ConsignmentStatusService(consignmentStatusRepository, fileStatusRepository, uuidSource, timeSource)
-    val fileMetadataService = new FileMetadataService(
-      fileMetadataRepository,
-      consignmentStatusService,
-      customMetadataPropertiesService,
-      validateFileMetadataService,
-      timeSource,
-      uuidSource
-    )
-    val ffidMetadataService =
-      new FFIDMetadataService(ffidMetadataRepository, ffidMetadataMatchesRepository, timeSource, uuidSource)
+    val fileMetadataService = new FileMetadataService(fileMetadataRepository, consignmentStatusService, customMetadataPropertiesService, validateFileMetadataService)
+    val ffidMetadataService = new FFIDMetadataService(ffidMetadataRepository, ffidMetadataMatchesRepository, timeSource, uuidSource)
     val fileStatusService = new FileStatusService(fileStatusRepository)
     val displayPropertiesService = new DisplayPropertiesService(displayPropertiesRepository)
     val referenceGeneratorService = new ReferenceGeneratorService(config, SimpleHttpClient())

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
@@ -52,7 +52,7 @@ class FileMetadataService(
 
     for {
       _ <- fileMetadataRepository.deleteFileMetadata(uniqueFileIds, distinctPropertyNames)
-      addedRows <- fileMetadataRepository.addFileMetadata(generateFileMetadataRows(uniqueFileIds, distinctMetadataProperties, userId))
+      addedRows <- fileMetadataRepository.addFileMetadata(generateFileMetadataInput(uniqueFileIds, distinctMetadataProperties, userId))
       _ <- validateFileMetadataService.validateAdditionalMetadata(uniqueFileIds, distinctPropertyNames)
       _ <- consignmentStatusService.updateMetadataConsignmentStatus(consignmentId, List(DescriptiveMetadata, ClosureMetadata))
       metadataPropertiesAdded = addedRows.map(r => { FileMetadata(r.propertyname, r.value) }).toSet
@@ -107,7 +107,7 @@ class FileMetadataService(
     } else originalPropertyNames
   }
 
-  private def generateFileMetadataRows(fileIds: Set[UUID], inputs: Set[UpdateFileMetadataInput], userId: UUID): List[AddFileMetadataInput] = {
+  private def generateFileMetadataInput(fileIds: Set[UUID], inputs: Set[UpdateFileMetadataInput], userId: UUID): List[AddFileMetadataInput] = {
     fileIds
       .flatMap(fileId =>
         {
@@ -183,6 +183,8 @@ object FileMetadataService {
   case class StaticMetadata(name: String, value: String)
 
   case class FileMetadataValue(name: String, value: String)
+
+  case class AddFileMetadataInput(fileId: UUID, value: String, userId: UUID, filePropertyName: String)
 
   case class File(
       fileId: UUID,

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileMetadataRepositorySpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileMetadataRepositorySpec.scala
@@ -6,8 +6,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Seconds, Span}
 import uk.gov.nationalarchives.Tables.FilemetadataRow
-import uk.gov.nationalarchives.tdr.api.graphql.fields.FileMetadataFields.AddFileMetadataInput
-import uk.gov.nationalarchives.tdr.api.service.FileMetadataService.ClientSideFileSize
+import uk.gov.nationalarchives.tdr.api.service.FileMetadataService.{AddFileMetadataInput, ClientSideFileSize}
 import uk.gov.nationalarchives.tdr.api.utils.TestAuthUtils.userId
 import uk.gov.nationalarchives.tdr.api.utils.TestContainerUtils._
 import uk.gov.nationalarchives.tdr.api.utils.{TestContainerUtils, TestUtils}

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileMetadataRepositorySpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileMetadataRepositorySpec.scala
@@ -6,6 +6,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Seconds, Span}
 import uk.gov.nationalarchives.Tables.FilemetadataRow
+import uk.gov.nationalarchives.tdr.api.graphql.fields.FileMetadataFields.AddFileMetadataInput
 import uk.gov.nationalarchives.tdr.api.service.FileMetadataService.ClientSideFileSize
 import uk.gov.nationalarchives.tdr.api.utils.TestAuthUtils.userId
 import uk.gov.nationalarchives.tdr.api.utils.TestContainerUtils._
@@ -37,7 +38,7 @@ class FileMetadataRepositorySpec extends TestContainerUtils with ScalaFutures wi
     utils.addFileProperty("FileProperty")
     utils.createConsignment(consignmentId, userId)
     utils.createFile(fileId, consignmentId)
-    val input = Seq(FilemetadataRow(UUID.randomUUID(), fileId, "value", Timestamp.from(Instant.now()), UUID.randomUUID(), "FileProperty"))
+    val input = Seq(AddFileMetadataInput(fileId, "value", UUID.randomUUID(), "FileProperty"))
     val result = fileMetadataRepository.addFileMetadata(input).futureValue.head
     result.propertyname should equal("FileProperty")
     result.value should equal("value")
@@ -54,7 +55,7 @@ class FileMetadataRepositorySpec extends TestContainerUtils with ScalaFutures wi
     utils.createConsignment(consignmentId, userId)
     utils.createFile(fileId, consignmentId)
     val numberOfFileMetadataRows = 100
-    val input = (1 to numberOfFileMetadataRows).map(_ => FilemetadataRow(UUID.randomUUID(), fileId, "value", Timestamp.from(Instant.now()), UUID.randomUUID(), "FileProperty"))
+    val input = (1 to numberOfFileMetadataRows).map(_ => AddFileMetadataInput(fileId, "value", UUID.randomUUID(), "FileProperty"))
 
     val result = fileMetadataRepository.addFileMetadata(input).futureValue
 

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataServiceSpec.scala
@@ -38,7 +38,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     val metadataId: UUID = fixedUUIDSource.uuid
     fixedUUIDSource.reset
 
-    val addChecksumCaptor: ArgumentCaptor[List[FilemetadataRow]] = ArgumentCaptor.forClass(classOf[List[FilemetadataRow]])
+    val addChecksumCaptor: ArgumentCaptor[List[AddFileMetadataInput]] = ArgumentCaptor.forClass(classOf[List[AddFileMetadataInput]])
     val getFileMetadataFileCaptor: ArgumentCaptor[List[UUID]] = ArgumentCaptor.forClass(classOf[List[UUID]])
     val getFileMetadataPropertyNameCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
     val mockFileMetadataResponse =
@@ -50,24 +50,17 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
       .thenReturn(Future(mockFileMetadataResponse))
     when(validateFileMetadataServiceMock.validateAdditionalMetadata(any[Set[UUID]], any[Set[String]])).thenReturn(Future(List()))
 
-    val service = new FileMetadataService(
-      metadataRepositoryMock,
-      consignmentStatusServiceMock,
-      customMetadataServiceMock,
-      validateFileMetadataServiceMock,
-      FixedTimeSource,
-      fixedUUIDSource
-    )
+    val service = new FileMetadataService(metadataRepositoryMock, consignmentStatusServiceMock, customMetadataServiceMock, validateFileMetadataServiceMock)
     service.addFileMetadata(createInput(SHA256ServerSideChecksum, fixedFileUuid, "value"), fixedUserId).futureValue
 
     verify(validateFileMetadataServiceMock, times(0)).validateAdditionalMetadata(any[Set[UUID]], any[Set[String]])
 
     val row = addChecksumCaptor.getValue.head
-    row.propertyname should equal(SHA256ServerSideChecksum)
-    row.fileid should equal(fixedFileUuid)
-    row.userid should equal(fixedUserId)
-    row.datetime should equal(Timestamp.from(FixedTimeSource.now))
-    row.metadataid.shouldBe(metadataId)
+    row.filePropertyName should equal(SHA256ServerSideChecksum)
+    row.fileId should equal(fixedFileUuid)
+    row.userId should equal(fixedUserId)
+//    row.datetime should equal(Timestamp.from(FixedTimeSource.now))
+//    row.metadataid.shouldBe(metadataId)
   }
 
   def createInput(propertyName: String, fileId: UUID, value: String): AddFileMetadataWithFileIdInput = {
@@ -91,17 +84,10 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     val mockClientChecksumRow = FilemetadataRow(UUID.randomUUID(), fixedFileUuid, "ChecksumMatch", timestamp, fixedUserId, SHA256ClientSideChecksum)
     val mockClientChecksumResponse = Future(Seq(mockClientChecksumRow))
 
-    when(metadataRepositoryMock.addFileMetadata(any[List[FilemetadataRow]])).thenReturn(mockMetadataResponse)
+    when(metadataRepositoryMock.addFileMetadata(any[List[AddFileMetadataInput]])).thenReturn(mockMetadataResponse)
     when(metadataRepositoryMock.getFileMetadataByProperty(fixedFileUuid :: Nil, SHA256ClientSideChecksum)).thenReturn(mockClientChecksumResponse)
 
-    val service = new FileMetadataService(
-      metadataRepositoryMock,
-      consignmentStatusServiceMock,
-      customMetadataServiceMock,
-      validateFileMetadataServiceMock,
-      FixedTimeSource,
-      fixedUUIDSource
-    )
+    val service = new FileMetadataService(metadataRepositoryMock, consignmentStatusServiceMock, customMetadataServiceMock, validateFileMetadataServiceMock)
     val result: FileMetadataWithFileId =
       service.addFileMetadata(createInput(propertyName, fixedFileUuid, "value"), fixedUserId).futureValue.head
 
@@ -123,9 +109,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
       testSetUp.metadataRepositoryMock,
       testSetUp.consignmentStatusServiceMock,
       customMetadataSetUp.customMetadataServiceMock,
-      testSetUp.validateFileMetadataServiceMock,
-      FixedTimeSource,
-      testSetUp.fixedUUIDSource
+      testSetUp.validateFileMetadataServiceMock
     )
 
     val input = UpdateBulkFileMetadataInput(testSetUp.consignmentId, fileIds, testSetUp.newMetadataProperties)
@@ -136,7 +120,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
 
     val deleteFileMetadataIdsArg: Set[UUID] = testSetUp.deleteFileMetadataIdsArgCaptor.getValue
     val deleteFileMetadataPropertiesArg: Set[String] = testSetUp.deletePropertyNamesCaptor.getValue
-    val addFileMetadataArgument: Seq[FilemetadataRow] = testSetUp.addFileMetadataCaptor.getValue
+    val addFileMetadataArgument: Seq[AddFileMetadataInput] = testSetUp.addFileMetadataCaptor.getValue
 
     val expectedUpdatedIds: Set[UUID] = Set(testSetUp.fileId1, testSetUp.childFileId1, testSetUp.childFileId2)
     val expectedUpdatedPropertyNames: Set[String] = Set("propertyName1", "propertyName2", "propertyName3")
@@ -146,7 +130,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     deleteFileMetadataPropertiesArg should equal(expectedUpdatedPropertyNames)
 
     addFileMetadataArgument.size should equal(12)
-    val addedFileIds = addFileMetadataArgument.map(_.fileid).toSet
+    val addedFileIds = addFileMetadataArgument.map(_.fileId).toSet
     addedFileIds.size should equal(deleteFileMetadataIdsArg.size)
     addedFileIds.subsetOf(expectedUpdatedIds) should equal(true)
 
@@ -154,7 +138,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     addedPropertyValues.size should equal(4)
     addedPropertyValues.subsetOf(expectedUpdatedPropertyValues) should equal(true)
 
-    val addedProperties = addFileMetadataArgument.map(_.propertyname).toSet
+    val addedProperties = addFileMetadataArgument.map(_.filePropertyName).toSet
     addedProperties.size should equal(3)
     addedProperties.subsetOf(expectedUpdatedPropertyNames) should equal(true)
   }
@@ -171,9 +155,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
       testSetUp.metadataRepositoryMock,
       testSetUp.consignmentStatusServiceMock,
       customMetadataSetUp.customMetadataServiceMock,
-      testSetUp.validateFileMetadataServiceMock,
-      FixedTimeSource,
-      testSetUp.fixedUUIDSource
+      testSetUp.validateFileMetadataServiceMock
     )
 
     val emptyMetadataProperties: Seq[UpdateFileMetadataInput] = Seq(
@@ -190,7 +172,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
 
     verify(testSetUp.fileRepositoryMock, times(0)).getAllDescendants(any[Seq[UUID]])
     verify(testSetUp.metadataRepositoryMock, times(0)).deleteFileMetadata(any[Set[UUID]], any[Set[String]])
-    verify(testSetUp.metadataRepositoryMock, times(0)).addFileMetadata(any[Seq[FilemetadataRow]])
+    verify(testSetUp.metadataRepositoryMock, times(0)).addFileMetadata(any[Seq[AddFileMetadataInput]])
     verify(testSetUp.validateFileMetadataServiceMock, times(0)).validateAdditionalMetadata(any[Set[UUID]], any[Set[String]])
 
     thrownException.getMessage should include("Cannot update properties with empty value: Property1, Property3")
@@ -211,14 +193,8 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
       .thenReturn(Future.successful(fileStatusRows.toList))
     val input = UpdateBulkFileMetadataInput(testSetUp.consignmentId, testSetUp.inputFileIds, testSetUp.newMetadataProperties)
 
-    val service = new FileMetadataService(
-      testSetUp.metadataRepositoryMock,
-      consignmentStatusServiceMock,
-      testSetUp.customMetadataServiceMock,
-      testSetUp.validateFileMetadataServiceMock,
-      FixedTimeSource,
-      testSetUp.fixedUUIDSource
-    )
+    val service =
+      new FileMetadataService(testSetUp.metadataRepositoryMock, consignmentStatusServiceMock, testSetUp.customMetadataServiceMock, testSetUp.validateFileMetadataServiceMock)
     service.updateBulkFileMetadata(input, testSetUp.userId).futureValue
 
     verify(consignmentStatusServiceMock, times(1))
@@ -246,14 +222,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     ).thenReturn(mockResponse)
 
     val service =
-      new FileMetadataService(
-        fileMetadataRepositoryMock,
-        consignmentStatusServiceMock,
-        customMetadataServiceMock,
-        validateFileMetadataServiceMock,
-        FixedTimeSource,
-        new FixedUUIDSource()
-      )
+      new FileMetadataService(fileMetadataRepositoryMock, consignmentStatusServiceMock, customMetadataServiceMock, validateFileMetadataServiceMock)
 
     service.getFileMetadata(Some(consignmentId)).futureValue
     consignmentIdCaptor.getValue should equal(Some(consignmentId))
@@ -285,14 +254,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     when(fileMetadataRepositoryMock.getFileMetadata(Some(any[UUID]), any[Option[Set[UUID]]], any[Option[Set[String]]])).thenReturn(mockResponse)
 
     val service =
-      new FileMetadataService(
-        fileMetadataRepositoryMock,
-        consignmentStatusServiceMock,
-        customMetadataServiceMock,
-        validateFileMetadataServiceMock,
-        FixedTimeSource,
-        new FixedUUIDSource()
-      )
+      new FileMetadataService(fileMetadataRepositoryMock, consignmentStatusServiceMock, customMetadataServiceMock, validateFileMetadataServiceMock)
     val response = service.getFileMetadata(Some(consignmentId)).futureValue
 
     response.size should equal(2)
@@ -312,14 +274,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     val consignmentId = UUID.randomUUID()
     when(fileMetadataRepository.getSumOfFileSizes(any[UUID])).thenReturn(Future(1))
 
-    val service = new FileMetadataService(
-      fileMetadataRepository,
-      mock[ConsignmentStatusService],
-      mock[CustomMetadataPropertiesService],
-      mock[ValidateFileMetadataService],
-      FixedTimeSource,
-      new FixedUUIDSource()
-    )
+    val service = new FileMetadataService(fileMetadataRepository, mock[ConsignmentStatusService], mock[CustomMetadataPropertiesService], mock[ValidateFileMetadataService])
     val result = service.getSumOfFileSizes(consignmentId).futureValue
 
     result should equal(1)
@@ -338,20 +293,13 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     customMetadataSetUp.stubResponse()
 
     val service =
-      new FileMetadataService(
-        fileMetadataRepositoryMock,
-        consignmentStatusServiceMock,
-        customMetadataSetUp.customMetadataServiceMock,
-        validateFileMetadataServiceMock,
-        FixedTimeSource,
-        new FixedUUIDSource()
-      )
+      new FileMetadataService(fileMetadataRepositoryMock, consignmentStatusServiceMock, customMetadataSetUp.customMetadataServiceMock, validateFileMetadataServiceMock)
 
     val thrownException = intercept[Exception] {
       service.deleteFileMetadata(DeleteFileMetadataInput(Seq(fileOneId, fileTwoId), Seq("Non-ExistentProperty"), UUID.randomUUID()), UUID.randomUUID()).futureValue
     }
 
-    verify(fileMetadataRepositoryMock, times(0)).addFileMetadata(any[Seq[FilemetadataRow]])
+    verify(fileMetadataRepositoryMock, times(0)).addFileMetadata(any[Seq[AddFileMetadataInput]])
     verify(fileMetadataRepositoryMock, times(0)).deleteFileMetadata(any[Set[UUID]], any[Set[String]])
     verify(customMetadataSetUp.customMetadataServiceMock, times(1)).getCustomMetadata
     verify(validateFileMetadataServiceMock, times(0)).validateAdditionalMetadata(any[Set[UUID]], any[Set[String]])
@@ -369,7 +317,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     val fileInFolderId1 = UUID.fromString("104dde28-21cc-43f6-aa47-d17f120497f5")
     val fileInFolderId2 = UUID.fromString("81643ecc-e618-43bb-829e-f7266565d0b5")
 
-    val addFileMetadataCaptor: ArgumentCaptor[Seq[FilemetadataRow]] = ArgumentCaptor.forClass(classOf[Seq[FilemetadataRow]])
+    val addFileMetadataCaptor: ArgumentCaptor[Seq[AddFileMetadataInput]] = ArgumentCaptor.forClass(classOf[Seq[AddFileMetadataInput]])
     val fileMetadataDeleteCaptor: ArgumentCaptor[Set[String]] = ArgumentCaptor.forClass(classOf[Set[String]])
     val expectedPropertyNamesToDelete: Seq[String] = Seq("TopLevelProperty1", "ClosureStartDate", "ClosurePeriod", "TitleClosed", "ClosureType")
 
@@ -382,14 +330,8 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     when(validateFileMetadataServiceMock.validateAdditionalMetadata(any[Set[UUID]], any[Set[String]])).thenReturn(Future(Nil))
     when(consignmentStatusServiceMock.updateMetadataConsignmentStatus(any[UUID], any[List[String]])).thenReturn(Future.successful(1 :: Nil))
 
-    val service = new FileMetadataService(
-      fileMetadataRepositoryMock,
-      consignmentStatusServiceMock,
-      customMetadataTestSetUp.customMetadataServiceMock,
-      validateFileMetadataServiceMock,
-      FixedTimeSource,
-      new FixedUUIDSource()
-    )
+    val service =
+      new FileMetadataService(fileMetadataRepositoryMock, consignmentStatusServiceMock, customMetadataTestSetUp.customMetadataServiceMock, validateFileMetadataServiceMock)
     val response = service
       .deleteFileMetadata(
         DeleteFileMetadataInput(
@@ -412,7 +354,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     val addFileMetadata = addFileMetadataCaptor.getValue
     val fileMetadataDelete = fileMetadataDeleteCaptor.getValue
 
-    addFileMetadata.size should equal(4)
+    addFileMetadata.size should equal(2)
     fileMetadataDelete.size should equal(5)
 
     fileMetadataDelete should equal(Set("TopLevelProperty1", "ClosureStartDate", "ClosurePeriod", "TitleClosed", ClosureType))
@@ -427,7 +369,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     val fileInFolderId1 = UUID.fromString("104dde28-21cc-43f6-aa47-d17f120497f5")
     val fileInFolderId2 = UUID.fromString("81643ecc-e618-43bb-829e-f7266565d0b5")
 
-    val addFileMetadataCaptor: ArgumentCaptor[Seq[FilemetadataRow]] = ArgumentCaptor.forClass(classOf[Seq[FilemetadataRow]])
+    val addFileMetadataCaptor: ArgumentCaptor[Seq[AddFileMetadataInput]] = ArgumentCaptor.forClass(classOf[Seq[AddFileMetadataInput]])
     val expectedPropertyNamesToDelete = Set("ClosurePeriod", "ClosureStartDate", "TitleClosed", "ClosureType")
 
     val customMetadataTestSetUp = new CustomMetadataTestSetUp()
@@ -439,14 +381,8 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     when(validateFileMetadataServiceMock.validateAdditionalMetadata(any[Set[UUID]], any[Set[String]])).thenReturn(Future(Nil))
     when(consignmentStatusServiceMock.updateMetadataConsignmentStatus(any[UUID], any[List[String]])).thenReturn(Future.successful(1 :: Nil))
 
-    val service = new FileMetadataService(
-      fileMetadataRepositoryMock,
-      consignmentStatusServiceMock,
-      customMetadataTestSetUp.customMetadataServiceMock,
-      validateFileMetadataServiceMock,
-      FixedTimeSource,
-      new FixedUUIDSource()
-    )
+    val service =
+      new FileMetadataService(fileMetadataRepositoryMock, consignmentStatusServiceMock, customMetadataTestSetUp.customMetadataServiceMock, validateFileMetadataServiceMock)
 
     val response = service.deleteFileMetadata(DeleteFileMetadataInput(Seq(fileInFolderId1, fileInFolderId2), Seq(ClosureType), consignmentId), userId).futureValue
     verify(validateFileMetadataServiceMock, times(1)).validateAdditionalMetadata(fileIds.toSet, expectedPropertyNamesToDelete)
@@ -455,14 +391,14 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     response.fileIds should equal(fileIds)
     response.filePropertyNames should equal(expectedPropertyNamesToDelete.toSeq)
     val addFileMetadata = addFileMetadataCaptor.getValue
-    addFileMetadata.size should equal(4)
+    addFileMetadata.size should equal(2)
 
     val expectedPropertyNames = List(TitleClosed, ClosureType)
     val expectedPropertyValues = List("false", "Open")
     addFileMetadata.foreach { metadata =>
-      expectedPropertyNames.contains(metadata.propertyname) shouldBe true
+      expectedPropertyNames.contains(metadata.filePropertyName) shouldBe true
       expectedPropertyValues.contains(metadata.value) shouldBe true
-      metadata.userid should equal(userId)
+      metadata.userId should equal(userId)
     }
   }
 
@@ -475,7 +411,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     val fileInFolderId1 = UUID.fromString("104dde28-21cc-43f6-aa47-d17f120497f5")
     val fileInFolderId2 = UUID.fromString("81643ecc-e618-43bb-829e-f7266565d0b5")
 
-    val addFileMetadataCaptor: ArgumentCaptor[Seq[FilemetadataRow]] = ArgumentCaptor.forClass(classOf[Seq[FilemetadataRow]])
+    val addFileMetadataCaptor: ArgumentCaptor[Seq[AddFileMetadataInput]] = ArgumentCaptor.forClass(classOf[Seq[AddFileMetadataInput]])
     val expectedPropertyNamesToDelete = Set("description", "DescriptionAlternate", "DescriptionClosed")
 
     val customMetadataTestSetUp = new CustomMetadataTestSetUp()
@@ -488,14 +424,8 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     when(validateFileMetadataServiceMock.validateAdditionalMetadata(any[Set[UUID]], any[Set[String]])).thenReturn(Future(Nil))
     when(consignmentStatusServiceMock.updateMetadataConsignmentStatus(any[UUID], any[List[String]])).thenReturn(Future.successful(1 :: Nil))
 
-    val service = new FileMetadataService(
-      fileMetadataRepositoryMock,
-      consignmentStatusServiceMock,
-      customMetadataTestSetUp.customMetadataServiceMock,
-      validateFileMetadataServiceMock,
-      FixedTimeSource,
-      new FixedUUIDSource()
-    )
+    val service =
+      new FileMetadataService(fileMetadataRepositoryMock, consignmentStatusServiceMock, customMetadataTestSetUp.customMetadataServiceMock, validateFileMetadataServiceMock)
 
     val response = service.deleteFileMetadata(DeleteFileMetadataInput(Seq(fileInFolderId1, fileInFolderId2), Seq("description"), consignmentId), userId).futureValue
     verify(validateFileMetadataServiceMock, times(1)).validateAdditionalMetadata(fileIds.toSet, expectedPropertyNamesToDelete)
@@ -509,10 +439,10 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     val expectedPropertyNames = List(DescriptionClosed)
     val expectedPropertyValues = List("false")
     addFileMetadata.foreach { metadata =>
-      expectedPropertyNames.contains(metadata.propertyname) shouldBe true
+      expectedPropertyNames.contains(metadata.filePropertyName) shouldBe true
       expectedPropertyValues.contains(metadata.value) shouldBe true
-      metadata.datetime != null shouldBe true
-      metadata.userid should equal(userId)
+//      metadata.datetime != null shouldBe true
+      metadata.userId should equal(userId)
     }
   }
 
@@ -525,7 +455,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     val fileInFolderId1 = UUID.fromString("104dde28-21cc-43f6-aa47-d17f120497f5")
     val fileInFolderId2 = UUID.fromString("81643ecc-e618-43bb-829e-f7266565d0b5")
 
-    val addFileMetadataCaptor: ArgumentCaptor[Seq[FilemetadataRow]] = ArgumentCaptor.forClass(classOf[Seq[FilemetadataRow]])
+    val addFileMetadataCaptor: ArgumentCaptor[Seq[AddFileMetadataInput]] = ArgumentCaptor.forClass(classOf[Seq[AddFileMetadataInput]])
     val fileMetadataDeleteCaptor: ArgumentCaptor[Set[String]] = ArgumentCaptor.forClass(classOf[Set[String]])
     val expectedPropertyNamesToDelete = List("ClosurePeriod", "ClosureStartDate", "TitleClosed", "ClosureType")
 
@@ -538,31 +468,25 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     when(validateFileMetadataServiceMock.validateAdditionalMetadata(any[Set[UUID]], any[Set[String]])).thenReturn(Future(Nil))
     when(consignmentStatusServiceMock.updateMetadataConsignmentStatus(any[UUID], any[List[String]])).thenReturn(Future.successful(1 :: Nil))
 
-    val service = new FileMetadataService(
-      fileMetadataRepositoryMock,
-      consignmentStatusServiceMock,
-      customMetadataTestSetUp.customMetadataServiceMock,
-      validateFileMetadataServiceMock,
-      FixedTimeSource,
-      new FixedUUIDSource()
-    )
+    val service =
+      new FileMetadataService(fileMetadataRepositoryMock, consignmentStatusServiceMock, customMetadataTestSetUp.customMetadataServiceMock, validateFileMetadataServiceMock)
     val response = service.deleteFileMetadata(DeleteFileMetadataInput(Seq(fileInFolderId1, fileInFolderId2), Seq(ClosureType), consignmentId), userId).futureValue
     verify(validateFileMetadataServiceMock, times(1)).validateAdditionalMetadata(fileIds.toSet, expectedPropertyNamesToDelete.toSet)
     verify(consignmentStatusServiceMock, times(1)).updateMetadataConsignmentStatus(consignmentId, List(DescriptiveMetadata, ClosureMetadata))
 
     response.fileIds should equal(fileIds)
     response.filePropertyNames should equal(expectedPropertyNamesToDelete)
-    val addfileMetadata: Seq[FilemetadataRow] = addFileMetadataCaptor.getValue
+    val addfileMetadata: Seq[AddFileMetadataInput] = addFileMetadataCaptor.getValue
     val fileMetadataDelete = fileMetadataDeleteCaptor.getValue
 
-    addfileMetadata.size should equal(4)
+    addfileMetadata.size should equal(2)
     val expectedPropertyNames = List(TitleClosed, ClosureType)
     val expectedPropertyValues = List("false", "Open")
 
     addfileMetadata.foreach { metadata =>
-      expectedPropertyNames.contains(metadata.propertyname) shouldBe true
+      expectedPropertyNames.contains(metadata.filePropertyName) shouldBe true
       expectedPropertyValues.contains(metadata.value) shouldBe true
-      metadata.userid should equal(userId)
+      metadata.userId should equal(userId)
     }
 
     fileMetadataDelete.size should equal(4)
@@ -590,9 +514,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
       testSetUp.metadataRepositoryMock,
       consignmentStatusServiceMock,
       customMetadataSetUp.customMetadataServiceMock,
-      testSetUp.validateFileMetadataServiceMock,
-      FixedTimeSource,
-      testSetUp.fixedUUIDSource
+      testSetUp.validateFileMetadataServiceMock
     )
     service.deleteFileMetadata(input, testSetUp.userId).futureValue
 
@@ -718,7 +640,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
 
     val getAllDescendentIdsCaptor: ArgumentCaptor[Seq[UUID]] = ArgumentCaptor.forClass(classOf[Seq[UUID]])
     val deletePropertyNamesCaptor: ArgumentCaptor[Set[String]] = ArgumentCaptor.forClass(classOf[Set[String]])
-    val addFileMetadataCaptor: ArgumentCaptor[Seq[FilemetadataRow]] = ArgumentCaptor.forClass(classOf[Seq[FilemetadataRow]])
+    val addFileMetadataCaptor: ArgumentCaptor[Seq[AddFileMetadataInput]] = ArgumentCaptor.forClass(classOf[Seq[AddFileMetadataInput]])
     val deleteFileMetadataIdsArgCaptor: ArgumentCaptor[Set[UUID]] = ArgumentCaptor.forClass(classOf[Set[UUID]])
 
     def stubRepoResponses(
@@ -809,7 +731,6 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
         closureStartDateField,
         closurePeriodField,
         titleClosedField,
-        closureTypeField,
         closureTypeField,
         descriptionField,
         descriptionClosedField,

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataServiceSpec.scala
@@ -35,7 +35,6 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
       FilemetadataRow(UUID.randomUUID(), fixedFileUuid, "value", Timestamp.from(FixedTimeSource.now), fixedUserId, SHA256ServerSideChecksum) :: Nil
     )
     val fixedUUIDSource = new FixedUUIDSource()
-    val metadataId: UUID = fixedUUIDSource.uuid
     fixedUUIDSource.reset
 
     val addChecksumCaptor: ArgumentCaptor[List[AddFileMetadataInput]] = ArgumentCaptor.forClass(classOf[List[AddFileMetadataInput]])
@@ -59,8 +58,6 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     row.filePropertyName should equal(SHA256ServerSideChecksum)
     row.fileId should equal(fixedFileUuid)
     row.userId should equal(fixedUserId)
-//    row.datetime should equal(Timestamp.from(FixedTimeSource.now))
-//    row.metadataid.shouldBe(metadataId)
   }
 
   def createInput(propertyName: String, fileId: UUID, value: String): AddFileMetadataWithFileIdInput = {
@@ -272,7 +269,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
   "getSumOfFileSizes" should "return the sum of the file sizes" in {
     val fileMetadataRepository = mock[FileMetadataRepository]
     val consignmentId = UUID.randomUUID()
-    when(fileMetadataRepository.getSumOfFileSizes(any[UUID])).thenReturn(Future(1))
+    when(fileMetadataRepository.getSumOfFileSizes(any[UUID])).thenReturn(Future(1L))
 
     val service = new FileMetadataService(fileMetadataRepository, mock[ConsignmentStatusService], mock[CustomMetadataPropertiesService], mock[ValidateFileMetadataService])
     val result = service.getSumOfFileSizes(consignmentId).futureValue
@@ -441,7 +438,6 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     addFileMetadata.foreach { metadata =>
       expectedPropertyNames.contains(metadata.filePropertyName) shouldBe true
       expectedPropertyValues.contains(metadata.value) shouldBe true
-//      metadata.datetime != null shouldBe true
       metadata.userId should equal(userId)
     }
   }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
@@ -9,7 +9,17 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor1}
-import uk.gov.nationalarchives.Tables.{AvmetadataRow, ConsignmentRow, FfidmetadataRow, FfidmetadatamatchesRow, FileRow, FilemetadataRow, FilepropertyRow, FilepropertyvaluesRow, FilestatusRow}
+import uk.gov.nationalarchives.Tables.{
+  AvmetadataRow,
+  ConsignmentRow,
+  FfidmetadataRow,
+  FfidmetadatamatchesRow,
+  FileRow,
+  FilemetadataRow,
+  FilepropertyRow,
+  FilepropertyvaluesRow,
+  FilestatusRow
+}
 import uk.gov.nationalarchives.tdr.api.db.repository._
 import uk.gov.nationalarchives.tdr.api.db.repository.FileRepository.FileFields
 import uk.gov.nationalarchives.tdr.api.graphql.QueriedFileFields
@@ -52,11 +62,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
   val referenceGeneratorServiceMock: ReferenceGeneratorService = mock[ReferenceGeneratorService]
   val consignmentStatusService = new ConsignmentStatusService(consignmentStatusRepositoryMock, fileStatusRepositoryMock, uuidSource, FixedTimeSource)
   val fileMetadataService =
-    new FileMetadataService(
-      fileMetadataRepositoryMock,
-      consignmentStatusService,
-      customMetadataServiceMock,
-      validateFileMetadataServiceMock)
+    new FileMetadataService(fileMetadataRepositoryMock, consignmentStatusService, customMetadataServiceMock, validateFileMetadataServiceMock)
   val queriedFileFieldsWithoutOriginalPath: QueriedFileFields = QueriedFileFields()
 
   // scalastyle:off magic.number
@@ -92,12 +98,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
       bodyid = bodyId
     )
 
-    val fileMetadataService =
-      new FileMetadataService(
-        fileMetadataRepositoryMock,
-        consignmentStatusService,
-        customMetadataServiceMock,
-        validateFileMetadataServiceMock)
+    val fileMetadataService = new FileMetadataService(fileMetadataRepositoryMock, consignmentStatusService, customMetadataServiceMock, validateFileMetadataServiceMock)
     val ffidMetadataService = new FFIDMetadataService(
       ffidMetadataRepositoryMock,
       mock[FFIDMetadataMatchesRepository],
@@ -452,12 +453,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     when(fileStatusRepositoryMock.getFileStatus(consignmentId, Set(FFID), None)).thenReturn(mockFileStatusResponse)
     when(fileStatusRepositoryMock.getFileStatus(consignmentId, allFileStatusTypes, None)).thenReturn(Future(mockFileStatuses))
 
-    val fileMetadataService =
-      new FileMetadataService(
-        fileMetadataRepositoryMock,
-        consignmentStatusService,
-        customMetadataServiceMock,
-        validateFileMetadataServiceMock)
+    val fileMetadataService = new FileMetadataService(fileMetadataRepositoryMock, consignmentStatusService, customMetadataServiceMock, validateFileMetadataServiceMock)
     val ffidMetadataService = new FFIDMetadataService(
       ffidMetadataRepositoryMock,
       mock[FFIDMetadataMatchesRepository],
@@ -562,12 +558,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     when(fileRepositoryMock.getFiles(consignmentId, FileFilters(None))).thenReturn(Future(fileAndMetadataRows))
     when(fileStatusRepositoryMock.getFileStatus(consignmentId, Set(FFID))).thenReturn(mockFileStatusResponse)
 
-    val fileMetadataService =
-      new FileMetadataService(
-        fileMetadataRepositoryMock,
-        consignmentStatusService,
-        customMetadataServiceMock,
-        validateFileMetadataServiceMock)
+    val fileMetadataService = new FileMetadataService(fileMetadataRepositoryMock, consignmentStatusService, customMetadataServiceMock, validateFileMetadataServiceMock)
     val ffidMetadataService = new FFIDMetadataService(
       ffidMetadataRepositoryMock,
       mock[FFIDMetadataMatchesRepository],
@@ -648,12 +639,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     when(fileRepositoryMock.getFiles(consignmentId, FileFilters(None))).thenReturn(Future(fileAndMetadataRows))
     when(fileStatusRepositoryMock.getFileStatus(consignmentId, Set(FFID))).thenReturn(Future(Seq()))
 
-    val fileMetadataService =
-      new FileMetadataService(
-        fileMetadataRepositoryMock,
-        consignmentStatusService,
-        customMetadataServiceMock,
-        validateFileMetadataServiceMock)
+    val fileMetadataService = new FileMetadataService(fileMetadataRepositoryMock, consignmentStatusService, customMetadataServiceMock, validateFileMetadataServiceMock)
     val ffidMetadataService = new FFIDMetadataService(
       ffidMetadataRepositoryMock,
       mock[FFIDMetadataMatchesRepository],
@@ -691,12 +677,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val antivirusMetadataService = mock[AntivirusMetadataService]
     val fileRepositoryMock = mock[FileRepository]
     val customMetadataPropertiesRepositoryMock = mock[CustomMetadataPropertiesRepository]
-    val fileMetadataService =
-      new FileMetadataService(
-        fileMetadataRepositoryMock,
-        consignmentStatusService,
-        customMetadataServiceMock,
-        validateFileMetadataServiceMock)
+    val fileMetadataService = new FileMetadataService(fileMetadataRepositoryMock, consignmentStatusService, customMetadataServiceMock, validateFileMetadataServiceMock)
     val fixedUuidSource = new FixedUUIDSource()
     val fileStatusServiceMock = mock[FileStatusService]
 
@@ -778,12 +759,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val antivirusMetadataService = mock[AntivirusMetadataService]
     val fileRepositoryMock = mock[FileRepository]
     val customMetadataPropertiesRepositoryMock = mock[CustomMetadataPropertiesRepository]
-    val fileMetadataService =
-      new FileMetadataService(
-        fileMetadataRepositoryMock,
-        consignmentStatusService,
-        customMetadataServiceMock,
-        validateFileMetadataServiceMock)
+    val fileMetadataService = new FileMetadataService(fileMetadataRepositoryMock, consignmentStatusService, customMetadataServiceMock, validateFileMetadataServiceMock)
     val fixedUuidSource = new FixedUUIDSource()
     val fileStatusServiceMock = mock[FileStatusService]
 
@@ -885,12 +861,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val antivirusMetadataService = mock[AntivirusMetadataService]
     val fileRepositoryMock = mock[FileRepository]
     val customMetadataServiceMock = mock[CustomMetadataPropertiesService]
-    val fileMetadataService =
-      new FileMetadataService(
-        fileMetadataRepositoryMock,
-        consignmentStatusService,
-        customMetadataServiceMock,
-        validateFileMetadataServiceMock)
+    val fileMetadataService = new FileMetadataService(fileMetadataRepositoryMock, consignmentStatusService, customMetadataServiceMock, validateFileMetadataServiceMock)
     val fixedUuidSource = new FixedUUIDSource()
     val fileStatusService = new FileStatusService(fileStatusRepositoryMock)
 

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
@@ -27,7 +27,6 @@ import uk.gov.nationalarchives.tdr.api.graphql.fields.AntivirusMetadataFields.An
 import uk.gov.nationalarchives.tdr.api.graphql.fields.ConsignmentFields.PaginationInput
 import uk.gov.nationalarchives.tdr.api.graphql.fields.FFIDMetadataFields.{FFIDMetadata, FFIDMetadataMatches}
 import uk.gov.nationalarchives.tdr.api.graphql.fields.FileFields.{AddFileAndMetadataInput, AllDescendantsInput, ClientSideMetadataInput, FileMatches}
-import uk.gov.nationalarchives.tdr.api.graphql.fields.FileMetadataFields.AddFileMetadataInput
 import uk.gov.nationalarchives.tdr.api.graphql.fields.FileStatusFields.{AddFileStatusInput, AddMultipleFileStatusesInput, FileStatus}
 import uk.gov.nationalarchives.tdr.api.model.file.NodeType
 import uk.gov.nationalarchives.tdr.api.service.FileMetadataService._

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
@@ -43,7 +43,6 @@ import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
-//scalastyle:off file.size.limit
 class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with ScalaFutures with TableDrivenPropertyChecks {
   implicit val executionContext: ExecutionContext = ExecutionContext.Implicits.global
 
@@ -65,7 +64,6 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     new FileMetadataService(fileMetadataRepositoryMock, consignmentStatusService, customMetadataServiceMock, validateFileMetadataServiceMock)
   val queriedFileFieldsWithoutOriginalPath: QueriedFileFields = QueriedFileFields()
 
-  // scalastyle:off magic.number
   "getOwnersOfFiles" should "find the owners of the given files" in {
     val fixedUuidSource = new FixedUUIDSource()
     val fileId1 = UUID.fromString("bc609dc4-e153-4620-a7ab-20e7fd5a4005")
@@ -137,7 +135,6 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     owners(1).fileId should equal(fileId2)
     owners(1).userId should equal(userId2)
   }
-  // scalastyle:on magic.number
 
   "getFileDetails" should "return all the correct files details from the database response" in {
     val fileRepositoryMock = mock[FileRepository]

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
@@ -9,17 +9,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor1}
-import uk.gov.nationalarchives.Tables.{
-  AvmetadataRow,
-  ConsignmentRow,
-  FfidmetadataRow,
-  FfidmetadatamatchesRow,
-  FileRow,
-  FilemetadataRow,
-  FilepropertyRow,
-  FilepropertyvaluesRow,
-  FilestatusRow
-}
+import uk.gov.nationalarchives.Tables.{AvmetadataRow, ConsignmentRow, FfidmetadataRow, FfidmetadatamatchesRow, FileRow, FilemetadataRow, FilepropertyRow, FilepropertyvaluesRow, FilestatusRow}
 import uk.gov.nationalarchives.tdr.api.db.repository._
 import uk.gov.nationalarchives.tdr.api.db.repository.FileRepository.FileFields
 import uk.gov.nationalarchives.tdr.api.graphql.QueriedFileFields
@@ -27,6 +17,7 @@ import uk.gov.nationalarchives.tdr.api.graphql.fields.AntivirusMetadataFields.An
 import uk.gov.nationalarchives.tdr.api.graphql.fields.ConsignmentFields.PaginationInput
 import uk.gov.nationalarchives.tdr.api.graphql.fields.FFIDMetadataFields.{FFIDMetadata, FFIDMetadataMatches}
 import uk.gov.nationalarchives.tdr.api.graphql.fields.FileFields.{AddFileAndMetadataInput, AllDescendantsInput, ClientSideMetadataInput, FileMatches}
+import uk.gov.nationalarchives.tdr.api.graphql.fields.FileMetadataFields.AddFileMetadataInput
 import uk.gov.nationalarchives.tdr.api.graphql.fields.FileStatusFields.{AddFileStatusInput, AddMultipleFileStatusesInput, FileStatus}
 import uk.gov.nationalarchives.tdr.api.model.file.NodeType
 import uk.gov.nationalarchives.tdr.api.service.FileMetadataService._
@@ -65,10 +56,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
       fileMetadataRepositoryMock,
       consignmentStatusService,
       customMetadataServiceMock,
-      validateFileMetadataServiceMock,
-      FixedTimeSource,
-      uuidSource
-    )
+      validateFileMetadataServiceMock)
   val queriedFileFieldsWithoutOriginalPath: QueriedFileFields = QueriedFileFields()
 
   // scalastyle:off magic.number
@@ -109,10 +97,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
         fileMetadataRepositoryMock,
         consignmentStatusService,
         customMetadataServiceMock,
-        validateFileMetadataServiceMock,
-        FixedTimeSource,
-        fixedUuidSource
-      )
+        validateFileMetadataServiceMock)
     val ffidMetadataService = new FFIDMetadataService(
       ffidMetadataRepositoryMock,
       mock[FFIDMetadataMatchesRepository],
@@ -140,7 +125,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
         Future.successful(Seq((fileId1, Some(NodeType.fileTypeIdentifier), userId1, consignmentId1), (fileId2, Some(NodeType.fileTypeIdentifier), userId2, consignmentId1)))
       )
     val mockFileMetadataResponse = Future.successful(Seq(FilemetadataRow(UUID.randomUUID(), fileId1, "value", Timestamp.from(Instant.now), userId1, "name")))
-    when(fileMetadataRepositoryMock.addFileMetadata(any[Seq[FilemetadataRow]])).thenReturn(mockFileMetadataResponse)
+    when(fileMetadataRepositoryMock.addFileMetadata(any[Seq[AddFileMetadataInput]])).thenReturn(mockFileMetadataResponse)
 
     val owners = fileService.getOwnersOfFiles(Seq(fileId1)).futureValue
 
@@ -472,10 +457,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
         fileMetadataRepositoryMock,
         consignmentStatusService,
         customMetadataServiceMock,
-        validateFileMetadataServiceMock,
-        FixedTimeSource,
-        fixedUuidSource
-      )
+        validateFileMetadataServiceMock)
     val ffidMetadataService = new FFIDMetadataService(
       ffidMetadataRepositoryMock,
       mock[FFIDMetadataMatchesRepository],
@@ -585,10 +567,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
         fileMetadataRepositoryMock,
         consignmentStatusService,
         customMetadataServiceMock,
-        validateFileMetadataServiceMock,
-        FixedTimeSource,
-        fixedUuidSource
-      )
+        validateFileMetadataServiceMock)
     val ffidMetadataService = new FFIDMetadataService(
       ffidMetadataRepositoryMock,
       mock[FFIDMetadataMatchesRepository],
@@ -674,10 +653,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
         fileMetadataRepositoryMock,
         consignmentStatusService,
         customMetadataServiceMock,
-        validateFileMetadataServiceMock,
-        FixedTimeSource,
-        fixedUuidSource
-      )
+        validateFileMetadataServiceMock)
     val ffidMetadataService = new FFIDMetadataService(
       ffidMetadataRepositoryMock,
       mock[FFIDMetadataMatchesRepository],
@@ -720,10 +696,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
         fileMetadataRepositoryMock,
         consignmentStatusService,
         customMetadataServiceMock,
-        validateFileMetadataServiceMock,
-        FixedTimeSource,
-        new FixedUUIDSource()
-      )
+        validateFileMetadataServiceMock)
     val fixedUuidSource = new FixedUUIDSource()
     val fileStatusServiceMock = mock[FileStatusService]
 
@@ -810,10 +783,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
         fileMetadataRepositoryMock,
         consignmentStatusService,
         customMetadataServiceMock,
-        validateFileMetadataServiceMock,
-        FixedTimeSource,
-        new FixedUUIDSource()
-      )
+        validateFileMetadataServiceMock)
     val fixedUuidSource = new FixedUUIDSource()
     val fileStatusServiceMock = mock[FileStatusService]
 
@@ -920,10 +890,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
         fileMetadataRepositoryMock,
         consignmentStatusService,
         customMetadataServiceMock,
-        validateFileMetadataServiceMock,
-        FixedTimeSource,
-        new FixedUUIDSource()
-      )
+        validateFileMetadataServiceMock)
     val fixedUuidSource = new FixedUUIDSource()
     val fileStatusService = new FileStatusService(fileStatusRepositoryMock)
 


### PR DESCRIPTION
Remove `MetadataId` & `Datetime` creation as these are generated automatically from the DB.