### PR TITLE
TDR-2207 Tidy up of metadata properties

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
@@ -145,10 +145,9 @@ object FileMetadataService {
   val Description = "description"
   val DescriptionAlternate = "DescriptionAlternate"
 
-  /** Default values for these properties stored in FilePropertyValues table. (TDR-2207)
-    * Save default values for these properties because TDR currently only supports records which are Open, in English, etc. Users agree to these conditions at a consignment level,
-    * so it's OK to save these as defaults for every file. They need to be saved so they can be included in the export package. The defaults may be removed in future once we let
-    * users upload a wider variety of records.
+  /** Default values for these properties stored in FilePropertyValues table. (TDR-2207) Save default values for these properties because TDR currently only supports records which
+    * are Open, in English, etc. Users agree to these conditions at a consignment level, so it's OK to save these as defaults for every file. They need to be saved so they can be
+    * included in the export package. The defaults may be removed in future once we let users upload a wider variety of records.
     */
   val RightsCopyright = "RightsCopyright"
   val LegalStatus = "LegalStatus"
@@ -157,7 +156,8 @@ object FileMetadataService {
   val FoiExemptionCode = "FoiExemptionCode"
   val clientSideProperties: List[String] =
     List(SHA256ClientSideChecksum, ClientSideOriginalFilepath, ClientSideFileLastModifiedDate, ClientSideFileSize, Filename, FileType)
-  val serverSideProperties: List[String] = List(FileReference, ParentReference)
+  // Moved to TestUtils as only used in test classes
+  // val serverSideProperties: List[String] = List(FileReference, ParentReference)
 
   def getFileMetadataValues(fileMetadataRow: Seq[FilemetadataRow]): FileMetadataValues = {
     val propertyNameMap: Map[String, String] = fileMetadataRow.groupBy(_.propertyname).transform { (_, value) =>

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
@@ -156,8 +156,6 @@ object FileMetadataService {
   val FoiExemptionCode = "FoiExemptionCode"
   val clientSideProperties: List[String] =
     List(SHA256ClientSideChecksum, ClientSideOriginalFilepath, ClientSideFileLastModifiedDate, ClientSideFileSize, Filename, FileType)
-  // Moved to TestUtils as only used in test classes
-  // val serverSideProperties: List[String] = List(FileReference, ParentReference)
 
   def getFileMetadataValues(fileMetadataRow: Seq[FilemetadataRow]): FileMetadataValues = {
     val propertyNameMap: Map[String, String] = fileMetadataRow.groupBy(_.propertyname).transform { (_, value) =>

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
@@ -145,10 +145,6 @@ object FileMetadataService {
   val Description = "description"
   val DescriptionAlternate = "DescriptionAlternate"
 
-  /** Default values for these properties stored in FilePropertyValues table. (TDR-2207) Save default values for these properties because TDR currently only supports records which
-    * are Open, in English, etc. Users agree to these conditions at a consignment level, so it's OK to save these as defaults for every file. They need to be saved so they can be
-    * included in the export package. The defaults may be removed in future once we let users upload a wider variety of records.
-    */
   val RightsCopyright = "RightsCopyright"
   val LegalStatus = "LegalStatus"
   val HeldBy = "HeldBy"
@@ -178,8 +174,6 @@ object FileMetadataService {
       propertyNameMap.get(DescriptionClosed).map(_.toBoolean)
     )
   }
-
-  case class StaticMetadata(name: String, value: String)
 
   case class FileMetadataValue(name: String, value: String)
 

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
@@ -145,15 +145,16 @@ object FileMetadataService {
   val Description = "description"
   val DescriptionAlternate = "DescriptionAlternate"
 
-  /** Save default values for these properties because TDR currently only supports records which are Open, in English, etc. Users agree to these conditions at a consignment level,
+  /** Default values for these properties stored in FilePropertyValues table. (TDR-2207)
+    * Save default values for these properties because TDR currently only supports records which are Open, in English, etc. Users agree to these conditions at a consignment level,
     * so it's OK to save these as defaults for every file. They need to be saved so they can be included in the export package. The defaults may be removed in future once we let
     * users upload a wider variety of records.
     */
-  val RightsCopyright: StaticMetadata = StaticMetadata("RightsCopyright", "Crown Copyright")
-  val LegalStatus: StaticMetadata = StaticMetadata("LegalStatus", "Public Record")
-  val HeldBy: StaticMetadata = StaticMetadata("HeldBy", "TNA")
-  val Language: StaticMetadata = StaticMetadata("Language", "English")
-  val FoiExemptionCode: StaticMetadata = StaticMetadata("FoiExemptionCode", "open")
+  val RightsCopyright = "RightsCopyright"
+  val LegalStatus = "LegalStatus"
+  val HeldBy = "HeldBy"
+  val Language = "Language"
+  val FoiExemptionCode = "FoiExemptionCode"
   val clientSideProperties: List[String] =
     List(SHA256ClientSideChecksum, ClientSideOriginalFilepath, ClientSideFileLastModifiedDate, ClientSideFileSize, Filename, FileType)
   val serverSideProperties: List[String] = List(FileReference, ParentReference)
@@ -167,11 +168,11 @@ object FileMetadataService {
       propertyNameMap.get(ClientSideOriginalFilepath),
       propertyNameMap.get(ClientSideFileLastModifiedDate).map(d => Timestamp.valueOf(d).toLocalDateTime),
       propertyNameMap.get(ClientSideFileSize).map(_.toLong),
-      propertyNameMap.get(RightsCopyright.name),
-      propertyNameMap.get(LegalStatus.name),
-      propertyNameMap.get(HeldBy.name),
-      propertyNameMap.get(Language.name),
-      propertyNameMap.get(FoiExemptionCode.name),
+      propertyNameMap.get(RightsCopyright),
+      propertyNameMap.get(LegalStatus),
+      propertyNameMap.get(HeldBy),
+      propertyNameMap.get(Language),
+      propertyNameMap.get(FoiExemptionCode),
       propertyNameMap.get(ClosurePeriod).map(_.toInt),
       propertyNameMap.get(ClosureStartDate).map(d => Timestamp.valueOf(d).toLocalDateTime),
       propertyNameMap.get(FoiExemptionAsserted).map(d => Timestamp.valueOf(d).toLocalDateTime),

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentRouteSpec.scala
@@ -228,7 +228,7 @@ class ConsignmentRouteSpec extends TestContainerUtils with Matchers with TestReq
 
     utils.addFileMetadata("06209e0d-95d0-4f13-8933-e5b9d00eb435", fileOneId, SHA256ServerSideChecksum)
     utils.addFileMetadata("c4759aae-dc68-45ec-aee1-5a562c7b42cc", fileTwoId, SHA256ServerSideChecksum)
-    (clientSideProperties ++ staticMetadataProperties).foreach(propertyName => {
+    (clientSideProperties ++ defaultMetadataProperties).foreach(propertyName => {
       utils.addFileProperty(propertyName)
       val value = propertyName match {
         case ClientSideFileLastModifiedDate => "2021-03-11 12:30:30.592853"
@@ -365,7 +365,7 @@ class ConsignmentRouteSpec extends TestContainerUtils with Matchers with TestReq
     val consignmentId = UUID.fromString("e72d94d5-ae79-4a05-bee9-86d9dea2bcc9")
     utils.createConsignment(consignmentId, userId)
     utils.addFileProperty(SHA256ServerSideChecksum)
-    staticMetadataProperties.foreach(utils.addFileProperty)
+    defaultMetadataProperties.foreach(utils.addFileProperty)
     clientSideProperties.foreach(utils.addFileProperty)
     val topDirectory = UUID.fromString("ce0a51a5-a224-474f-b3a4-df75effd5b34")
     val subDirectory = UUID.fromString("2753ceca-4df3-436b-8891-78ad38e2e8c5")
@@ -374,12 +374,10 @@ class ConsignmentRouteSpec extends TestContainerUtils with Matchers with TestReq
     utils.createFile(topDirectory, consignmentId, NodeType.directoryTypeIdentifier, "directory", fileRef = Some("REF1"))
     utils.createFile(subDirectory, consignmentId, NodeType.directoryTypeIdentifier, "subDirectory", parentId = subDirectory.some, fileRef = Some("REF2"), parentRef = Some("REF1"))
 
-    // staticMetadataProperties.foreach(p => utils.addFileMetadata(UUID.randomUUID().toString, topDirectory.toString, p.name, p.value))
-    addStaticMetaData(utils, topDirectory, false)
+    addDefaultMetaData(utils, topDirectory, false)
     utils.addFileMetadata(UUID.randomUUID.toString, topDirectory.toString, ClientSideOriginalFilepath, "directory")
 
-    // staticMetadataProperties.foreach(p => utils.addFileMetadata(UUID.randomUUID().toString, subDirectory.toString, p.name, p.value))
-    addStaticMetaData(utils, subDirectory, false)
+    addDefaultMetaData(utils, subDirectory, false)
     utils.addFileMetadata(UUID.randomUUID.toString, subDirectory.toString, ClientSideOriginalFilepath, "directory")
 
     setUpFileAndStandardMetadata(consignmentId, fileId, utils, subDirectory.some, fileRef = Some("REF3"))
@@ -521,7 +519,7 @@ class ConsignmentRouteSpec extends TestContainerUtils with Matchers with TestReq
     val consignmentId = UUID.fromString("e72d94d5-ae79-4a05-bee9-86d9dea2bcc9")
     utils.createConsignment(consignmentId, userId)
     utils.addFileProperty(SHA256ServerSideChecksum)
-    staticMetadataProperties.foreach(utils.addFileProperty)
+    defaultMetadataProperties.foreach(utils.addFileProperty)
     clientSideProperties.foreach(utils.addFileProperty)
     utils.addFileProperty(OriginalFilepath)
     val originalFilePath = "/an/original/file/path"
@@ -837,7 +835,7 @@ class ConsignmentRouteSpec extends TestContainerUtils with Matchers with TestReq
   }
 
   private def setUpConsignments(consignmentParams: List[ConsignmentParams], utils: TestUtils, fileRef: String): Unit = {
-    (staticMetadataProperties ++ clientSideProperties).foreach(prop => utils.addFileProperty(prop))
+    (defaultMetadataProperties ++ clientSideProperties).foreach(prop => utils.addFileProperty(prop))
 
     setUpConsignmentsFor(consignmentParams, utils, userId, fileRef)
   }
@@ -875,7 +873,7 @@ class ConsignmentRouteSpec extends TestContainerUtils with Matchers with TestReq
   }
 
   private def generateMetadataPropertiesForFile(fileId: UUID, utils: TestUtils, addProperty: Boolean): Unit = {
-    addStaticMetaData(utils, fileId, addProperty)
+    addDefaultMetaData(utils, fileId, addProperty)
     addClientSideProperties(utils, fileId, addProperty)
   }
 
@@ -889,22 +887,21 @@ class ConsignmentRouteSpec extends TestContainerUtils with Matchers with TestReq
       parentRef: Option[Reference] = None
   ): UUID = {
     utils.createFile(fileId, consignmentId, NodeType.directoryTypeIdentifier, fileName, parentId = parentId, fileRef = fileRef, parentRef = parentRef)
-    addStaticMetaData(utils, fileId, false)
-    // staticMetadataProperties.foreach(p => utils.addFileMetadata(UUID.randomUUID().toString, fileId.toString, p.name, p.value))
+    addDefaultMetaData(utils, fileId, false)
     utils.addFileMetadata(UUID.randomUUID.toString, fileId.toString, ClientSideOriginalFilepath, fileName)
     fileId
   }
 
-  private def addStaticMetaData(utils: TestUtils, parentId: UUID, addProperty: Boolean): Unit = {
-    staticMetadataProperties.foreach { staticMetadataProperty =>
+  private def addDefaultMetaData(utils: TestUtils, parentId: UUID, addProperty: Boolean): Unit = {
+    defaultMetadataProperties.foreach { defaultMetadataProperty =>
       if (addProperty) {
-        utils.addFileProperty(staticMetadataProperty)
+        utils.addFileProperty(defaultMetadataProperty)
       }
       utils.addFileMetadata(
         UUID.randomUUID().toString,
         parentId.toString,
-        staticMetadataProperty,
-        staticMetadataProperty match {
+        defaultMetadataProperty,
+        defaultMetadataProperty match {
           case RightsCopyright  => defaultCopyright
           case LegalStatus      => defaultLegalStatus
           case HeldBy           => defaultHeldBy

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentRouteSpec.scala
@@ -896,38 +896,38 @@ class ConsignmentRouteSpec extends TestContainerUtils with Matchers with TestReq
   }
 
   private def addStaticMetaData(utils: TestUtils, parentId: UUID, addProperty: Boolean): Unit = {
-    staticMetadataProperties.foreach { smp =>
+    staticMetadataProperties.foreach { staticMetadataProperty =>
       if (addProperty) {
-        utils.addFileProperty(smp)
+        utils.addFileProperty(staticMetadataProperty)
       }
       utils.addFileMetadata(
         UUID.randomUUID().toString,
         parentId.toString,
-        smp,
-        smp match {
-          case RightsCopyright  => "Crown Copyright"
-          case LegalStatus      => "Public Record"
-          case HeldBy           => "TNA"
-          case Language         => "English"
-          case FoiExemptionCode => "open"
+        staticMetadataProperty,
+        staticMetadataProperty match {
+          case RightsCopyright  => defaultCopyright
+          case LegalStatus      => defaultLegalStatus
+          case HeldBy           => defaultHeldBy
+          case Language         => defaultLanguage
+          case FoiExemptionCode => defaultFoiExemptionCode
         }
       )
     }
   }
 
   private def addClientSideProperties(utils: TestUtils, parentId: UUID, addProperty: Boolean): Unit = {
-    clientSideProperties.foreach { csp =>
+    clientSideProperties.foreach { clientSideProperty =>
       if (addProperty) {
-        utils.addFileProperty(csp)
+        utils.addFileProperty(clientSideProperty)
       }
       utils.addFileMetadata(
         UUID.randomUUID().toString,
         parentId.toString,
-        csp,
-        csp match {
+        clientSideProperty,
+        clientSideProperty match {
           case ClientSideFileLastModifiedDate => s"2021-02-08 16:00:00"
           case ClientSideFileSize             => "1"
-          case _                              => s"$csp value"
+          case _                              => s"$clientSideProperty value"
         }
       )
     }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
@@ -54,17 +54,15 @@ class FileRouteSpec extends TestContainerUtils with Matchers with TestRequest {
     (clientSideProperties ++ serverSideProperties ++ staticMetadataProperties).foreach(utils.addFileProperty)
     utils.createConsignment(consignmentId, userId)
 
-    // staticMetadataProperties.foreach(staticMetadata => utils.createFilePropertyValues(staticMetadata.name, staticMetadata.value, default = true, 1, 1))
-    // Currently hardcoding this to get the tests working (TH - TDR-2207)
     staticMetadataProperties.foreach { smp =>
       utils.createFilePropertyValues(
         smp,
         smp match {
-          case RightsCopyright  => "Crown Copyright"
-          case LegalStatus      => "Public Record"
-          case HeldBy           => "TNA"
-          case Language         => "English"
-          case FoiExemptionCode => "open"
+          case RightsCopyright  => defaultCopyright
+          case LegalStatus      => defaultLegalStatus
+          case HeldBy           => defaultHeldBy
+          case Language         => defaultLanguage
+          case FoiExemptionCode => defaultFoiExemptionCode
         },
         default = true,
         1,
@@ -187,21 +185,6 @@ class FileRouteSpec extends TestContainerUtils with Matchers with TestRequest {
       None
     }
   }
-
-  /* Doesn't appear to be referenced anywhere so could be removed
-    def checkStaticMetadataExists(fileId: UUID, utils: TestUtils): List[Assertion] = {
-      staticMetadataProperties.map(property => {
-        val sql = """SELECT * FROM "FileMetadata" WHERE "FileId" = ? AND "PropertyName" = ?"""
-        val ps: PreparedStatement = utils.connection.prepareStatement(sql)
-        ps.setObject(1, fileId, Types.OTHER)
-        ps.setString(2, property.name)
-        val result = ps.executeQuery()
-        result.next()
-        result.getString("Value") should equal(property.value)
-      })
-    }
-
-   */
 
   private def createConsignmentStructure(utils: TestUtils, userId: UUID = userId): Unit = {
     val consignmentId = UUID.fromString("1cd5e07a-34c8-4751-8e81-98edd17d1729")

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
@@ -11,6 +11,7 @@ import uk.gov.nationalarchives.tdr.api.utils.TestAuthUtils._
 import uk.gov.nationalarchives.tdr.api.utils.TestContainerUtils._
 import uk.gov.nationalarchives.tdr.api.utils.TestUtils._
 import uk.gov.nationalarchives.tdr.api.utils.{FixedUUIDSource, TestContainerUtils, TestRequest, TestUtils}
+import uk.gov.nationalarchives.tdr.api.service.FileMetadataService._
 
 import java.sql.{PreparedStatement, Types}
 import java.util.UUID
@@ -54,6 +55,22 @@ class FileRouteSpec extends TestContainerUtils with Matchers with TestRequest {
     utils.createConsignment(consignmentId, userId)
 
     // staticMetadataProperties.foreach(staticMetadata => utils.createFilePropertyValues(staticMetadata.name, staticMetadata.value, default = true, 1, 1))
+    // Currently hardcoding this to get the tests working (TH - TDR-2207)
+    staticMetadataProperties.foreach { smp =>
+      utils.createFilePropertyValues(
+        smp,
+        smp match {
+          case RightsCopyright  => "Crown Copyright"
+          case LegalStatus      => "Public Record"
+          case HeldBy           => "TNA"
+          case Language         => "English"
+          case FoiExemptionCode => "open"
+        },
+        default = true,
+        1,
+        1
+      )
+    }
     val res = runTestMutationFileMetadata("mutation_alldata_2", validUserToken())
     val distinctDirectoryCount = 3
     val fileCount = 5

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
@@ -4,9 +4,7 @@ import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import com.dimafeng.testcontainers.PostgreSQLContainer
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.auto._
-import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
-import uk.gov.nationalarchives.tdr.api.service.FileMetadataService.{FileReference, FileType, Filename, ParentReference, clientSideProperties}
 import uk.gov.nationalarchives.tdr.api.utils.TestAuthUtils._
 import uk.gov.nationalarchives.tdr.api.utils.TestContainerUtils._
 import uk.gov.nationalarchives.tdr.api.utils.TestUtils._
@@ -51,13 +49,13 @@ class FileRouteSpec extends TestContainerUtils with Matchers with TestRequest {
   "The api" should "add files and metadata entries for files and directories" in withContainers { case container: PostgreSQLContainer =>
     val consignmentId = UUID.fromString("c44f1b9b-1275-4bc3-831c-808c50a0222d")
     val utils = TestUtils(container.database)
-    (clientSideProperties ++ serverSideProperties ++ staticMetadataProperties).foreach(utils.addFileProperty)
+    (clientSideProperties ++ serverSideProperties ++ defaultMetadataProperties).foreach(utils.addFileProperty)
     utils.createConsignment(consignmentId, userId)
 
-    staticMetadataProperties.foreach { smp =>
+    defaultMetadataProperties.foreach { defaultMetadataProperty =>
       utils.createFilePropertyValues(
-        smp,
-        smp match {
+        defaultMetadataProperty,
+        defaultMetadataProperty match {
           case RightsCopyright  => defaultCopyright
           case LegalStatus      => defaultLegalStatus
           case HeldBy           => defaultHeldBy
@@ -72,8 +70,8 @@ class FileRouteSpec extends TestContainerUtils with Matchers with TestRequest {
     val res = runTestMutationFileMetadata("mutation_alldata_2", validUserToken())
     val distinctDirectoryCount = 3
     val fileCount = 5
-    val expectedCount = ((Filename :: FileType :: FileReference :: ParentReference :: staticMetadataProperties).size * distinctDirectoryCount) +
-      (staticMetadataProperties.size * fileCount) +
+    val expectedCount = ((Filename :: FileType :: FileReference :: ParentReference :: defaultMetadataProperties).size * distinctDirectoryCount) +
+      (defaultMetadataProperties.size * fileCount) +
       (clientSideProperties.size * fileCount) +
       (serverSideProperties.size * fileCount) +
       distinctDirectoryCount
@@ -92,7 +90,7 @@ class FileRouteSpec extends TestContainerUtils with Matchers with TestRequest {
   "The api" should "return file ids matched with sequence ids for addFilesAndMetadata" in withContainers { case container: PostgreSQLContainer =>
     val consignmentId = UUID.fromString("1cd5e07a-34c8-4751-8e81-98edd17d1729")
     val utils = TestUtils(container.database)
-    (clientSideProperties ++ serverSideProperties ++ staticMetadataProperties).foreach(utils.addFileProperty)
+    (clientSideProperties ++ serverSideProperties ++ defaultMetadataProperties).foreach(utils.addFileProperty)
     utils.createConsignment(consignmentId, userId)
 
     val expectedResponse = expectedFilesAndMetadataMutationResponse("data_all")

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataServiceSpec.scala
@@ -542,16 +542,11 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     FileMetadataService.ClosureType shouldEqual "ClosureType"
     FileMetadataService.Description shouldEqual "description"
     FileMetadataService.DescriptionAlternate shouldEqual "DescriptionAlternate"
-    FileMetadataService.RightsCopyright.name shouldEqual "RightsCopyright"
-    FileMetadataService.RightsCopyright.value shouldEqual "Crown Copyright"
-    FileMetadataService.LegalStatus.name shouldEqual "LegalStatus"
-    FileMetadataService.LegalStatus.value shouldEqual "Public Record"
-    FileMetadataService.HeldBy.name shouldEqual "HeldBy"
-    FileMetadataService.HeldBy.value shouldEqual "TNA"
-    FileMetadataService.Language.name shouldEqual "Language"
-    FileMetadataService.Language.value shouldEqual "English"
-    FileMetadataService.FoiExemptionCode.name shouldEqual "FoiExemptionCode"
-    FileMetadataService.FoiExemptionCode.value shouldEqual "open"
+    FileMetadataService.RightsCopyright shouldEqual "RightsCopyright"
+    FileMetadataService.LegalStatus shouldEqual "LegalStatus"
+    FileMetadataService.HeldBy shouldEqual "HeldBy"
+    FileMetadataService.Language shouldEqual "Language"
+    FileMetadataService.FoiExemptionCode shouldEqual "FoiExemptionCode"
   }
 
   private def generateFileStatusRows(fileIds: Seq[UUID]) = {

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
@@ -33,7 +33,7 @@ import uk.gov.nationalarchives.tdr.api.service.FileMetadataService._
 import uk.gov.nationalarchives.tdr.api.service.FileService.TDRConnection
 import uk.gov.nationalarchives.tdr.api.service.FileStatusService._
 import uk.gov.nationalarchives.tdr.api.utils.TestAuthUtils.userId
-import uk.gov.nationalarchives.tdr.api.utils.TestUtils.staticMetadataProperties
+import uk.gov.nationalarchives.tdr.api.utils.TestUtils._
 import uk.gov.nationalarchives.tdr.api.utils.{FixedTimeSource, FixedUUIDSource}
 
 import java.sql.Timestamp
@@ -737,7 +737,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val expectedSize = 56
     metadataRows.size should equal(expectedSize)
     staticMetadataProperties.foreach(prop => {
-      metadataRows.count(r => r.propertyname == prop) should equal(5)
+      metadataRows.count(_.propertyname == prop) should equal(5)
     })
 
     clientSideProperties.foreach(prop => {
@@ -823,7 +823,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val expectedSize = 56
     metadataRows.size should equal(expectedSize)
     staticMetadataProperties.foreach(prop => {
-      metadataRows.count(r => r.propertyname == prop) should equal(5)
+      metadataRows.count(_.propertyname == prop) should equal(5)
     })
 
     clientSideProperties.foreach(prop => {
@@ -908,7 +908,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val expectedSize = 36
     metadataRows.size should equal(expectedSize)
     staticMetadataProperties.foreach(prop => {
-      metadataRows.count(r => r.propertyname == prop) should equal(3)
+      metadataRows.count(_.propertyname == prop) should equal(3)
     })
 
     clientSideProperties.foreach(prop => {
@@ -1342,9 +1342,17 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
 
   private def mockCustomMetadataValuesResponse(customMetadataMock: CustomMetadataPropertiesRepository): ScalaOngoingStubbing[Future[Seq[FilepropertyvaluesRow]]] = {
     val staticMetadataRows = staticMetadataProperties.map(staticMetadata => {
-      // TODO Check whether should populate this with value or not
-      // FilepropertyvaluesRow(staticMetadata.name, staticMetadata.value, Some(true))
-      FilepropertyvaluesRow(staticMetadata, s"$staticMetadata value", Some(true))
+      FilepropertyvaluesRow(
+        staticMetadata,
+        staticMetadata match {
+          case RightsCopyright  => defaultCopyright
+          case LegalStatus      => defaultLegalStatus
+          case HeldBy           => defaultHeldBy
+          case Language         => defaultLanguage
+          case FoiExemptionCode => defaultFoiExemptionCode
+        },
+        Some(true)
+      )
     })
 
     when(customMetadataMock.getCustomMetadataValuesWithDefault).thenReturn(Future(staticMetadataRows))

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
@@ -737,7 +737,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val expectedSize = 56
     metadataRows.size should equal(expectedSize)
     staticMetadataProperties.foreach(prop => {
-      metadataRows.count(r => r.propertyname == prop.name && r.value == prop.value) should equal(5)
+      metadataRows.count(r => r.propertyname == prop) should equal(5)
     })
 
     clientSideProperties.foreach(prop => {
@@ -823,7 +823,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val expectedSize = 56
     metadataRows.size should equal(expectedSize)
     staticMetadataProperties.foreach(prop => {
-      metadataRows.count(r => r.propertyname == prop.name && r.value == prop.value) should equal(5)
+      metadataRows.count(r => r.propertyname == prop) should equal(5)
     })
 
     clientSideProperties.foreach(prop => {
@@ -908,7 +908,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val expectedSize = 36
     metadataRows.size should equal(expectedSize)
     staticMetadataProperties.foreach(prop => {
-      metadataRows.count(r => r.propertyname == prop.name && r.value == prop.value) should equal(3)
+      metadataRows.count(r => r.propertyname == prop) should equal(3)
     })
 
     clientSideProperties.foreach(prop => {
@@ -1342,7 +1342,9 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
 
   private def mockCustomMetadataValuesResponse(customMetadataMock: CustomMetadataPropertiesRepository): ScalaOngoingStubbing[Future[Seq[FilepropertyvaluesRow]]] = {
     val staticMetadataRows = staticMetadataProperties.map(staticMetadata => {
-      FilepropertyvaluesRow(staticMetadata.name, staticMetadata.value, Some(true))
+      // TODO Check whether should populate this with value or not
+      // FilepropertyvaluesRow(staticMetadata.name, staticMetadata.value, Some(true))
+      FilepropertyvaluesRow(staticMetadata, s"$staticMetadata value", Some(true))
     })
 
     when(customMetadataMock.getCustomMetadataValuesWithDefault).thenReturn(Future(staticMetadataRows))

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
@@ -736,7 +736,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     })
     val expectedSize = 56
     metadataRows.size should equal(expectedSize)
-    staticMetadataProperties.foreach(prop => {
+    defaultMetadataProperties.foreach(prop => {
       metadataRows.count(_.propertyname == prop) should equal(5)
     })
 
@@ -822,7 +822,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     file.get.parentreference should equal(Some("ref2"))
     val expectedSize = 56
     metadataRows.size should equal(expectedSize)
-    staticMetadataProperties.foreach(prop => {
+    defaultMetadataProperties.foreach(prop => {
       metadataRows.count(_.propertyname == prop) should equal(5)
     })
 
@@ -907,7 +907,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     })
     val expectedSize = 36
     metadataRows.size should equal(expectedSize)
-    staticMetadataProperties.foreach(prop => {
+    defaultMetadataProperties.foreach(prop => {
       metadataRows.count(_.propertyname == prop) should equal(3)
     })
 
@@ -1341,10 +1341,10 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
   }
 
   private def mockCustomMetadataValuesResponse(customMetadataMock: CustomMetadataPropertiesRepository): ScalaOngoingStubbing[Future[Seq[FilepropertyvaluesRow]]] = {
-    val staticMetadataRows = staticMetadataProperties.map(staticMetadata => {
+    val defaultMetadataRows = defaultMetadataProperties.map(defaultMetadata => {
       FilepropertyvaluesRow(
-        staticMetadata,
-        staticMetadata match {
+        defaultMetadata,
+        defaultMetadata match {
           case RightsCopyright  => defaultCopyright
           case LegalStatus      => defaultLegalStatus
           case HeldBy           => defaultHeldBy
@@ -1355,6 +1355,6 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
       )
     })
 
-    when(customMetadataMock.getCustomMetadataValuesWithDefault).thenReturn(Future(staticMetadataRows))
+    when(customMetadataMock.getCustomMetadataValuesWithDefault).thenReturn(Future(defaultMetadataRows))
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestUtils.scala
@@ -580,4 +580,9 @@ object TestUtils {
   val defaultFileId: UUID = UUID.fromString("07a3a4bd-0281-4a6d-a4c1-8fa3239e1313")
   val serverSideProperties: List[String] = List(FileReference, ParentReference)
   val staticMetadataProperties: List[String] = List(RightsCopyright, LegalStatus, HeldBy, Language, FoiExemptionCode)
+  val defaultCopyright: String = "Crown Copyright"
+  val defaultLegalStatus: String = "Public Record"
+  val defaultHeldBy: String = "TNA"
+  val defaultLanguage: String = "English"
+  val defaultFoiExemptionCode = "open"
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestUtils.scala
@@ -578,5 +578,6 @@ object TestUtils {
   case class Locations(column: Int, line: Int)
 
   val defaultFileId: UUID = UUID.fromString("07a3a4bd-0281-4a6d-a4c1-8fa3239e1313")
-  val staticMetadataProperties: List[StaticMetadata] = List(RightsCopyright, LegalStatus, HeldBy, Language, FoiExemptionCode)
+  val serverSideProperties: List[String] = List(FileReference, ParentReference)
+  val staticMetadataProperties: List[String] = List(RightsCopyright, LegalStatus, HeldBy, Language, FoiExemptionCode)
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestUtils.scala
@@ -579,7 +579,7 @@ object TestUtils {
 
   val defaultFileId: UUID = UUID.fromString("07a3a4bd-0281-4a6d-a4c1-8fa3239e1313")
   val serverSideProperties: List[String] = List(FileReference, ParentReference)
-  val staticMetadataProperties: List[String] = List(RightsCopyright, LegalStatus, HeldBy, Language, FoiExemptionCode)
+  val defaultMetadataProperties: List[String] = List(RightsCopyright, LegalStatus, HeldBy, Language, FoiExemptionCode)
   val defaultCopyright: String = "Crown Copyright"
   val defaultLegalStatus: String = "Public Record"
   val defaultHeldBy: String = "TNA"


### PR DESCRIPTION
Refactored "static-metadata" properties to use string literals instead as defaults pulled from db