### PR TITLE
New transfer service role to give access permission to consignment

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/auth/AuthorisationTags.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/auth/AuthorisationTags.scala
@@ -17,6 +17,7 @@ trait AuthorisationTag extends ValidationTag {
   val antiVirusRole = "antivirus"
   val checksumRole = "checksum"
   val dataLoadRole = "data-load"
+  val dataLoadAccessRole = "data_load_access"
   val fileFormatRole = "file_format"
   val exportRole = "export"
   val reportingRole = "reporting"
@@ -77,7 +78,8 @@ case class ValidateUserHasAccessToConsignment[T](argument: Argument[T], updateCo
   override def validateAsync(ctx: Context[ConsignmentApiContext, _])(implicit executionContext: ExecutionContext): Future[BeforeFieldResult[ConsignmentApiContext, Unit]] = {
     val token = ctx.ctx.accessToken
     val arg: T = ctx.arg[T](argument.name)
-    val hasAccess = token.backendChecksRoles.contains(exportRole) || token.draftMetadataRoles.contains(updateMetadataRole)
+    val hasAccess = token.backendChecksRoles.contains(exportRole) || token.draftMetadataRoles.contains(updateMetadataRole) ||
+      token.transferServiceRoles.contains(dataLoadAccessRole)
     lazy val hasUserIdOverrideAccess: Boolean = token.transferServiceRoles.contains(dataLoadRole)
 
     val userId: UUID = arg match {


### PR DESCRIPTION
To ensure the continuing integrity of the user id ovveride check use separate transfer service client role for providing general access to a consignment

Transfer service client needs access to consignment data to support SharePoint transfer features