### PR TITLE
Allow backend check client to access any consignment and files

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/metadatainputvalidation/MetadataInputTags.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/metadatainputvalidation/MetadataInputTags.scala
@@ -37,10 +37,10 @@ case class ValidateMetadataInput[T](argument: Argument[T]) extends MetadataInput
 
     for {
       fileFields <- ctx.ctx.fileService.getFileDetails(inputFileIds)
-      nonOwnership = fileFields.exists(_.userId != userId)
+      noAccess = fileFields.exists(_.userId != userId) && !draftMetadataValidatorAccess
     } yield {
-      nonOwnership match {
-        case true if !draftMetadataValidatorAccess => throw AuthorisationException(s"User '$userId' does not own the files they are trying to access")
+      noAccess match {
+        case true => throw AuthorisationException("Access denied to file metadata")
         case _ if inputErrors(fileFields, inputFileIds, inputConsignmentId) =>
           throw InputDataException("Input contains directory id or contains non-existing file id or consignment id is incorrect")
         case _ => continue

--- a/src/test/resources/json/addorupdatebulkfilemetadata_data_error_not_file_owner.json
+++ b/src/test/resources/json/addorupdatebulkfilemetadata_data_error_not_file_owner.json
@@ -2,7 +2,7 @@
   "data": null,
   "errors": [
     {
-      "message": "User '4ab14990-ed63-4615-8336-56fbb9960300' does not own the files they are trying to access"
+      "message": "Access denied to file metadata"
     }
   ]
 }

--- a/src/test/resources/json/deletefilemetadata_data_error_not_file_owner.json
+++ b/src/test/resources/json/deletefilemetadata_data_error_not_file_owner.json
@@ -2,7 +2,7 @@
   "data": null,
   "errors": [
     {
-      "message": "User '29f65c4e-0eb8-4719-afdb-ace1bcbae4b6' does not own the files they are trying to access"
+      "message": "Access denied to file metadata"
     }
   ]
 }

--- a/src/test/resources/json/updatebulkfilemetadata_data_error_not_file_owner.json
+++ b/src/test/resources/json/updatebulkfilemetadata_data_error_not_file_owner.json
@@ -2,7 +2,7 @@
   "data": null,
   "errors": [
     {
-      "message": "User '4ab14990-ed63-4615-8336-56fbb9960300' does not own the files they are trying to access"
+      "message": "Access denied to file metadata"
     }
   ]
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileMetadataRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileMetadataRouteSpec.scala
@@ -466,6 +466,38 @@ class FileMetadataRouteSpec extends TestContainerUtils with Matchers with TestRe
     checkNoFileMetadataAdded(utils, "property2")
   }
 
+  "addOrUpdateBulkFileMetadata" should "add or update all file metadata when consignment belongs to another user but it got the backend check token" in withContainers {
+    case container: PostgreSQLContainer =>
+      val utils = TestUtils(container.database)
+      val (consignmentId, _) = utils.seedDatabaseWithDefaultEntries()
+
+      val folderOneId = UUID.fromString("d74650ff-21b1-402d-8c59-b114698a8341")
+      val fileOneId = UUID.fromString("51c55218-1322-4453-9ef8-2300ef1c0fef")
+      val fileTwoId = UUID.fromString("7076f399-b596-4161-a95d-e686c6435710")
+      val fileThreeId = UUID.fromString("d2e64eed-faff-45ac-9825-79548f681323")
+      utils.addFileProperty("newProperty1")
+      utils.addFileProperty("existingPropertyUpdated1")
+
+      utils.createFile(fileOneId, consignmentId, NodeType.fileTypeIdentifier, "fileName", Some(folderOneId))
+      utils.createFile(fileTwoId, consignmentId)
+      utils.createFile(fileThreeId, consignmentId)
+      utils.addFileMetadata(UUID.randomUUID().toString, fileOneId.toString, "existingPropertyUpdated1", "existingValue1")
+      utils.addFileMetadata(UUID.randomUUID().toString, fileTwoId.toString, "existingPropertyUpdated1", "newValue1")
+      utils.addFileMetadata(UUID.randomUUID().toString, fileThreeId.toString, "newProperty1", "value1")
+      utils.addFileMetadata(UUID.randomUUID().toString, fileThreeId.toString, "existingPropertyUpdated1", "existingValue1")
+
+      val exportAccessToken = validBackendChecksToken("export")
+
+      val expectedResponse: GraphqlAddOrUpdateBulkFileMetadataMutationData =
+        expectedAddOrUpdateBulkFileMetadataMutationResponse("data_all")
+      val expectedResponseFileMetadata = expectedResponse.data.get
+      val response: GraphqlAddOrUpdateBulkFileMetadataMutationData =
+        runAddOrUpdateBulkFileMetadataTestMutation("mutation_alldata", exportAccessToken)
+      val responseFileMetadataProperties = response.data.get
+
+      responseFileMetadataProperties should equal(expectedResponseFileMetadata)
+  }
+
   "addOrUpdateBulkFileMetadata" should "throw a 'not authorised' error if a file id belongs to another user and an input error is also present" in withContainers {
     case container: PostgreSQLContainer =>
       val utils = TestUtils(container.database)

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileMetadataRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileMetadataRouteSpec.scala
@@ -466,7 +466,7 @@ class FileMetadataRouteSpec extends TestContainerUtils with Matchers with TestRe
     checkNoFileMetadataAdded(utils, "property2")
   }
 
-  "addOrUpdateBulkFileMetadata" should "add or update all file metadata when consignment belongs to another user but it got the backend check token" in withContainers {
+  "addOrUpdateBulkFileMetadata" should "add or update all file metadata when consignment belongs to another user when called by backend checks client" in withContainers {
     case container: PostgreSQLContainer =>
       val utils = TestUtils(container.database)
       val (consignmentId, _) = utils.seedDatabaseWithDefaultEntries()
@@ -498,7 +498,7 @@ class FileMetadataRouteSpec extends TestContainerUtils with Matchers with TestRe
       responseFileMetadataProperties should equal(expectedResponseFileMetadata)
   }
 
-  "addOrUpdateBulkFileMetadata" should "throw a 'not authorised' error if a file id belongs to another user and an input error is also present" in withContainers {
+  "addOrUpdateBulkFileMetadata" should "throw a 'not authorised' exception is thrown when the user doesn't own the file and the backend checks client is not used" in withContainers {
     case container: PostgreSQLContainer =>
       val utils = TestUtils(container.database)
       val (consignmentId, _) = utils.seedDatabaseWithDefaultEntries()


### PR DESCRIPTION
Draft metadata validator doesn't know the user id and due to this, the `addOrUpdateBulkFileMetadata` mutation throws an error that `User 'id' does not own the files they are trying to access`. So, for now, allow backend check client to access any consignment and files.