### PR TITLE
Sort manage transfers by date descending only

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentService.scala
@@ -12,7 +12,6 @@ import uk.gov.nationalarchives.tdr.api.model.consignment.ConsignmentType.Consign
 import uk.gov.nationalarchives.tdr.api.service.FileStatusService._
 import uk.gov.nationalarchives.tdr.api.utils.TimeUtils.TimestampUtils
 import uk.gov.nationalarchives.tdr.common.utils.statuses.MetadataReviewLogAction.MetadataReviewLogAction
-import uk.gov.nationalarchives.tdr.common.utils.statuses.MetadataReviewStatus
 import uk.gov.nationalarchives.tdr.keycloak.Token
 
 import java.sql.Timestamp
@@ -34,14 +33,6 @@ class ConsignmentService(
 )(implicit val executionContext: ExecutionContext) {
 
   val maxLimit: Int = config.getInt("pagination.consignmentsMaxLimit")
-
-  // Review status sort ordering: Requested > Rejected > Approved > Transferred
-  private val reviewStatusOrder: Map[String, Int] = Map(
-    MetadataReviewStatus.Requested.value -> 0,
-    MetadataReviewStatus.Rejected.value -> 1,
-    MetadataReviewStatus.Approved.value -> 2,
-    MetadataReviewStatus.Transferred.value -> 3
-  )
 
   def startUpload(startUploadInput: StartUploadInput): Future[String] = {
     consignmentStatusRepository
@@ -144,7 +135,7 @@ class ConsignmentService(
       val latestLogByConsignment = latestLogPerConsignment(logEntries)
       val details = buildReviewDetails(consignmentRows, latestLogByConsignment)
       val filtered = filterByStatus(details, statusFilter)
-      sortByReviewStatus(filtered)
+      sortByDateDescending(filtered)
     }
   }
 
@@ -217,8 +208,8 @@ class ConsignmentService(
     }
   }
 
-  private def sortByReviewStatus(details: Seq[ConsignmentReviewDetails]): Seq[ConsignmentReviewDetails] = {
-    details.sortBy(d => (reviewStatusOrder.getOrElse(d.reviewStatus, Int.MaxValue), -d.lastUpdated.toInstant.toEpochMilli))
+  private def sortByDateDescending(details: Seq[ConsignmentReviewDetails]): Seq[ConsignmentReviewDetails] = {
+    details.sortBy(d => -d.lastUpdated.toInstant.toEpochMilli)
   }
 
   private def convertRowToConsignment(row: ConsignmentRow): Consignment = {

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentServiceSpec.scala
@@ -579,7 +579,7 @@ class ConsignmentServiceSpec extends AnyFlatSpec with MockitoSugar with ResetMoc
     consignment.transferringBodyTdrCode should equal(consignmentRow.transferringbodytdrcode)
   }
 
-  "getConsignmentReviewDetails" should "return a sorted list of all ConsignmentReviewDetails when statusFilter is None" in {
+  "getConsignmentReviewDetails" should "return a list sorted by date descending when statusFilter is None" in {
     val consignmentId1 = UUID.randomUUID()
     val consignmentId2 = UUID.randomUUID()
 
@@ -587,8 +587,11 @@ class ConsignmentServiceSpec extends AnyFlatSpec with MockitoSugar with ResetMoc
     val consignmentRow2 =
       createReviewConsignmentRow(consignmentId2, sequence = 401L, reference = "TDR-2020-B", seriesName = "seriesName2", bodyName = "department2", bodyCode = "code2")
 
-    val logEntry1 = MetadatareviewlogRow(UUID.randomUUID(), consignmentId1, userId, Approval.value, Timestamp.from(FixedTimeSource.now))
-    val logEntry2 = MetadatareviewlogRow(UUID.randomUUID(), consignmentId2, userId, Submission.value, Timestamp.from(FixedTimeSource.now))
+    val olderTimestamp = Timestamp.from(FixedTimeSource.now.minusSeconds(3600))
+    val newerTimestamp = Timestamp.from(FixedTimeSource.now)
+
+    val logEntry1 = MetadatareviewlogRow(UUID.randomUUID(), consignmentId1, userId, Approval.value, olderTimestamp)
+    val logEntry2 = MetadatareviewlogRow(UUID.randomUUID(), consignmentId2, userId, Submission.value, newerTimestamp)
 
     when(consignmentRepoMock.getConsignmentsWithMetadataReviewStatus)
       .thenReturn(Future.successful(Seq(consignmentRow1, consignmentRow2)))
@@ -599,7 +602,7 @@ class ConsignmentServiceSpec extends AnyFlatSpec with MockitoSugar with ResetMoc
 
     verify(consignmentRepoMock, times(1)).getConsignmentsWithMetadataReviewStatus
     response should have size 2
-    // Requested sorts before Approved
+    // Most recent date first, regardless of status
     response.head.consignmentId should equal(consignmentId2)
     response.head.reviewStatus should equal(MetadataReviewStatus.Requested.value)
     response.head.consignmentReference should equal("TDR-2020-B")


### PR DESCRIPTION
## What does this PR do?

Changes the sort order on the manage transfers screen (consignment review details) from **status rank then date desc** to **date descending only**.

## Why?

The status-based grouping is redundant because the screen already has tabs filtering by status. Sorting purely by date gives TNA reviewers a clearer chronological view of transfers requiring attention.

## Changes

- Removed `reviewStatusOrder` map and `MetadataReviewStatus` import from `ConsignmentService`
- Renamed `sortByReviewStatus` → `sortByDateDescending`
- Simplified sort to: `details.sortBy(d => -d.lastUpdated.toInstant.toEpochMilli)`
- Updated unit test to verify date-based ordering with distinct timestamps