### PR TITLE
update akkaHttpVersion as this is compatible with akkaVersion 2.10.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ enablePlugins(GraphQLSchemaPlugin)
 graphqlSchemaSnippet := "uk.gov.nationalarchives.tdr.api.graphql.GraphQlTypes.schema"
 
 lazy val akkaVersion = "2.10.0"
-lazy val akkaHttpVersion = "10.6.3"
+lazy val akkaHttpVersion = "10.7.0"
 lazy val circeVersion = "0.14.10"
 lazy val testContainersVersion = "0.41.8"
 

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileRepository.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileRepository.scala
@@ -96,7 +96,7 @@ class FileRepository(db: JdbcBackend#Database)(implicit val executionContext: Ex
 
   def getAllDescendants(fileIds: Seq[UUID]): Future[Seq[FileRow]] = {
 
-    val sql =
+    val plainSql =
       sql"""WITH RECURSIVE children AS (
            SELECT
             "FileId"::text,
@@ -119,7 +119,9 @@ class FileRepository(db: JdbcBackend#Database)(implicit val executionContext: Ex
              f."FileName",
              f."ParentId"::text
             FROM "File" f INNER JOIN children c ON c."FileId"::text = f."ParentId"::text
-        ) SELECT * FROM children;""".as[FileRow]
+        ) SELECT * FROM children;"""
+
+    val sql = plainSql.as[FileRow]
     db.run(sql)
   }
 

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileRepository.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileRepository.scala
@@ -96,6 +96,7 @@ class FileRepository(db: JdbcBackend#Database)(implicit val executionContext: Ex
 
   def getAllDescendants(fileIds: Seq[UUID]): Future[Seq[FileRow]] = {
 
+    val valueIdsString = fileIds.mkString("('", "','", "')")
     val plainSql =
       sql"""WITH RECURSIVE children AS (
            SELECT
@@ -108,7 +109,7 @@ class FileRepository(db: JdbcBackend#Database)(implicit val executionContext: Ex
             "FileName",
             "ParentId"::text
            FROM "File"
-            WHERE "FileId"::text IN #${fileIds.mkString("('", "','", "')")}
+            WHERE "FileId"::text IN #$valueIdsString
             UNION SELECT
              f."FileId"::text,
              f."ConsignmentId"::text,


### PR DESCRIPTION
hopefully this will fix the slick upgrade. Quite a few changes including in pre-release
chore: drop usage of akka.dispatch.ExecutionContexts in https://github.com/akka/akka-http/pull/4422