### PR TITLE
[TDRD-1334] Add metadataReviewNotes support to ConsignmentStatusInput and MetadataReviewLog

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-generic-extras" % "0.14.4",
   "com.softwaremill.sttp.client3" %% "core" % "3.11.0",
-  "uk.gov.nationalarchives" %% "consignment-api-db" % "0.1.56",
+  "uk.gov.nationalarchives" %% "consignment-api-db" % "0.1.57",
   "uk.gov.nationalarchives" %% "tdr-metadata-validation" % "0.0.214",
   "org.postgresql" % "postgresql" % "42.7.10",
   "com.typesafe.slick" %% "slick" % "3.6.1",

--- a/schema.graphql
+++ b/schema.graphql
@@ -212,6 +212,7 @@ input ConsignmentStatusInput {
   statusType: String!
   statusValue: String
   userIdOverride: UUID
+  metadataReviewNotes: String
 }
 
 enum Direction {
@@ -399,6 +400,7 @@ type MetadataReviewLog {
   userId: UUID!
   action: String!
   eventTime: ZonedDateTime!
+  metadataReviewNotes: String
 }
 
 type Mutation {

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentFields.scala
@@ -100,7 +100,8 @@ object ConsignmentFields {
       consignmentId: UUID,
       userId: UUID,
       action: String,
-      eventTime: ZonedDateTime
+      eventTime: ZonedDateTime,
+      metadataReviewNotes: Option[String]
   )
 
   case class ConsignmentReviewDetails(

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentStatusFields.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/graphql/fields/ConsignmentStatusFields.scala
@@ -23,8 +23,13 @@ object ConsignmentStatusFields {
       modifiedDatetime: Option[ZonedDateTime]
   )
 
-  case class ConsignmentStatusInput(consignmentId: UUID, statusType: String, statusValue: Option[String], userIdOverride: Option[UUID] = None)
-      extends UserOwnsConsignment
+  case class ConsignmentStatusInput(
+      consignmentId: UUID,
+      statusType: String,
+      statusValue: Option[String],
+      userIdOverride: Option[UUID] = None,
+      metadataReviewNotes: Option[String] = None
+  ) extends UserOwnsConsignment
       with ServiceTransfer
 
   val ConsignmentStatusInputType: InputObjectType[ConsignmentStatusInput] =

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentStatusService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentStatusService.scala
@@ -113,7 +113,9 @@ class ConsignmentStatusService(
         }
       }
       .flatten
-    action.map(a => MetadatareviewlogRow(uuidSource.uuid, consignmentStatusInput.consignmentId, userId, a, Timestamp.from(timeSource.now)))
+    action.map(a =>
+      MetadatareviewlogRow(uuidSource.uuid, consignmentStatusInput.consignmentId, userId, a, Timestamp.from(timeSource.now), consignmentStatusInput.metadataReviewNotes)
+    )
   }
 }
 

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/MetadataReviewService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/MetadataReviewService.scala
@@ -18,7 +18,8 @@ class MetadataReviewService(
       row.consignmentid,
       row.userid,
       row.action,
-      row.eventtime.toZonedDateTime
+      row.eventtime.toZonedDateTime,
+      row.metadatareviewnotes
     )
   }
 

--- a/src/test/resources/json/getconsignment_data_metadata_review_logs.json
+++ b/src/test/resources/json/getconsignment_data_metadata_review_logs.json
@@ -7,7 +7,8 @@
           "consignmentId": "6e3b76c4-1745-4467-8ac5-b4dd736e1b3e",
           "userId": "4ab14990-ed63-4615-8336-56fbb9960300",
           "action": "Approval",
-          "eventTime": "2020-01-01T09:00Z"
+          "eventTime": "2020-01-01T09:00Z",
+          "metadataReviewNotes": null
         }
       ]
     }

--- a/src/test/resources/json/getconsignment_query_metadata_review_logs.json
+++ b/src/test/resources/json/getconsignment_query_metadata_review_logs.json
@@ -1,3 +1,3 @@
 {
-  "query": "{getConsignment(consignmentid: \"6e3b76c4-1745-4467-8ac5-b4dd736e1b3e\") {metadataReviewLogs {metadataReviewLogId consignmentId userId action eventTime}}}"
+  "query": "{getConsignment(consignmentid: \"6e3b76c4-1745-4467-8ac5-b4dd736e1b3e\") {metadataReviewLogs {metadataReviewLogId consignmentId userId action eventTime metadataReviewNotes}}}"
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentStatusServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentStatusServiceSpec.scala
@@ -552,4 +552,79 @@ class ConsignmentStatusServiceSpec extends AnyFlatSpec with MockitoSugar with Re
     capturedLogRow.userid should equal(dummyUserId)
     capturedLogRow.action should equal(Rejection.value)
   }
+
+  "addConsignmentStatus" should "pass metadataReviewNotes to the metadata review log entry" in {
+    val fixedUUIDSource = new FixedUUIDSource()
+    val expectedConsignmentId = fixedUUIDSource.uuid
+    val expectedStatusType = "MetadataReview"
+    val expectedStatusValue = "InProgress"
+    val expectedNotes = "Some review notes"
+
+    val metadataReviewLogRowCaptor: ArgumentCaptor[MetadatareviewlogRow] = ArgumentCaptor.forClass(classOf[MetadatareviewlogRow])
+
+    val mockGetConsignmentStatusRepoResponse: Future[Seq[ConsignmentstatusRow]] = Future(Seq())
+    val mockAddConsignmentStatusRepoResponse = Future(
+      generateConsignmentStatusRow(expectedConsignmentId, expectedStatusType, expectedStatusValue, None)
+    )
+
+    when(consignmentStatusRepositoryMock.getConsignmentStatus(any[UUID])).thenReturn(mockGetConsignmentStatusRepoResponse)
+    when(consignmentStatusRepositoryMock.addConsignmentStatus(any[ConsignmentstatusRow])).thenReturn(mockAddConsignmentStatusRepoResponse)
+    when(metadataReviewLogRepositoryMock.addLogEntry(metadataReviewLogRowCaptor.capture()))
+      .thenReturn(Future.successful(mock[MetadatareviewlogRow]))
+
+    val addConsignmentStatusInput =
+      ConsignmentStatusInput(expectedConsignmentId, expectedStatusType, Some(expectedStatusValue), metadataReviewNotes = Some(expectedNotes))
+    consignmentService.addConsignmentStatus(addConsignmentStatusInput, dummyUserId).futureValue
+
+    val capturedLogRow = metadataReviewLogRowCaptor.getValue
+    capturedLogRow.metadatareviewnotes should equal(Some(expectedNotes))
+  }
+
+  "updateConsignmentStatus" should "pass metadataReviewNotes to the metadata review log entry" in {
+    val fixedUUIDSource = new FixedUUIDSource()
+    val expectedConsignmentId = fixedUUIDSource.uuid
+    val expectedStatusType = "MetadataReview"
+    val expectedStatusValue = "CompletedWithIssues"
+    val expectedNotes = "Rejection reason notes"
+
+    val metadataReviewLogRowCaptor: ArgumentCaptor[MetadatareviewlogRow] = ArgumentCaptor.forClass(classOf[MetadatareviewlogRow])
+
+    when(consignmentStatusRepositoryMock.updateConsignmentStatus(any[UUID], any[String], any[String], any[Timestamp]))
+      .thenReturn(Future.successful(1))
+    when(metadataReviewLogRepositoryMock.addLogEntry(metadataReviewLogRowCaptor.capture()))
+      .thenReturn(Future.successful(mock[MetadatareviewlogRow]))
+
+    val updateConsignmentStatusInput =
+      ConsignmentStatusInput(expectedConsignmentId, expectedStatusType, Some(expectedStatusValue), metadataReviewNotes = Some(expectedNotes))
+    consignmentService.updateConsignmentStatus(updateConsignmentStatusInput, dummyUserId).futureValue
+
+    val capturedLogRow = metadataReviewLogRowCaptor.getValue
+    capturedLogRow.metadatareviewnotes should equal(Some(expectedNotes))
+    capturedLogRow.action should equal(Rejection.value)
+  }
+
+  "addConsignmentStatus" should "set metadataReviewNotes to None when no notes provided for MetadataReview status" in {
+    val fixedUUIDSource = new FixedUUIDSource()
+    val expectedConsignmentId = fixedUUIDSource.uuid
+    val expectedStatusType = "MetadataReview"
+    val expectedStatusValue = "InProgress"
+
+    val metadataReviewLogRowCaptor: ArgumentCaptor[MetadatareviewlogRow] = ArgumentCaptor.forClass(classOf[MetadatareviewlogRow])
+
+    val mockGetConsignmentStatusRepoResponse: Future[Seq[ConsignmentstatusRow]] = Future(Seq())
+    val mockAddConsignmentStatusRepoResponse = Future(
+      generateConsignmentStatusRow(expectedConsignmentId, expectedStatusType, expectedStatusValue, None)
+    )
+
+    when(consignmentStatusRepositoryMock.getConsignmentStatus(any[UUID])).thenReturn(mockGetConsignmentStatusRepoResponse)
+    when(consignmentStatusRepositoryMock.addConsignmentStatus(any[ConsignmentstatusRow])).thenReturn(mockAddConsignmentStatusRepoResponse)
+    when(metadataReviewLogRepositoryMock.addLogEntry(metadataReviewLogRowCaptor.capture()))
+      .thenReturn(Future.successful(mock[MetadatareviewlogRow]))
+
+    val addConsignmentStatusInput = ConsignmentStatusInput(expectedConsignmentId, expectedStatusType, Some(expectedStatusValue))
+    consignmentService.addConsignmentStatus(addConsignmentStatusInput, dummyUserId).futureValue
+
+    val capturedLogRow = metadataReviewLogRowCaptor.getValue
+    capturedLogRow.metadatareviewnotes should equal(None)
+  }
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentStatusServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentStatusServiceSpec.scala
@@ -14,6 +14,8 @@ import uk.gov.nationalarchives.tdr.api.service.ConsignmentStatusService.{validSt
 import uk.gov.nationalarchives.tdr.api.service.FileStatusService._
 import uk.gov.nationalarchives.tdr.api.utils.{FixedTimeSource, FixedUUIDSource}
 import uk.gov.nationalarchives.tdr.common.utils.statuses.MetadataReviewLogAction.{Approval, Rejection, Submission}
+import uk.gov.nationalarchives.tdr.common.utils.statuses.StatusTypes.MetadataReviewType
+import uk.gov.nationalarchives.tdr.common.utils.statuses.StatusValues.{CompletedWithIssuesValue, InProgressValue}
 
 import java.sql.Timestamp
 import java.time.{ZoneId, ZonedDateTime}
@@ -556,8 +558,8 @@ class ConsignmentStatusServiceSpec extends AnyFlatSpec with MockitoSugar with Re
   "addConsignmentStatus" should "pass metadataReviewNotes to the metadata review log entry" in {
     val fixedUUIDSource = new FixedUUIDSource()
     val expectedConsignmentId = fixedUUIDSource.uuid
-    val expectedStatusType = "MetadataReview"
-    val expectedStatusValue = "InProgress"
+    val expectedStatusType = MetadataReviewType.id
+    val expectedStatusValue = InProgressValue.value
     val expectedNotes = "Some review notes"
 
     val metadataReviewLogRowCaptor: ArgumentCaptor[MetadatareviewlogRow] = ArgumentCaptor.forClass(classOf[MetadatareviewlogRow])
@@ -583,8 +585,8 @@ class ConsignmentStatusServiceSpec extends AnyFlatSpec with MockitoSugar with Re
   "updateConsignmentStatus" should "pass metadataReviewNotes to the metadata review log entry" in {
     val fixedUUIDSource = new FixedUUIDSource()
     val expectedConsignmentId = fixedUUIDSource.uuid
-    val expectedStatusType = "MetadataReview"
-    val expectedStatusValue = "CompletedWithIssues"
+    val expectedStatusType = MetadataReviewType.id
+    val expectedStatusValue = CompletedWithIssuesValue.value
     val expectedNotes = "Rejection reason notes"
 
     val metadataReviewLogRowCaptor: ArgumentCaptor[MetadatareviewlogRow] = ArgumentCaptor.forClass(classOf[MetadatareviewlogRow])
@@ -606,8 +608,8 @@ class ConsignmentStatusServiceSpec extends AnyFlatSpec with MockitoSugar with Re
   "addConsignmentStatus" should "set metadataReviewNotes to None when no notes provided for MetadataReview status" in {
     val fixedUUIDSource = new FixedUUIDSource()
     val expectedConsignmentId = fixedUUIDSource.uuid
-    val expectedStatusType = "MetadataReview"
-    val expectedStatusValue = "InProgress"
+    val expectedStatusType = MetadataReviewType.id
+    val expectedStatusValue = InProgressValue.value
 
     val metadataReviewLogRowCaptor: ArgumentCaptor[MetadatareviewlogRow] = ArgumentCaptor.forClass(classOf[MetadatareviewlogRow])
 

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/MetadataReviewServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/MetadataReviewServiceSpec.scala
@@ -28,8 +28,8 @@ class MetadataReviewServiceSpec extends AnyFlatSpec with MockitoSugar with Match
     val eventTime = Timestamp.valueOf("2024-06-01 12:00:00")
 
     val rows = Seq(
-      MetadatareviewlogRow(logId1, consignmentId, userId, Approval.value, eventTime),
-      MetadatareviewlogRow(logId2, consignmentId, userId, Rejection.value, eventTime)
+      MetadatareviewlogRow(logId1, consignmentId, userId, Approval.value, eventTime, Some("Looks good")),
+      MetadatareviewlogRow(logId2, consignmentId, userId, Rejection.value, eventTime, Some("Needs changes"))
     )
 
     when(metadataReviewLogRepositoryMock.getEntriesByConsignmentId(consignmentId)).thenReturn(Future.successful(rows))
@@ -42,8 +42,10 @@ class MetadataReviewServiceSpec extends AnyFlatSpec with MockitoSugar with Match
     result.head.consignmentId shouldBe consignmentId
     result.head.userId shouldBe userId
     result.head.action shouldBe Approval.value
+    result.head.metadataReviewNotes shouldBe Some("Looks good")
     result(1).metadataReviewLogId shouldBe logId2
     result(1).action shouldBe Rejection.value
+    result(1).metadataReviewNotes shouldBe Some("Needs changes")
   }
 
   "getMetadataReviewDetails" should "return an empty list if no log entries exist for the consignment" in {
@@ -73,5 +75,24 @@ class MetadataReviewServiceSpec extends AnyFlatSpec with MockitoSugar with Match
     result.size shouldBe 1
     result.head.eventTime shouldBe a[ZonedDateTime]
     result.head.eventTime.toInstant shouldBe eventTime.toInstant
+    result.head.metadataReviewNotes shouldBe None
+  }
+
+  "getMetadataReviewDetails" should "map metadataReviewNotes from row to case class" in {
+    val consignmentId = UUID.randomUUID()
+    val userId = UUID.randomUUID()
+    val logId = UUID.randomUUID()
+    val eventTime = Timestamp.valueOf("2024-06-01 12:00:00")
+    val notes = "Some review notes"
+
+    val rows = Seq(MetadatareviewlogRow(logId, consignmentId, userId, Approval.value, eventTime, Some(notes)))
+
+    when(metadataReviewLogRepositoryMock.getEntriesByConsignmentId(consignmentId)).thenReturn(Future.successful(rows))
+
+    val service = new MetadataReviewService(metadataReviewLogRepositoryMock)
+    val result: Seq[MetadataReviewLog] = service.getMetadataReviewDetails(consignmentId).futureValue
+
+    result.size shouldBe 1
+    result.head.metadataReviewNotes shouldBe Some(notes)
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestUtils.scala
@@ -463,14 +463,26 @@ class TestUtils(db: JdbcBackend#Database) {
     rs.next()
   }
 
-  def addMetadataReviewLog(logId: UUID, consignmentId: UUID, userId: UUID, action: String, eventTime: Timestamp = Timestamp.from(FixedTimeSource.now)): Unit = {
-    val sql = s"""INSERT INTO "MetadataReviewLog" ("MetadataReviewLogId", "ConsignmentId", "UserId", "Action", "EventTime") VALUES (?, ?, ?, ?, ?)"""
+  def addMetadataReviewLog(
+      logId: UUID,
+      consignmentId: UUID,
+      userId: UUID,
+      action: String,
+      eventTime: Timestamp = Timestamp.from(FixedTimeSource.now),
+      metadataReviewNotes: Option[String] = None
+  ): Unit = {
+    val sql =
+      s"""INSERT INTO "MetadataReviewLog" ("MetadataReviewLogId", "ConsignmentId", "UserId", "Action", "EventTime", "MetadataReviewNotes") VALUES (?, ?, ?, ?, ?, ?)"""
     val ps: PreparedStatement = connection.prepareStatement(sql)
     ps.setObject(1, logId, Types.OTHER)
     ps.setObject(2, consignmentId, Types.OTHER)
     ps.setObject(3, userId, Types.OTHER)
     ps.setString(4, action)
     ps.setTimestamp(5, eventTime)
+    metadataReviewNotes match {
+      case Some(notes) => ps.setString(6, notes)
+      case None        => ps.setNull(6, Types.VARCHAR)
+    }
     ps.executeUpdate()
   }
 


### PR DESCRIPTION
## Changes

- Bump `consignment-api-db` dependency from 0.1.56 to 0.1.57 (includes V200 migration adding MetadataReviewNotes column)
- Add optional `metadataReviewNotes` field to `ConsignmentStatusInput` GraphQL input
- Add `metadataReviewNotes` field to `MetadataReviewLog` GraphQL type
- Pass notes from `ConsignmentStatusInput` through to `MetadatareviewlogRow` in `ConsignmentStatusService`
- Map `metadatareviewnotes` from DB row in `MetadataReviewService`
- Update test utilities and route spec test data
- Add unit tests for notes pass-through and mapping

## Deployment note
The DB migration (V200) in `tdr-consignment-api-data` v0.1.57 must be applied before deploying this API change.