### PR TITLE
Add skipped status as a valid status value

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,7 +84,7 @@ libraryDependencies ++= Seq(
   "com.dimafeng" %% "testcontainers-scala-postgresql" % testContainersVersion % Test,
   "com.github.tomakehurst" % "wiremock-standalone" % "3.0.1" % Test,
   "uk.gov.nationalarchives" % "da-metadata-schema_2.13" % "0.0.133",
-  "uk.gov.nationalarchives" %% "tdr-statuses" % "0.0.31"
+  "uk.gov.nationalarchives" %% "tdr-statuses" % "0.0.32"
 )
 
 dependencyOverrides ++= Seq(

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentStatusService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentStatusService.scala
@@ -134,5 +134,5 @@ object ConsignmentStatusService {
       MetadataReviewType.id
     )
   val validStatusTypes: Set[String] = validConsignmentTypes.toSet ++ Set(ServerFFIDType.id, ServerChecksumType.id, ServerAntivirusType.id, ServerRedactionType.id)
-  val validStatusValues: Set[String] = Set(InProgressValue.value, CompletedValue.value, CompletedWithIssuesValue.value, FailedValue.value)
+  val validStatusValues: Set[String] = Set(InProgressValue.value, CompletedValue.value, CompletedWithIssuesValue.value, FailedValue.value, SkippedValue.value)
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentStatusServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentStatusServiceSpec.scala
@@ -23,7 +23,21 @@ import java.util.UUID
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
-import uk.gov.nationalarchives.tdr.common.utils.statuses.StatusTypes.{ClientChecksType, ConfirmTransferType, DraftMetadataType, DraftMetadataUploadType, ExportType, MetadataReviewType, SeriesType, ServerAntivirusType, ServerChecksumType, ServerFFIDType, ServerRedactionType, TransferAgreementType, UploadType}
+import uk.gov.nationalarchives.tdr.common.utils.statuses.StatusTypes.{
+  ClientChecksType,
+  ConfirmTransferType,
+  DraftMetadataType,
+  DraftMetadataUploadType,
+  ExportType,
+  MetadataReviewType,
+  SeriesType,
+  ServerAntivirusType,
+  ServerChecksumType,
+  ServerFFIDType,
+  ServerRedactionType,
+  TransferAgreementType,
+  UploadType
+}
 
 class ConsignmentStatusServiceSpec extends AnyFlatSpec with MockitoSugar with ResetMocksAfterEachTest with Matchers with ScalaFutures with TableDrivenPropertyChecks {
   implicit val executionContext: ExecutionContext = ExecutionContext.Implicits.global

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentStatusServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/ConsignmentStatusServiceSpec.scala
@@ -15,7 +15,7 @@ import uk.gov.nationalarchives.tdr.api.service.FileStatusService._
 import uk.gov.nationalarchives.tdr.api.utils.{FixedTimeSource, FixedUUIDSource}
 import uk.gov.nationalarchives.tdr.common.utils.statuses.MetadataReviewLogAction.{Approval, Rejection, Submission}
 import uk.gov.nationalarchives.tdr.common.utils.statuses.StatusTypes.MetadataReviewType
-import uk.gov.nationalarchives.tdr.common.utils.statuses.StatusValues.{CompletedWithIssuesValue, InProgressValue}
+import uk.gov.nationalarchives.tdr.common.utils.statuses.StatusValues.{CompletedValue, CompletedWithIssuesValue, FailedValue, InProgressValue, SkippedValue}
 
 import java.sql.Timestamp
 import java.time.{ZoneId, ZonedDateTime}
@@ -23,22 +23,7 @@ import java.util.UUID
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
-import uk.gov.nationalarchives.tdr.common.utils.statuses.StatusTypes.{
-  ClientChecksType,
-  ConfirmTransferType,
-  DraftMetadataType,
-  DraftMetadataUploadType,
-  ExportType,
-  MetadataReviewType,
-  SeriesType,
-  ServerAntivirusType,
-  ServerChecksumType,
-  ServerFFIDType,
-  ServerRedactionType,
-  TransferAgreementType,
-  UploadType
-}
-import uk.gov.nationalarchives.tdr.common.utils.statuses.StatusValues.{CompletedValue, CompletedWithIssuesValue, FailedValue, InProgressValue}
+import uk.gov.nationalarchives.tdr.common.utils.statuses.StatusTypes.{ClientChecksType, ConfirmTransferType, DraftMetadataType, DraftMetadataUploadType, ExportType, MetadataReviewType, SeriesType, ServerAntivirusType, ServerChecksumType, ServerFFIDType, ServerRedactionType, TransferAgreementType, UploadType}
 
 class ConsignmentStatusServiceSpec extends AnyFlatSpec with MockitoSugar with ResetMocksAfterEachTest with Matchers with ScalaFutures with TableDrivenPropertyChecks {
   implicit val executionContext: ExecutionContext = ExecutionContext.Implicits.global
@@ -418,7 +403,7 @@ class ConsignmentStatusServiceSpec extends AnyFlatSpec with MockitoSugar with Re
   }
 
   "validStatusValues" should "contain the correct values" in {
-    val expectedValues = List(CompletedValue.value, CompletedWithIssuesValue.value, FailedValue.value, InProgressValue.value)
+    val expectedValues = List(CompletedValue.value, CompletedWithIssuesValue.value, FailedValue.value, InProgressValue.value, SkippedValue.value)
     validStatusValues.toList.sorted should equal(expectedValues)
   }
 


### PR DESCRIPTION
To allow frontend to add a `Skipped` status to the `draftmetadata` status when a user skips it