### PR TITLE
TDRD-1333 Allow TNA user to view details for 

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepository.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepository.scala
@@ -97,7 +97,6 @@ class ConsignmentRepository(db: JdbcBackend#Database, timeSource: TimeSource) {
       .on(_.consignmentid === _.consignmentid)
       .filter(_._1.consignmentid === consignmentId)
       .filter(_._2.statustype === MetadataReviewType.id)
-      .filter(_._2.value === InProgressValue.value)
       .map(_._1)
     db.run(query.result)
   }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepositorySpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepositorySpec.scala
@@ -382,7 +382,7 @@ class ConsignmentRepositorySpec extends TestContainerUtils with ScalaFutures wit
       response.headOption.get.consignmentid should equal(consignmentId)
   }
 
-  "getConsignmentForMetadataReview" should "not return the matching consignment when the 'MetadataReview' status set to `Completed`" in withContainers {
+  "getConsignmentForMetadataReview" should "return the matching consignment when the 'MetadataReview' status set to `Completed`" in withContainers {
     case container: PostgreSQLContainer =>
       val consignmentId = UUID.fromString("a3088f8a-59a3-4ab3-9e50-1677648e8186")
       val db = container.database

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepositorySpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepositorySpec.scala
@@ -20,7 +20,7 @@ import uk.gov.nationalarchives.tdr.api.graphql.fields.ConsignmentFields.{
 }
 import uk.gov.nationalarchives.tdr.api.service.CurrentTimeSource
 import uk.gov.nationalarchives.tdr.api.service.FileStatusService.{InProgress, Upload}
-import uk.gov.nationalarchives.tdr.api.utils.Statuses.{CompletedValue, InProgressValue, MetadataReviewType}
+import uk.gov.nationalarchives.tdr.api.utils.Statuses.{CompletedValue, CompletedWithIssuesValue, InProgressValue, MetadataReviewType}
 import uk.gov.nationalarchives.tdr.api.utils.TestAuthUtils._
 import uk.gov.nationalarchives.tdr.api.utils.TestContainerUtils._
 import uk.gov.nationalarchives.tdr.api.utils.{FixedTimeSource, TestContainerUtils, TestUtils}
@@ -367,7 +367,22 @@ class ConsignmentRepositorySpec extends TestContainerUtils with ScalaFutures wit
       response.headOption.get.consignmentid should equal(consignmentId)
   }
 
-  "getConsignmentForMetadataReview" should "not return the matching consignment when the 'MetadataReview' status is not `InProgress`" in withContainers {
+  "getConsignmentForMetadataReview" should "return the matching consignment when the 'MetadataReview' status set to `CompletedWithIssues`" in withContainers {
+    case container: PostgreSQLContainer =>
+      val consignmentId = UUID.fromString("a3088f8a-59a3-4ab3-9e50-1677648e8186")
+      val db = container.database
+      val consignmentRepository = new ConsignmentRepository(db, new CurrentTimeSource)
+      val utils = TestUtils(db)
+      utils.createConsignment(consignmentId, userId)
+      utils.createConsignmentStatus(consignmentId, MetadataReviewType.id, CompletedWithIssuesValue.value)
+
+      val response = consignmentRepository.getConsignmentForMetadataReview(consignmentId).futureValue
+
+      response should have size 1
+      response.headOption.get.consignmentid should equal(consignmentId)
+  }
+
+  "getConsignmentForMetadataReview" should "not return the matching consignment when the 'MetadataReview' status set to `Completed`" in withContainers {
     case container: PostgreSQLContainer =>
       val consignmentId = UUID.fromString("a3088f8a-59a3-4ab3-9e50-1677648e8186")
       val db = container.database
@@ -378,7 +393,8 @@ class ConsignmentRepositorySpec extends TestContainerUtils with ScalaFutures wit
 
       val response = consignmentRepository.getConsignmentForMetadataReview(consignmentId).futureValue
 
-      response.isEmpty should be(true)
+      response should have size 1
+      response.headOption.get.consignmentid should equal(consignmentId)
   }
 
   "updateSeriesOfConsignment" should "update id and name of the consignment" in withContainers { case container: PostgreSQLContainer =>


### PR DESCRIPTION
With the introduction of the metadata review v2 we now have columns for viewing metadata that are in `Requested`. `Rejected` , `Approved` state this pr allows TNA users to view consignment details for metadata in those state