### PR TITLE
Sptdr service transfer status update permissions

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -167,6 +167,7 @@ input ConsignmentStatusInput {
   consignmentId: UUID!
   statusType: String!
   statusValue: String
+  userIdOverride: UUID
 }
 
 type CustomMetadataField {

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentStatusFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentStatusFields.scala
@@ -7,7 +7,7 @@ import sangria.schema.{Argument, Field, InputObjectType, IntType, ObjectType, Op
 import uk.gov.nationalarchives.tdr.api.auth.ValidateUserHasAccessToConsignment
 import uk.gov.nationalarchives.tdr.api.graphql.ConsignmentApiContext
 import uk.gov.nationalarchives.tdr.api.graphql.fields.FieldTypes.{UuidType, ZonedDateTimeType}
-import uk.gov.nationalarchives.tdr.api.graphql.validation.UserOwnsConsignment
+import uk.gov.nationalarchives.tdr.api.graphql.validation.{ServiceTransfer, UserOwnsConsignment}
 
 import java.time.ZonedDateTime
 import java.util.UUID
@@ -23,7 +23,7 @@ object ConsignmentStatusFields {
       modifiedDatetime: Option[ZonedDateTime]
   )
 
-  case class ConsignmentStatusInput(consignmentId: UUID, statusType: String, statusValue: Option[String]) extends UserOwnsConsignment
+  case class ConsignmentStatusInput(consignmentId: UUID, statusType: String, statusValue: Option[String], userIdOverride: Option[UUID] = None) extends UserOwnsConsignment with ServiceTransfer
 
   val ConsignmentStatusInputType: InputObjectType[ConsignmentStatusInput] =
     deriveInputObjectType[ConsignmentStatusInput]()

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentStatusFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentStatusFields.scala
@@ -23,7 +23,9 @@ object ConsignmentStatusFields {
       modifiedDatetime: Option[ZonedDateTime]
   )
 
-  case class ConsignmentStatusInput(consignmentId: UUID, statusType: String, statusValue: Option[String], userIdOverride: Option[UUID] = None) extends UserOwnsConsignment with ServiceTransfer
+  case class ConsignmentStatusInput(consignmentId: UUID, statusType: String, statusValue: Option[String], userIdOverride: Option[UUID] = None)
+      extends UserOwnsConsignment
+      with ServiceTransfer
 
   val ConsignmentStatusInputType: InputObjectType[ConsignmentStatusInput] =
     deriveInputObjectType[ConsignmentStatusInput]()

--- a/src/test/resources/json/updateconsignmentstatus_mutation_incorrect_override_user_id.json
+++ b/src/test/resources/json/updateconsignmentstatus_mutation_incorrect_override_user_id.json
@@ -2,7 +2,7 @@
   "query": "mutation updateConsignmentStatus($updateConsignmentStatusInput: ConsignmentStatusInput!){updateConsignmentStatus(updateConsignmentStatusInput: $updateConsignmentStatusInput)}",
   "variables": {
     "updateConsignmentStatusInput": {
-      "overrideUserId": "49762121-4425-4dc4-9194-98f72e04d52x",
+      "userIdOverride": "c44f1b9b-1275-4bc3-831c-808c50a0222d",
       "consignmentId": "6e3b76c4-1745-4467-8ac5-b4dd736e1b3e",
       "statusType": "Series",
       "statusValue": "Completed"

--- a/src/test/resources/json/updateconsignmentstatus_mutation_incorrect_override_user_id.json
+++ b/src/test/resources/json/updateconsignmentstatus_mutation_incorrect_override_user_id.json
@@ -1,0 +1,11 @@
+{
+  "query": "mutation updateConsignmentStatus($updateConsignmentStatusInput: ConsignmentStatusInput!){updateConsignmentStatus(updateConsignmentStatusInput: $updateConsignmentStatusInput)}",
+  "variables": {
+    "updateConsignmentStatusInput": {
+      "overrideUserId": "49762121-4425-4dc4-9194-98f72e04d52x",
+      "consignmentId": "6e3b76c4-1745-4467-8ac5-b4dd736e1b3e",
+      "statusType": "Series",
+      "statusValue": "Completed"
+    }
+  }
+}

--- a/src/test/resources/json/updateconsignmentstatus_mutation_override_user_id.json
+++ b/src/test/resources/json/updateconsignmentstatus_mutation_override_user_id.json
@@ -1,0 +1,11 @@
+{
+  "query": "mutation updateConsignmentStatus($updateConsignmentStatusInput: ConsignmentStatusInput!){updateConsignmentStatus(updateConsignmentStatusInput: $updateConsignmentStatusInput)}",
+  "variables": {
+    "updateConsignmentStatusInput": {
+      "userIdOverride": "49762121-4425-4dc4-9194-98f72e04d52e",
+      "consignmentId": "6e3b76c4-1745-4467-8ac5-b4dd736e1b3e",
+      "statusType": "Series",
+      "statusValue": "Completed"
+    }
+  }
+}

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentStatusRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentStatusRouteSpec.scala
@@ -162,6 +162,23 @@ class ConsignmentStatusRouteSpec extends TestContainerUtils with Matchers with T
     response.data.get.updateConsignmentStatus should equal(expectedResponse.data.get.updateConsignmentStatus)
   }
 
+  "updateConsignmentStatus" should "x" in withContainers { case container: PostgreSQLContainer =>
+    val utils = TestUtils(container.database)
+    val consignmentId = UUID.fromString("a8dc972d-58f9-4733-8bb2-4254b89a35f2")
+    val userId = UUID.fromString("49762121-4425-4dc4-9194-98f72e04d52e")
+    val statusType = "Series"
+    val statusValue = "InProgress"
+    val token = validTransferServiceToken("data-load")
+
+    utils.createConsignment(consignmentId, userId)
+    utils.createConsignmentStatus(consignmentId, statusType, statusValue)
+
+    val expectedResponse = expectedUpdateConsignmentStatusMutationResponse("data_all")
+    val response = runUpdateConsignmentStatusTestMutation("mutation_override_user_id", token)
+
+    response.data.get.updateConsignmentStatus should equal(expectedResponse.data.get.updateConsignmentStatus)
+  }
+
   "updateConsignmentStatus" should "allow a transfer adviser user to update the consignment status" in withContainers { case container: PostgreSQLContainer =>
     val utils = TestUtils(container.database)
     val consignmentId = UUID.fromString("a8dc972d-58f9-4733-8bb2-4254b89a35f2")

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentStatusServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentStatusServiceSpec.scala
@@ -79,36 +79,6 @@ class ConsignmentStatusServiceSpec extends AnyFlatSpec with MockitoSugar with Re
     consignmentStatusRowPassedToRepo.value should equal(expectedStatusValue)
   }
 
-  "addConsignmentStatus" should "set user id to override id where present on input" in {
-    val fixedUUIDSource = new FixedUUIDSource()
-    val expectedConsignmentId = fixedUUIDSource.uuid
-    val expectedStatusType = "Upload"
-    val expectedStatusValue = "Completed"
-    val overrideUserId = UUID.randomUUID()
-
-    val consignmentStatusRowCaptor: ArgumentCaptor[ConsignmentstatusRow] = ArgumentCaptor.forClass(classOf[ConsignmentstatusRow])
-    val consignmentIdCaptor: ArgumentCaptor[UUID] = ArgumentCaptor.forClass(classOf[UUID])
-
-    val mockGetConsignmentStatusRepoResponse: Future[Seq[ConsignmentstatusRow]] = Future(Seq())
-    val mockAddConsignmentStatusRepoResponse = Future(
-      generateConsignmentStatusRow(expectedConsignmentId, expectedStatusType, expectedStatusValue, None)
-    )
-
-    when(consignmentStatusRepositoryMock.getConsignmentStatus(consignmentIdCaptor.capture())).thenReturn(mockGetConsignmentStatusRepoResponse)
-    when(consignmentStatusRepositoryMock.addConsignmentStatus(consignmentStatusRowCaptor.capture())).thenReturn(mockAddConsignmentStatusRepoResponse)
-
-    val addConsignmentStatusInput =
-      ConsignmentStatusInput(expectedConsignmentId, expectedStatusType, Some(expectedStatusValue), Some(overrideUserId))
-    consignmentService.addConsignmentStatus(addConsignmentStatusInput).futureValue
-
-    val consignmentStatusRowPassedToRepo = consignmentStatusRowCaptor.getValue
-
-    consignmentIdCaptor.getValue should equal(expectedConsignmentId)
-    consignmentStatusRowPassedToRepo.consignmentid should equal(expectedConsignmentId)
-    consignmentStatusRowPassedToRepo.statustype should equal(expectedStatusType)
-    consignmentStatusRowPassedToRepo.value should equal(expectedStatusValue)
-  }
-
   "addConsignmentStatus" should "return the consignment status row if a row with same statusType doesn't already exist" in {
     val fixedUUIDSource = new FixedUUIDSource()
     val expectedConsignmentId = fixedUUIDSource.uuid


### PR DESCRIPTION
To support SharePoint and other third party service transfers the updating of Consignment statuses will be done via a service client user

The user id in the bearer access token will be the service client user and not the user that owns the transfer this will cause an Authorisation Exception

These changes will allow the service client user to update Consignment statuses for all consignments