### PR TITLE
TDRD-336 - Give tna user permission to call consignment api's

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/auth/AuthorisationTags.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/auth/AuthorisationTags.scala
@@ -88,7 +88,7 @@ case class ValidateUserHasAccessToConsignment[T](argument: Argument[T]) extends 
     ctx.ctx.consignmentService
       .getConsignment(consignmentId)
       .map(consignment => {
-        if (consignment.isDefined && (consignment.get.userid == userId || exportAccess)) {
+        if (consignment.isDefined && (consignment.get.userid == userId || exportAccess || token.isTNAUser)) {
           continue
         } else {
           throw AuthorisationException(s"User '$userId' does not have access to consignment '$consignmentId'")

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentRouteSpec.scala
@@ -352,6 +352,17 @@ class ConsignmentRouteSpec extends TestContainerUtils with Matchers with TestReq
     response.data should equal(expectedResponse.data)
   }
 
+  "getConsignment" should "allow a user of type TNAUser access to return data" in withContainers { case container: PostgreSQLContainer =>
+    val utils = TestUtils(container.database)
+    val consignmentId = UUID.fromString("6e3b76c4-1745-4467-8ac5-b4dd736e1b3e")
+    val tnaUserId = UUID.fromString("c59cd886-6b12-4288-bf64-80c59f6a566a")
+    utils.createConsignment(consignmentId, userId)
+
+    val expectedResponse: GraphqlQueryData = expectedQueryResponse("data_some")
+    val response: GraphqlQueryData = runTestQuery("query_somedata", validTNAUserToken(userId = tnaUserId))
+    response.data should equal(expectedResponse.data)
+  }
+
   "getConsignment" should "not allow a user to get a consignment that they did not create" in withContainers { case container: PostgreSQLContainer =>
     val utils = TestUtils(container.database)
     val consignmentId = UUID.fromString("f1dbc692-e56c-4d76-be94-d8d3d79bd38a")


### PR DESCRIPTION
This allows TNAUsers to call the required api's such as downloading metadata or fetching consignment details