### PR TITLE
TDRD 217 Remove `PropertyProtected` and use `editable` instead

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -189,7 +189,6 @@ type CustomMetadataField {
   uiOrdinal: Int!
   allowExport: Boolean!
   exportOrdinal: Int
-  propertyProtected: Boolean!
 }
 
 type CustomMetadataValues {

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/CustomMetadataFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/CustomMetadataFields.scala
@@ -32,8 +32,7 @@ object CustomMetadataFields extends DataTypeFields {
       values: List[CustomMetadataValues],
       uiOrdinal: Int,
       allowExport: Boolean = false,
-      exportOrdinal: Option[Int] = None,
-      propertyProtected: Boolean
+      exportOrdinal: Option[Int] = None
   )
 
   implicit val PropertyTypeType: EnumType[PropertyType] = deriveEnumType[PropertyType]()

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/CustomMetadataFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/CustomMetadataFields.scala
@@ -1,13 +1,12 @@
 package uk.gov.nationalarchives.tdr.api.graphql.fields
 
 import io.circe.generic.auto._
-import sangria.marshalling.circe._
 import sangria.macros.derive.{deriveEnumType, deriveObjectType}
+import sangria.marshalling.circe._
 import sangria.schema.{Argument, EnumType, Field, ListType, ObjectType, fields}
 import uk.gov.nationalarchives.tdr.api.auth.ValidateUserHasAccessToConsignment
 import uk.gov.nationalarchives.tdr.api.graphql.ConsignmentApiContext
 import uk.gov.nationalarchives.tdr.api.graphql.fields.FieldTypes.UuidType
-import uk.gov.nationalarchives.tdr.api.graphql.fields.DataTypeFields
 
 import java.util.UUID
 

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/CustomMetadataPropertiesService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/CustomMetadataPropertiesService.scala
@@ -4,7 +4,6 @@ import uk.gov.nationalarchives.Tables.{FilepropertyRow, Filepropertydependencies
 import uk.gov.nationalarchives.tdr.api.db.repository.CustomMetadataPropertiesRepository
 import uk.gov.nationalarchives.tdr.api.graphql.fields.CustomMetadataFields
 import uk.gov.nationalarchives.tdr.api.graphql.fields.CustomMetadataFields._
-import uk.gov.nationalarchives.tdr.api.service.CustomMetadataPropertiesService.{MandatoryMetadata, SystemProperty, protectedPropertyGroups}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -89,8 +88,7 @@ class CustomMetadataPropertiesService(customMetadataPropertiesRepository: Custom
       metadataValues.toList,
       fp.uiordinal.getOrElse(Int.MaxValue),
       fp.allowexport,
-      fp.exportordinal.map(_.toInt),
-      protectedPropertyGroups.contains(fp.propertygroup.get)
+      fp.exportordinal.map(_.toInt)
     )
   }
 
@@ -100,12 +98,4 @@ class CustomMetadataPropertiesService(customMetadataPropertiesRepository: Custom
     case Some("Supplied") => Supplied
     case _                => throw new Exception(s"Invalid property type $propertyType")
   }
-}
-
-object CustomMetadataPropertiesService {
-
-  val SystemProperty = "System"
-  val MandatoryMetadata = "MandatoryMetadata"
-  val OptionalMetadata = "OptionalMetadata"
-  val protectedPropertyGroups: Set[String] = Set(MandatoryMetadata, SystemProperty)
 }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
@@ -63,7 +63,7 @@ class FileMetadataService(
   def addOrUpdateBulkFileMetadata(input: AddOrUpdateBulkFileMetadataInput, userId: UUID): Future[List[FileMetadataWithFileId]] = {
     for {
       customMetadata <- customMetadataService.getCustomMetadata
-      protectedMetadata = customMetadata.filter(_.propertyProtected).map(_.name)
+      protectedMetadata = customMetadata.filter(!_.editable).map(_.name)
       _ = input.fileMetadata.map { addOrUpdateFileMetadata =>
         addOrUpdateFileMetadata.metadata.map { metadata =>
           if (protectedMetadata.contains(metadata.filePropertyName)) {

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileMetadataRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileMetadataRouteSpec.scala
@@ -8,7 +8,6 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor1}
 import uk.gov.nationalarchives.tdr.api.graphql.fields.FileMetadataFields.{BulkFileMetadata, DeleteFileMetadata, FileMetadataWithFileId, SHA256ServerSideChecksum}
 import uk.gov.nationalarchives.tdr.api.model.file.NodeType
-import uk.gov.nationalarchives.tdr.api.service.CustomMetadataPropertiesService.{OptionalMetadata, SystemProperty}
 import uk.gov.nationalarchives.tdr.api.service.FileStatusService._
 import uk.gov.nationalarchives.tdr.api.utils.TestAuthUtils._
 import uk.gov.nationalarchives.tdr.api.utils.TestContainerUtils._
@@ -161,8 +160,8 @@ class FileMetadataRouteSpec extends TestContainerUtils with Matchers with TestRe
       val fileOneId = UUID.fromString("51c55218-1322-4453-9ef8-2300ef1c0fef")
       val fileTwoId = UUID.fromString("7076f399-b596-4161-a95d-e686c6435710")
       val fileThreeId = UUID.fromString("d2e64eed-faff-45ac-9825-79548f681323")
-      utils.addFileProperty("newProperty1", propertyGroup = OptionalMetadata)
-      utils.addFileProperty("existingPropertyUpdated1", propertyGroup = OptionalMetadata)
+      utils.addFileProperty("newProperty1", propertyType = "Supplied")
+      utils.addFileProperty("existingPropertyUpdated1", propertyType = "Supplied")
 
       utils.createFile(fileOneId, consignmentId, NodeType.fileTypeIdentifier, "fileName", Some(folderOneId))
       utils.createFile(fileTwoId, consignmentId)
@@ -192,7 +191,7 @@ class FileMetadataRouteSpec extends TestContainerUtils with Matchers with TestRe
     val (consignmentId, _) = utils.seedDatabaseWithDefaultEntries()
 
     val fileId = UUID.fromString("7076f399-b596-4161-a95d-e686c6435710")
-    utils.addFileProperty("newProperty1", propertyGroup = SystemProperty)
+    utils.addFileProperty("newProperty1")
     utils.createFile(fileId, consignmentId)
 
     val expectedResponse: GraphqlAddOrUpdateBulkFileMetadataMutationData =
@@ -212,9 +211,9 @@ class FileMetadataRouteSpec extends TestContainerUtils with Matchers with TestRe
     val fileOneId = UUID.fromString("51c55218-1322-4453-9ef8-2300ef1c0fef")
     val fileTwoId = UUID.fromString("7076f399-b596-4161-a95d-e686c6435710")
     val fileThreeId = UUID.fromString("d2e64eed-faff-45ac-9825-79548f681323")
-    utils.addFileProperty("ClosureType", propertyGroup = propertyGroup)
-    utils.addFileProperty("newProperty1", propertyGroup = propertyGroup)
-    utils.addFileProperty("existingPropertyUpdated1", propertyGroup = propertyGroup)
+    utils.addFileProperty("ClosureType", propertyType = "Supplied", propertyGroup = propertyGroup)
+    utils.addFileProperty("newProperty1", propertyType = "Supplied", propertyGroup = propertyGroup)
+    utils.addFileProperty("existingPropertyUpdated1", propertyType = "Supplied", propertyGroup = propertyGroup)
 
     utils.createDisplayProperty("newProperty1", "Active", "true", "boolean")
     utils.createDisplayProperty("existingPropertyUpdated1", "Active", "true", "boolean")
@@ -245,14 +244,14 @@ class FileMetadataRouteSpec extends TestContainerUtils with Matchers with TestRe
       val fileTwoId = UUID.fromString("7076f399-b596-4161-a95d-e686c6435710")
       val fileThreeId = UUID.randomUUID()
 
-      utils.createFileProperty("TestProperty1", "", "Defined", "text", false, false, mandatoryClosure, "")
-      utils.createFileProperty("TestProperty2", "", "Defined", "text", false, false, mandatoryClosure, "")
-      utils.createFilePropertyValues("TestProperty1", "value1", false, 1, 2)
+      utils.createFileProperty("TestProperty1", "", "Defined", "text", editable = true, multivalue = false, mandatoryClosure, "")
+      utils.createFileProperty("TestProperty2", "", "Defined", "text", editable = true, multivalue = false, mandatoryClosure, "")
+      utils.createFilePropertyValues("TestProperty1", "value1", default = false, 1, 2)
       utils.createFilePropertyDependencies(1, "TestProperty2", "")
 
-      utils.createFileProperty("TestProperty3", "", "Defined", "text", false, false, optionalMetadata, "")
-      utils.createFileProperty("TestProperty4", "", "Defined", "text", false, false, optionalMetadata, "")
-      utils.createFilePropertyValues("TestProperty3", "value2", false, 3, 4)
+      utils.createFileProperty("TestProperty3", "", "Defined", "text", editable = true, multivalue = false, optionalMetadata, "")
+      utils.createFileProperty("TestProperty4", "", "Defined", "text", editable = true, multivalue = false, optionalMetadata, "")
+      utils.createFilePropertyValues("TestProperty3", "value2", default = false, 3, 4)
       utils.createFilePropertyDependencies(3, "TestProperty4", "")
 
       utils.createFile(fileOneId, consignmentId)
@@ -279,8 +278,8 @@ class FileMetadataRouteSpec extends TestContainerUtils with Matchers with TestRe
       val fileThreeId = UUID.fromString("d2e64eed-faff-45ac-9825-79548f681323")
       val fileFourId = UUID.randomUUID()
 
-      utils.addFileProperty("newProperty1", propertyGroup = closurePropertyGroup)
-      utils.addFileProperty("existingPropertyUpdated1", propertyGroup = descriptivePropertyGroup)
+      utils.addFileProperty("newProperty1", propertyType = "Supplied", propertyGroup = closurePropertyGroup)
+      utils.addFileProperty("existingPropertyUpdated1", propertyType = "Supplied", propertyGroup = descriptivePropertyGroup)
 
       utils.createFile(fileOneId, consignmentId, NodeType.fileTypeIdentifier, "fileName", Some(folderOneId))
       utils.createFile(fileTwoId, consignmentId)
@@ -308,8 +307,8 @@ class FileMetadataRouteSpec extends TestContainerUtils with Matchers with TestRe
       val fileThreeId = UUID.fromString("d2e64eed-faff-45ac-9825-79548f681323")
       val fileFourId = UUID.randomUUID()
 
-      utils.addFileProperty("newProperty1", propertyGroup = closurePropertyGroup)
-      utils.addFileProperty("existingPropertyUpdated1", propertyGroup = descriptivePropertyGroup)
+      utils.addFileProperty("newProperty1", propertyType = "Supplied", propertyGroup = closurePropertyGroup)
+      utils.addFileProperty("existingPropertyUpdated1", propertyType = "Supplied", propertyGroup = descriptivePropertyGroup)
 
       utils.createFile(fileOneId, consignmentId, NodeType.fileTypeIdentifier, "fileName", Some(folderOneId))
       utils.createFile(fileTwoId, consignmentId)
@@ -491,8 +490,8 @@ class FileMetadataRouteSpec extends TestContainerUtils with Matchers with TestRe
       val fileOneId = UUID.fromString("51c55218-1322-4453-9ef8-2300ef1c0fef")
       val fileTwoId = UUID.fromString("7076f399-b596-4161-a95d-e686c6435710")
       val fileThreeId = UUID.fromString("d2e64eed-faff-45ac-9825-79548f681323")
-      utils.addFileProperty("newProperty1", propertyGroup = OptionalMetadata)
-      utils.addFileProperty("existingPropertyUpdated1", propertyGroup = OptionalMetadata)
+      utils.addFileProperty("newProperty1", propertyType = "Supplied")
+      utils.addFileProperty("existingPropertyUpdated1", propertyType = "Supplied")
 
       utils.createFile(fileOneId, consignmentId, NodeType.fileTypeIdentifier, "fileName", Some(folderOneId))
       utils.createFile(fileTwoId, consignmentId)

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
@@ -8,7 +8,6 @@ import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.auto._
 import org.scalatest.matchers.should.Matchers
-import uk.gov.nationalarchives.tdr.api.service.CustomMetadataPropertiesService.OptionalMetadata
 import uk.gov.nationalarchives.tdr.api.service.FileMetadataService._
 import uk.gov.nationalarchives.tdr.api.utils.TestAuthUtils._
 import uk.gov.nationalarchives.tdr.api.utils.TestContainerUtils._
@@ -53,7 +52,7 @@ class FileRouteSpec extends TestContainerUtils with Matchers with TestRequest {
   "The api" should "add files and metadata entries for files and directories" in withContainers { case container: PostgreSQLContainer =>
     val consignmentId = UUID.fromString("c44f1b9b-1275-4bc3-831c-808c50a0222d")
     val utils = TestUtils(container.database)
-    (clientSideProperties ++ serverSideProperties ++ defaultMetadataProperties).foreach(utils.addFileProperty(_, propertyGroup = OptionalMetadata))
+    (clientSideProperties ++ serverSideProperties ++ defaultMetadataProperties).foreach(utils.addFileProperty(_))
     utils.createConsignment(consignmentId, userId)
 
     defaultMetadataProperties.foreach { defaultMetadataProperty =>
@@ -96,7 +95,7 @@ class FileRouteSpec extends TestContainerUtils with Matchers with TestRequest {
   "The api" should "return file ids matched with sequence ids for addFilesAndMetadata" in withContainers { case container: PostgreSQLContainer =>
     val consignmentId = UUID.fromString("1cd5e07a-34c8-4751-8e81-98edd17d1729")
     val utils = TestUtils(container.database)
-    (clientSideProperties ++ serverSideProperties ++ defaultMetadataProperties).foreach(utils.addFileProperty(_, propertyGroup = OptionalMetadata))
+    (clientSideProperties ++ serverSideProperties ++ defaultMetadataProperties).foreach(utils.addFileProperty(_))
     utils.createConsignment(consignmentId, userId)
 
     val referenceMockServer = getReferencesMockServer(4)

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataServiceSpec.scala
@@ -12,7 +12,6 @@ import uk.gov.nationalarchives.tdr.api.graphql.fields.CustomMetadataFields.{Bool
 import uk.gov.nationalarchives.tdr.api.graphql.fields.FileMetadataFields
 import uk.gov.nationalarchives.tdr.api.graphql.fields.FileMetadataFields.{SHA256ServerSideChecksum, _}
 import uk.gov.nationalarchives.tdr.api.model.file.NodeType.{directoryTypeIdentifier, fileTypeIdentifier}
-import uk.gov.nationalarchives.tdr.api.service.CustomMetadataPropertiesService.SystemProperty
 import uk.gov.nationalarchives.tdr.api.service.FileMetadataService._
 import uk.gov.nationalarchives.tdr.api.service.FileStatusService.{ClosureMetadata, DescriptiveMetadata}
 import uk.gov.nationalarchives.tdr.api.utils.{FixedTimeSource, FixedUUIDSource}
@@ -862,8 +861,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
         List(),
         2147483647,
         false,
-        None,
-        propertyProtected = false
+        None
       )
 
     private val closurePeriodField: CustomMetadataField =
@@ -880,8 +878,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
         List(),
         2147483647,
         false,
-        None,
-        propertyProtected = false
+        None
       )
 
     private val closureStartDateField: CustomMetadataField =
@@ -898,8 +895,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
         List(),
         2147483647,
         false,
-        None,
-        propertyProtected = false
+        None
       )
 
     private val descriptionField: CustomMetadataField =
@@ -916,8 +912,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
         List(),
         2147483647,
         false,
-        None,
-        propertyProtected = false
+        None
       )
 
     private val titleClosedField: CustomMetadataField =
@@ -934,8 +929,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
         List(),
         2147483647,
         false,
-        None,
-        propertyProtected = false
+        None
       )
 
     private val topLevelDependencyField: CustomMetadataField =
@@ -952,8 +946,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
         List(),
         2147483647,
         false,
-        None,
-        propertyProtected = false
+        None
       )
 
     private val sHA256ServerSideChecksumField: CustomMetadataField =
@@ -962,7 +955,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
         Some(Description),
         None,
         System,
-        Some(SystemProperty),
+        Some("System"),
         Text,
         false,
         false,
@@ -970,8 +963,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
         List(),
         2147483647,
         false,
-        None,
-        propertyProtected = true
+        None
       )
 
     private val closureTypeClosedValues: CustomMetadataValues = CustomMetadataValues(List(closurePeriodField, closureStartDateField, titleClosedField), "Closed", 2147483647)
@@ -991,8 +983,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
         List(closureTypeClosedValues, closureTypeOpenValues),
         2147483647,
         false,
-        None,
-        propertyProtected = false
+        None
       )
 
     private val descriptionClosedTrueValues: CustomMetadataValues = CustomMetadataValues(List(alternativeDescriptionField), "true", 2147483647)
@@ -1011,8 +1002,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
         List(descriptionClosedTrueValues),
         2147483647,
         false,
-        None,
-        propertyProtected = false
+        None
       )
 
     private val foiExemptionCodeField =
@@ -1029,8 +1019,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
         List(),
         2147483647,
         false,
-        None,
-        propertyProtected = false
+        None
       )
 
     private val mockFields = Future(

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ValidateFileMetadataServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ValidateFileMetadataServiceSpec.scala
@@ -330,8 +330,7 @@ class ValidateFileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with
         List(),
         2147483647,
         false,
-        None,
-        propertyProtected = false
+        None
       )
     val descriptionField: CustomMetadataField =
       CustomMetadataField(
@@ -347,8 +346,7 @@ class ValidateFileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with
         List(),
         2147483647,
         false,
-        None,
-        propertyProtected = false
+        None
       )
     val languageField =
       CustomMetadataField(
@@ -364,8 +362,7 @@ class ValidateFileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with
         List(),
         2147483647,
         false,
-        None,
-        propertyProtected = false
+        None
       )
     val alternativeDescriptionField: CustomMetadataField =
       CustomMetadataField(
@@ -381,8 +378,7 @@ class ValidateFileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with
         List(),
         2147483647,
         false,
-        None,
-        propertyProtected = false
+        None
       )
     val alternativeTitleField: CustomMetadataField =
       CustomMetadataField(
@@ -398,8 +394,7 @@ class ValidateFileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with
         List(),
         2147483647,
         false,
-        None,
-        propertyProtected = false
+        None
       )
     val foiExemptionCodeField =
       CustomMetadataField(
@@ -415,8 +410,7 @@ class ValidateFileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with
         List(),
         2147483647,
         false,
-        None,
-        propertyProtected = false
+        None
       )
 
     val descriptionClosedTrueValues: CustomMetadataValues = CustomMetadataValues(List(alternativeDescriptionField), "true", 2147483647)
@@ -435,8 +429,7 @@ class ValidateFileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with
         List(descriptionClosedTrueValues, descriptionClosedFalseValues),
         2147483647,
         false,
-        None,
-        propertyProtected = false
+        None
       )
 
     val titleClosedTrueValue: CustomMetadataValues = CustomMetadataValues(List(alternativeTitleField), "true", 2147483647)
@@ -455,8 +448,7 @@ class ValidateFileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with
         List(titleClosedTrueValue, titleClosedFalseValue),
         2147483647,
         false,
-        None,
-        propertyProtected = false
+        None
       )
 
     val closureTypeClosedValues: CustomMetadataValues =
@@ -476,8 +468,7 @@ class ValidateFileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with
         List(closureTypeClosedValues, closureTypeOpenValues),
         2147483647,
         false,
-        None,
-        propertyProtected = false
+        None
       )
 
     val multiValueDependency40Value: CustomMetadataValues = CustomMetadataValues(List(closurePeriodField), "40", 2147483647)
@@ -496,8 +487,7 @@ class ValidateFileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with
         List(multiValueDependency30Value, multiValueDependency40Value),
         2147483647,
         false,
-        None,
-        propertyProtected = false
+        None
       )
 
     Seq(

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestUtils.scala
@@ -421,13 +421,15 @@ class TestUtils(db: JdbcBackend#DatabaseDef) {
   }
 
   def addFileProperty(name: String, propertyType: String = "System", propertyGroup: String = "System"): Unit = {
-    val sql = s"""INSERT INTO "FileProperty" ("Name", "PropertyType", "Datatype", "PropertyGroup") VALUES (?, ?, ?, ?)"""
+    val sql = s"""INSERT INTO "FileProperty" ("Name", "PropertyType", "Datatype", "PropertyGroup", "Editable") VALUES (?, ?, ?, ?, ?)"""
     val defaultDataType = "text"
+    val editable = propertyType != "System"
     val ps: PreparedStatement = connection.prepareStatement(sql)
     ps.setString(1, name)
     ps.setString(2, propertyType)
     ps.setString(3, defaultDataType)
     ps.setString(4, propertyGroup)
+    ps.setBoolean(5, editable)
     ps.executeUpdate()
   }
 


### PR DESCRIPTION
With Parliamentary Archives `LegalStatus` and `RightsCopyright` will be editable so we can use the existing `editable` property in the `FileProperty` table to get protected properties instead.