### PR TITLE
Provide a dummy Akka token value as a default

### DIFF
--- a/lightbend.sbt
+++ b/lightbend.sbt
@@ -1,4 +1,4 @@
-lazy val akkaToken = sys.env.getOrElse("AKKA_TOKEN", throw new Exception("Missing Akka token"))
+lazy val akkaToken = sys.env.getOrElse("AKKA_TOKEN", "dummyTokenValue")
 
 ThisBuild / resolvers += "lightbend-commercial-mvn" at s"https://repo.lightbend.com/pass/$akkaToken/commercial-releases"
 ThisBuild / resolvers += Resolver.url("lightbend-commercial-ivy", url(s"https://repo.lightbend.com/pass/$akkaToken/commercial-releases"))(Resolver.ivyStylePatterns)


### PR DESCRIPTION
Scala Steward is failing because an exception was thrown if no akka token value

There is no way to pass the akka token into Scala Steward so providing a dummy value for the token instead of throwing the exception