### PR TITLE
TDRD-148: bump future time-out in validate

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/ValidationTag.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/ValidationTag.scala
@@ -17,7 +17,7 @@ trait ValidationTag extends FieldTag {
     //
     // We are only using Await because Sangria middleware does not support Futures like the main resolvers do. We should
     // remove it when we find a way to do authorisation in a completely async way in Sangria.
-    Await.result(validationResult, 120 seconds)
+    Await.result(validationResult, 180 seconds)
   }
 
   def validateAsync(ctx: Context[ConsignmentApiContext, _])(implicit executionContext: ExecutionContext): Future[BeforeFieldResult[ConsignmentApiContext, Unit]]


### PR DESCRIPTION
As a follow-up to yesterday increase on `staging` of request-timeout  https://github.com/nationalarchives/tdr-consignment-api/pull/852 to understand where bottle neck is:
- that has stopped `request-timeout` error previously seen but we encounter a (new) 504 behind it. 
- think this `await result` will be source of that... mainly based on https://github.com/nationalarchives/tdr-consignment-api/commit/cd3aec131042fb145f3aadaa627000f5b8d66b15 where it was updated alongside the request-timeout in 2022 (and noted at that time that going to 2 mins worked with 10,000 files so testing to see if a little more time is all that is required).