### PR TITLE
Generate and persist asset id in database

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,7 @@ libraryDependencies ++= Seq(
   "com.softwaremill.sttp.client3" %% "core" % "3.11.0",
   "uk.gov.nationalarchives" %% "consignment-api-db" % "0.1.58",
   "uk.gov.nationalarchives" %% "tdr-metadata-validation" % "0.0.236",
-  "org.postgresql" % "postgresql" % "42.7.12",
+  "org.postgresql" % "postgresql" % "42.7.13",
   "com.typesafe.slick" %% "slick" % "3.6.1",
   "com.typesafe.slick" %% "slick-hikaricp" % "3.6.1",
   "ch.qos.logback" % "logback-classic" % "1.5.37",

--- a/build.sbt
+++ b/build.sbt
@@ -40,8 +40,9 @@ graphqlSchemaSnippet := "uk.gov.nationalarchives.tdr.api.graphql.GraphQlTypes.sc
 
 lazy val pekkoVersion = "1.6.0"
 lazy val pekkoHttpVersion = "1.3.0"
-lazy val circeVersion = "0.14.15"
+lazy val circeVersion = "0.14.16"
 lazy val testContainersVersion = "0.44.1"
+lazy val awsSdkVersion = "2.47.0"
 
 libraryDependencies ++= Seq(
   "org.sangria-graphql" %% "sangria" % "4.2.18",
@@ -63,28 +64,28 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-generic-extras" % "0.14.4",
   "com.softwaremill.sttp.client3" %% "core" % "3.11.0",
-  "uk.gov.nationalarchives" %% "consignment-api-db" % "0.1.57",
-  "uk.gov.nationalarchives" %% "tdr-metadata-validation" % "0.0.232",
-  "org.postgresql" % "postgresql" % "42.7.11",
+  "uk.gov.nationalarchives" %% "consignment-api-db" % "0.1.58",
+  "uk.gov.nationalarchives" %% "tdr-metadata-validation" % "0.0.236",
+  "org.postgresql" % "postgresql" % "42.7.12",
   "com.typesafe.slick" %% "slick" % "3.6.1",
   "com.typesafe.slick" %% "slick-hikaricp" % "3.6.1",
-  "ch.qos.logback" % "logback-classic" % "1.5.34",
+  "ch.qos.logback" % "logback-classic" % "1.5.37",
   "net.logstash.logback" % "logstash-logback-encoder" % "9.0",
-  "software.amazon.awssdk" % "rds" % "2.46.10",
-  "software.amazon.awssdk" % "sts" % "2.46.10",
+  "software.amazon.awssdk" % "rds" % awsSdkVersion,
+  "software.amazon.awssdk" % "sts" % awsSdkVersion,
   "com.github.cb372" %% "scalacache-caffeine" % "0.28.0",
   "uk.gov.nationalarchives.oci" % "oci-tools-scala_2.13" % "0.4.0",
   "org.scalatest" %% "scalatest" % "3.2.20" % Test,
   "org.mockito" %% "mockito-scala" % "2.2.1" % Test,
   "org.mockito" %% "mockito-scala-scalatest" % "2.2.1" % Test,
   "com.tngtech.keycloakmock" % "mock" % "0.20.0" % Test,
-  "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.291",
+  "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.292",
   "io.github.hakky54" % "logcaptor" % "2.12.6" % Test,
   "com.dimafeng" %% "testcontainers-scala-scalatest" % testContainersVersion % Test,
   "com.dimafeng" %% "testcontainers-scala-postgresql" % testContainersVersion % Test,
   "com.github.tomakehurst" % "wiremock-standalone" % "3.0.1" % Test,
-  "uk.gov.nationalarchives" % "da-metadata-schema_2.13" % "0.0.133",
-  "uk.gov.nationalarchives" %% "tdr-statuses" % "0.0.32"
+  "uk.gov.nationalarchives" % "da-metadata-schema_2.13" % "0.0.136",
+  "uk.gov.nationalarchives" %% "tdr-statuses" % "0.0.36"
 )
 
 dependencyOverrides ++= Seq(

--- a/schema.graphql
+++ b/schema.graphql
@@ -280,6 +280,7 @@ type File {
   originalFilePath: String
   fileMetadata: [FileMetadataValue!]!
   fileStatuses: [FileStatus!]!
+  assetId: UUID
 }
 
 type FileCheckFailure {
@@ -364,6 +365,7 @@ type FileMetadataValues {
   foiExemptionAsserted: LocalDateTime
   titleClosed: Boolean
   descriptionClosed: Boolean
+  assetId: UUID
 }
 
 type FileMetadataWithFileId {

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataService.scala
@@ -107,6 +107,7 @@ object FileMetadataService {
   val HeldBy = "HeldBy"
   val Language = "Language"
   val FoiExemptionCode = "FoiExemptionCode"
+  val AssetId = "AssetId"
   val clientSideProperties: List[String] =
     List(SHA256ClientSideChecksum, ClientSideOriginalFilepath, ClientSideFileLastModifiedDate, ClientSideFileSize, Filename, FileType)
 
@@ -128,7 +129,8 @@ object FileMetadataService {
       propertyNameMap.get(ClosureStartDate).map(d => Timestamp.valueOf(d).toLocalDateTime),
       propertyNameMap.get(FoiExemptionAsserted).map(d => Timestamp.valueOf(d).toLocalDateTime),
       propertyNameMap.get(TitleClosed).map(_.toBoolean),
-      propertyNameMap.get(DescriptionClosed).map(_.toBoolean)
+      propertyNameMap.get(DescriptionClosed).map(_.toBoolean),
+      propertyNameMap.get(AssetId).map(UUID.fromString)
     )
   }
 
@@ -151,7 +153,8 @@ object FileMetadataService {
       antivirusMetadata: Option[AntivirusMetadata],
       originalFilePath: Option[String] = None,
       fileMetadata: List[FileMetadataValue] = Nil,
-      fileStatuses: List[FileStatus] = Nil
+      fileStatuses: List[FileStatus] = Nil,
+      assetId: Option[UUID] = None
   )
 
   case class FileMetadataValues(
@@ -168,7 +171,8 @@ object FileMetadataService {
       closureStartDate: Option[LocalDateTime],
       foiExemptionAsserted: Option[LocalDateTime],
       titleClosed: Option[Boolean],
-      descriptionClosed: Option[Boolean]
+      descriptionClosed: Option[Boolean],
+      assetId: Option[UUID]
   )
 
   val config: ConfigUtils.MetadataConfiguration = ConfigUtils.loadConfiguration

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/service/FileService.scala
@@ -70,10 +70,11 @@ class FileService(
         val parentId = parentNode.map(_.id)
         val parentFileReference = parentNode.flatMap(_.reference)
         val fileId = treeNode.id
-        val fileRow = createFileRow(userId, now, consignmentId, treeNode, parentId, parentFileReference, fileId)
+        val assetId = uuidSource.uuid
+        val fileRow = createFileRow(userId, now, consignmentId, treeNode, parentId, parentFileReference, fileId, assetId)
         val legalStatusMetadata = metadata.find(_.propertyname == LegalStatus).map(metadata => LegalStatus -> metadata.value).toMap
 
-        createFileRows(addFileAndMetadataInput, row, defaultPropertyValues, path, treeNode, parentFileReference, fileId, fileRow, legalStatusMetadata)
+        createFileRows(addFileAndMetadataInput, row, defaultPropertyValues, path, treeNode, parentFileReference, fileId, fileRow, legalStatusMetadata, assetId)
       }).toList)
       matchedFileRows <- generateMatchedRows(rows)
     } yield matchedFileRows
@@ -225,7 +226,8 @@ class FileService(
       parentFileReference: Option[Reference],
       fileId: UUID,
       fileRow: FileRow,
-      legalStatusMetadata: Map[String, String]
+      legalStatusMetadata: Map[String, String],
+      assetId: UUID
   ): Rows = {
 
     // Replace the default LegalStatus property value with the value from consignment metadata if it exists, otherwise keep the default values
@@ -240,7 +242,8 @@ class FileService(
       row(fileId, treeNode.treeNodeType, FileType),
       row(fileId, treeNode.name, Filename),
       row(fileId, treeNode.reference.getOrElse(""), FileReference),
-      row(fileId, parentFileReference.getOrElse(""), ParentReference)
+      row(fileId, parentFileReference.getOrElse(""), ParentReference),
+      row(fileId, assetId.toString, AssetId)
     ) ++ updatedDefaultPropertyValues
       .map(fileProperty => {
         row(fileId, fileProperty._2, tdrDataLoadHeaderToPropertyMapper(fileProperty._1))
@@ -266,7 +269,16 @@ class FileService(
     }
   }
 
-  private def createFileRow(userId: UUID, now: Timestamp, consignmentId: UUID, treeNode: TreeNode, parentId: Option[UUID], parentFileReference: Option[Reference], fileId: UUID) = {
+  private def createFileRow(
+      userId: UUID,
+      now: Timestamp,
+      consignmentId: UUID,
+      treeNode: TreeNode,
+      parentId: Option[UUID],
+      parentFileReference: Option[Reference],
+      fileId: UUID,
+      assetId: UUID
+  ) = {
     FileRow(
       fileId,
       consignmentId,
@@ -277,7 +289,8 @@ class FileService(
       parentid = parentId,
       filereference = treeNode.reference,
       parentreference = parentFileReference,
-      uploadmatchid = treeNode.matchId
+      uploadmatchid = treeNode.matchId,
+      assetid = Some(assetId)
     )
   }
 }
@@ -336,7 +349,8 @@ object FileService {
             avMetadata.find(_.fileId == fileId),
             fmr.find(_._2.exists(_.propertyname == "OriginalFilepath")).flatMap(_._2.map(_.value)),
             filterMetadataRows(metadataRows, metadataPropertyNames).toList,
-            statuses
+            statuses,
+            fr.assetid
           )
         }
         .toSeq
@@ -359,7 +373,11 @@ object FileService {
     ): Seq[File] = {
       fileRows.map(fr => {
         val id = fr.fileid
-        val metadata = fileMetadata.getOrElse(id, FileMetadataValues(None, None, None, None, None, None, None, None, None, None, None, None, None, None))
+        val assetId = fr.assetid
+        val metadata = fileMetadata.getOrElse(
+          id,
+          FileMetadataValues(None, None, None, None, None, None, None, None, None, None, None, None, None, None, None)
+        )
         val statuses = fileStatuses.filter(_.fileId == id)
         File(
           id,
@@ -373,7 +391,8 @@ object FileService {
           ffidStatus.get(id),
           ffidMetadata.find(_.fileId == id),
           avMetadata.find(_.fileId == id),
-          fileStatuses = statuses
+          fileStatuses = statuses,
+          assetId = assetId
         )
       })
     }

--- a/src/test/resources/json/getconsignment_data_all.json
+++ b/src/test/resources/json/getconsignment_data_all.json
@@ -73,53 +73,6 @@
           ]
         },
         {
-          "fileId": "e7ba59c9-5b8b-4029-9f27-2d03957463ad",
-          "fileType": "File",
-          "fileName": "fileOneName",
-          "fileReference": "REF1",
-          "parentId": "7b19b272-d4d1-4d77-bf25-511dc6489d12",
-          "parentReference": null,
-          "uploadMatchId": "1",
-          "fileStatus": "Success",
-          "metadata": {
-            "clientSideOriginalFilePath": "ClientSideOriginalFilepath value",
-            "legalStatus": "LegalStatus value",
-            "clientSideFileSize": 2,
-            "clientSideLastModifiedDate": "2021-03-11T12:30:30.592853",
-            "rightsCopyright": "RightsCopyright value",
-            "heldBy": "HeldBy value",
-            "foiExemptionCode": "FoiExemptionCode value",
-            "language": "Language value"
-          },
-          "ffidMetadata": {
-            "method": "TEST DATA method",
-            "softwareVersion": "TEST DATA software version",
-            "datetime": 1577869200000,
-            "software": "TEST DATA software",
-            "matches": [
-              {
-                "extension": "txt",
-                "identificationBasis": "TEST DATA identification",
-                "puid": "TEST DATA puid"
-              }
-            ],
-            "containerSignatureFileVersion": "TEST DATA container signature file version",
-            "binarySignatureFileVersion": "TEST DATA binary signature file version"
-          },
-          "fileStatuses": [
-            {
-              "fileId": "e7ba59c9-5b8b-4029-9f27-2d03957463ad",
-              "statusType": "ChecksumMatch",
-              "statusValue": "Failed"
-            },
-            {
-              "fileId": "e7ba59c9-5b8b-4029-9f27-2d03957463ad",
-              "statusType": "FFID",
-              "statusValue": "Success"
-            }
-          ]
-        },
-        {
           "fileId": "42910a85-85c3-40c3-888f-32f697bfadb6",
           "fileType": "File",
           "fileName": "fileTwoName",
@@ -221,6 +174,53 @@
             },
             {
               "fileId": "42910a85-85c3-40c3-888f-32f697bfadb6",
+              "statusType": "FFID",
+              "statusValue": "Success"
+            }
+          ]
+        },
+        {
+          "fileId": "e7ba59c9-5b8b-4029-9f27-2d03957463ad",
+          "fileType": "File",
+          "fileName": "fileOneName",
+          "fileReference": "REF1",
+          "parentId": "7b19b272-d4d1-4d77-bf25-511dc6489d12",
+          "parentReference": null,
+          "uploadMatchId": "1",
+          "fileStatus": "Success",
+          "metadata": {
+            "clientSideOriginalFilePath": "ClientSideOriginalFilepath value",
+            "legalStatus": "LegalStatus value",
+            "clientSideFileSize": 2,
+            "clientSideLastModifiedDate": "2021-03-11T12:30:30.592853",
+            "rightsCopyright": "RightsCopyright value",
+            "heldBy": "HeldBy value",
+            "foiExemptionCode": "FoiExemptionCode value",
+            "language": "Language value"
+          },
+          "ffidMetadata": {
+            "method": "TEST DATA method",
+            "softwareVersion": "TEST DATA software version",
+            "datetime": 1577869200000,
+            "software": "TEST DATA software",
+            "matches": [
+              {
+                "extension": "txt",
+                "identificationBasis": "TEST DATA identification",
+                "puid": "TEST DATA puid"
+              }
+            ],
+            "containerSignatureFileVersion": "TEST DATA container signature file version",
+            "binarySignatureFileVersion": "TEST DATA binary signature file version"
+          },
+          "fileStatuses": [
+            {
+              "fileId": "e7ba59c9-5b8b-4029-9f27-2d03957463ad",
+              "statusType": "ChecksumMatch",
+              "statusValue": "Failed"
+            },
+            {
+              "fileId": "e7ba59c9-5b8b-4029-9f27-2d03957463ad",
               "statusType": "FFID",
               "statusValue": "Success"
             }

--- a/src/test/resources/json/getconsignment_data_files_and_directories.json
+++ b/src/test/resources/json/getconsignment_data_files_and_directories.json
@@ -3,15 +3,6 @@
     "getConsignment": {
       "files": [
         {
-          "fileId": "2753ceca-4df3-436b-8891-78ad38e2e8c5",
-          "fileType": "Folder",
-          "fileReference": "REF2",
-          "parentReference": "REF1",
-          "metadata": {
-            "clientSideOriginalFilePath": "directory"
-          }
-        },
-        {
           "fileId": "6420152a-aaf2-4401-a309-f67ae35f5702",
           "fileType": "File",
           "fileReference": "REF3",
@@ -25,6 +16,15 @@
           "fileType": "Folder",
           "fileReference": "REF1",
           "parentReference": null,
+          "metadata": {
+            "clientSideOriginalFilePath": "directory"
+          }
+        },
+        {
+          "fileId": "2753ceca-4df3-436b-8891-78ad38e2e8c5",
+          "fileType": "Folder",
+          "fileReference": "REF2",
+          "parentReference": "REF1",
           "metadata": {
             "clientSideOriginalFilePath": "directory"
           }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepositorySpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/ConsignmentRepositorySpec.scala
@@ -30,6 +30,7 @@ import java.sql.Timestamp
 import java.time.{Instant, ZoneOffset, ZonedDateTime}
 import java.util.UUID
 import scala.concurrent.ExecutionContext
+import scala.util.Random
 
 class ConsignmentRepositorySpec extends TestContainerUtils with ScalaFutures with Matchers {
   implicit val executionContext: ExecutionContext = ExecutionContext.Implicits.global
@@ -92,11 +93,11 @@ class ConsignmentRepositorySpec extends TestContainerUtils with ScalaFutures wit
     val consignmentId = UUID.fromString("b59a8bfd-5709-46c7-a5e9-71bae146e2f1")
     val seriesId = UUID.fromString("9e2e2a51-c2d0-4b99-8bef-2ca322528861")
     val bodyId = UUID.fromString("6e3b76c4-1745-4467-8ac5-b4dd736e1b3e")
-    val seriesCode = "MOCK1"
+    val seriesCode = UUID.randomUUID().toString
     val utils = TestUtils(db)
     utils.addTransferringBody(bodyId, "Test", "Test")
     utils.addSeries(seriesId, bodyId, seriesCode)
-    utils.createConsignment(consignmentId, userId)
+    utils.createConsignment(consignmentId, userId, seriesId = seriesId)
 
     val consignmentSeries = consignmentRepository.getSeriesOfConsignment(consignmentId).futureValue.head
 

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileRepositorySpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/db/repository/FileRepositorySpec.scala
@@ -15,8 +15,8 @@ import java.sql.Timestamp
 import java.time.{Instant, ZoneOffset, ZonedDateTime}
 import java.util.UUID
 import scala.concurrent.ExecutionContext
-import uk.gov.nationalarchives.tdr.common.utils.statuses.StatusTypes.{UploadType}
-import uk.gov.nationalarchives.tdr.common.utils.statuses.StatusValues.{InProgressValue}
+import uk.gov.nationalarchives.tdr.common.utils.statuses.StatusTypes.UploadType
+import uk.gov.nationalarchives.tdr.common.utils.statuses.StatusValues.InProgressValue
 
 class FileRepositorySpec extends TestContainerUtils with ScalaFutures with Matchers with TableDrivenPropertyChecks {
   implicit val executionContext: ExecutionContext = ExecutionContext.Implicits.global
@@ -33,10 +33,12 @@ class FileRepositorySpec extends TestContainerUtils with ScalaFutures with Match
     val fileRepository = new FileRepository(db)
     val consignmentId = UUID.fromString("94abafc4-165e-469b-ba93-eace3f224de5")
     val fileOneId = UUID.fromString("7499a278-2fec-4c47-92fb-dd9024c65d0d")
+    val fileOneAssetId = UUID.fromString("bedcab5f-1bd3-4188-877f-0d5cddbb78e1")
     val fileTwoId = UUID.fromString("e7d21444-0c62-4115-a4ad-320fd3d3dae3")
+    val fileTwoAssetId = UUID.fromString("14b957a3-c6d9-4250-9137-e6375f34ddf3")
     val fileRows = Seq(
-      FileRow(fileOneId, consignmentId, userId, Timestamp.from(Instant.now)),
-      FileRow(fileTwoId, consignmentId, userId, Timestamp.from(Instant.now))
+      FileRow(fileOneId, consignmentId, userId, Timestamp.from(Instant.now), assetid = Some(fileOneAssetId)),
+      FileRow(fileTwoId, consignmentId, userId, Timestamp.from(Instant.now), assetid = Some(fileTwoAssetId))
     )
     val consignmentStatusRow = ConsignmentstatusRow(
       UUID.fromString("ad5ac54c-6a67-4892-b8ac-120362df7917"),

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/ConsignmentRouteSpec.scala
@@ -1043,7 +1043,8 @@ class ConsignmentRouteSpec extends TestContainerUtils with Matchers with TestReq
     utils.createConsignment(new FixedUUIDSource().uuid, userId)
 
     val seriesId = "4252c920-b1ac-4b0a-9711-33409b8fae6e"
-    utils.addSeries(UUID.fromString(seriesId), fixedBodyId, "MOCK1")
+    val seriesCode = UUID.randomUUID().toString
+    utils.addSeries(UUID.fromString(seriesId), fixedBodyId, code = seriesCode)
 
     val expectedResponse: GraphqlMutationUpdateSeriesIdOfConsignment = expectedUpdateConsignmentSeriesIdMutationResponse("data_all")
     val response: GraphqlMutationUpdateSeriesIdOfConsignment =
@@ -1059,7 +1060,8 @@ class ConsignmentRouteSpec extends TestContainerUtils with Matchers with TestReq
     utils.createConsignment(new FixedUUIDSource().uuid, userId)
 
     val seriesId = "4252c920-b1ac-4b0a-9711-33409b8fae6b"
-    utils.addSeries(UUID.fromString(seriesId), fixedBodyId, "MOCK1")
+    val seriesCode = UUID.randomUUID().toString
+    utils.addSeries(UUID.fromString(seriesId), fixedBodyId, code = seriesCode)
 
     val expectedResponse: GraphqlMutationUpdateSeriesIdOfConsignment = expectedUpdateConsignmentSeriesIdMutationResponse("data_incorrect_body")
     val response: GraphqlMutationUpdateSeriesIdOfConsignment =

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
@@ -28,9 +28,9 @@ class FileRouteSpec extends TestContainerUtils with Matchers with TestRequest {
 
   case class GraphqlMutationDataFilesMetadata(data: Option[AddFilesAndMetadata], errors: List[GraphqlError] = Nil)
 
-  case class FileMatches(fileId: UUID, matchId: Long)
+  case class FileMatches(fileId: UUID, matchId: String)
 
-  case class File(fileId: UUID, fileType: Option[String], fileName: Option[String], parentId: Option[UUID])
+//  case class File(fileId: UUID, fileType: Option[String], fileName: Option[String], parentId: Option[UUID], assetId: Option[UUID])
 
   case class AddFilesAndMetadata(addFilesAndMetadata: List[FileMatches])
 
@@ -44,14 +44,14 @@ class FileRouteSpec extends TestContainerUtils with Matchers with TestRequest {
   "The api" should "add files and metadata entries for files and directories" in withContainers { case container: PostgreSQLContainer =>
     val consignmentId = UUID.fromString("c44f1b9b-1275-4bc3-831c-808c50a0222d")
     val utils = TestUtils(container.database)
-    (clientSideProperties ++ serverSideProperties ++ defaultMetadataProperties).foreach(utils.addFileProperty(_))
+    (clientSideProperties ++ serverSideProperties ++ defaultMetadataProperties).foreach(utils.addFileProperty)
     utils.createConsignment(consignmentId, userId)
 
     val referenceMockServer = getReferencesMockServer(4)
     val res = runTestMutationFileMetadata("mutation_alldata_2", validUserToken())
     val distinctDirectoryCount = 3
     val fileCount = 5
-    val expectedCount = ((FileUUID :: Filename :: FileType :: FileReference :: ParentReference :: defaultMetadataProperties).size * distinctDirectoryCount) +
+    val expectedCount = ((FileUUID :: Filename :: FileType :: FileReference :: ParentReference :: AssetId :: defaultMetadataProperties).size * distinctDirectoryCount) +
       (defaultMetadataProperties.size * fileCount) +
       (clientSideProperties.size * fileCount) +
       (serverSideProperties.size * fileCount) +
@@ -76,7 +76,7 @@ class FileRouteSpec extends TestContainerUtils with Matchers with TestRequest {
     val consignmentId = UUID.fromString("c44f1b9b-1275-4bc3-831c-808c50a0222d")
     val overrideUserId = userId
     val utils = TestUtils(container.database)
-    (clientSideProperties ++ serverSideProperties ++ defaultMetadataProperties).foreach(utils.addFileProperty(_))
+    (clientSideProperties ++ serverSideProperties ++ defaultMetadataProperties).foreach(utils.addFileProperty)
     utils.createConsignment(consignmentId, overrideUserId)
 
     val referenceMockServer = getReferencesMockServer(4)
@@ -95,7 +95,7 @@ class FileRouteSpec extends TestContainerUtils with Matchers with TestRequest {
       val consignmentId = UUID.fromString("c44f1b9b-1275-4bc3-831c-808c50a0222d")
       val differentUserId = UUID.randomUUID()
       val utils = TestUtils(container.database)
-      (clientSideProperties ++ serverSideProperties ++ defaultMetadataProperties).foreach(utils.addFileProperty(_))
+      (clientSideProperties ++ serverSideProperties ++ defaultMetadataProperties).foreach(utils.addFileProperty)
       utils.createConsignment(consignmentId, differentUserId)
 
       val referenceMockServer = getReferencesMockServer(4)
@@ -109,7 +109,7 @@ class FileRouteSpec extends TestContainerUtils with Matchers with TestRequest {
     val consignmentId = UUID.fromString("c44f1b9b-1275-4bc3-831c-808c50a0222d")
     val overrideUserId = userId
     val utils = TestUtils(container.database)
-    (clientSideProperties ++ serverSideProperties ++ defaultMetadataProperties).foreach(utils.addFileProperty(_))
+    (clientSideProperties ++ serverSideProperties ++ defaultMetadataProperties).foreach(utils.addFileProperty)
     utils.createConsignment(consignmentId, overrideUserId)
 
     val referenceMockServer = getReferencesMockServer(4)
@@ -122,7 +122,7 @@ class FileRouteSpec extends TestContainerUtils with Matchers with TestRequest {
   "The api" should "return file ids matched with sequence ids for addFilesAndMetadata" in withContainers { case container: PostgreSQLContainer =>
     val consignmentId = UUID.fromString("1cd5e07a-34c8-4751-8e81-98edd17d1729")
     val utils = TestUtils(container.database)
-    (clientSideProperties ++ serverSideProperties ++ defaultMetadataProperties).foreach(utils.addFileProperty(_))
+    (clientSideProperties ++ serverSideProperties ++ defaultMetadataProperties).foreach(utils.addFileProperty)
     utils.createConsignment(consignmentId, userId)
 
     val referenceMockServer = getReferencesMockServer(4)

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/routes/FileRouteSpec.scala
@@ -30,8 +30,6 @@ class FileRouteSpec extends TestContainerUtils with Matchers with TestRequest {
 
   case class FileMatches(fileId: UUID, matchId: String)
 
-//  case class File(fileId: UUID, fileType: Option[String], fileName: Option[String], parentId: Option[UUID], assetId: Option[UUID])
-
   case class AddFilesAndMetadata(addFilesAndMetadata: List[FileMatches])
 
   val runTestMutationFileMetadata: (String, OAuth2BearerToken) => GraphqlMutationDataFilesMetadata =

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileMetadataServiceSpec.scala
@@ -214,6 +214,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     val consignmentId = UUID.randomUUID()
     val fileIdOne = UUID.randomUUID()
     val fileIdTwo = UUID.randomUUID()
+    val fileTwoAssetId = UUID.randomUUID()
     val closureStartDate = Timestamp.from(Instant.parse("2020-01-01T09:00:00Z"))
     val foiExemptionAsserted = Timestamp.from(Instant.parse("2020-01-01T09:00:00Z"))
     val mockResponse = Future(
@@ -224,7 +225,8 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
         FilemetadataRow(UUID.randomUUID(), fileIdTwo, foiExemptionAsserted.toString, Timestamp.from(FixedTimeSource.now), UUID.randomUUID(), FoiExemptionAsserted),
         FilemetadataRow(UUID.randomUUID(), fileIdTwo, "true", Timestamp.from(FixedTimeSource.now), UUID.randomUUID(), TitleClosed),
         FilemetadataRow(UUID.randomUUID(), fileIdTwo, "true", Timestamp.from(FixedTimeSource.now), UUID.randomUUID(), DescriptionClosed),
-        FilemetadataRow(UUID.randomUUID(), fileIdTwo, "1", Timestamp.from(FixedTimeSource.now), UUID.randomUUID(), ClosurePeriod)
+        FilemetadataRow(UUID.randomUUID(), fileIdTwo, "1", Timestamp.from(FixedTimeSource.now), UUID.randomUUID(), ClosurePeriod),
+        FilemetadataRow(UUID.randomUUID(), fileIdTwo, fileTwoAssetId.toString, Timestamp.from(FixedTimeSource.now), UUID.randomUUID(), AssetId)
       )
     )
 
@@ -244,6 +246,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     response(fileIdTwo).titleClosed.get should equal(true)
     response(fileIdTwo).descriptionClosed.get should equal(true)
     response(fileIdTwo).foiExemptionAsserted.get should equal(foiExemptionAsserted.toLocalDateTime)
+    response(fileIdTwo).assetId.get should equal(fileTwoAssetId)
   }
 
   "getSumOfFileSizes" should "return the sum of the file sizes" in {
@@ -286,6 +289,7 @@ class FileMetadataServiceSpec extends AnyFlatSpec with MockitoSugar with Matcher
     FileMetadataService.Language shouldEqual "Language"
     FileMetadataService.FoiExemptionCode shouldEqual "FoiExemptionCode"
     FileMetadataService.FileUUID shouldEqual "UUID"
+    FileMetadataService.AssetId shouldEqual "AssetId"
   }
 
   private class AddOrUpdateBulkMetadataTestSetUp() {

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/service/FileServiceSpec.scala
@@ -177,24 +177,24 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     val parentFolder = files.find(_.fileId == parentFolderId).get
     parentFolder.fileName.get shouldBe "folderName"
     parentFolder.uploadMatchId shouldBe None
-    parentFolder.metadata shouldBe FileMetadataValues(None, None, None, None, None, None, None, None, None, None, None, None, None, None)
+    parentFolder.metadata shouldBe FileMetadataValues(None, None, None, None, None, None, None, None, None, None, None, None, None, None, None)
 
     val fileOne = files.find(_.fileId == fileId1).get
     fileOne.fileName.get shouldBe "fileOneName"
     fileOne.uploadMatchId.get shouldBe "1"
-    fileOne.metadata shouldBe FileMetadataValues(Some("checksum"), None, Some(timestamp.toLocalDateTime), None, None, None, None, None, None, None, None, None, None, None)
+    fileOne.metadata shouldBe FileMetadataValues(Some("checksum"), None, Some(timestamp.toLocalDateTime), None, None, None, None, None, None, None, None, None, None, None, None)
     fileOne.originalFilePath.isDefined should be(false)
 
     val fileTwo = files.find(_.fileId == fileId2).get
     fileTwo.fileName.get shouldBe "fileTwoName"
     fileTwo.uploadMatchId.get shouldBe "2"
-    fileTwo.metadata shouldBe FileMetadataValues(Some("checksum"), None, Some(timestamp.toLocalDateTime), None, None, None, None, None, None, None, None, None, None, None)
+    fileTwo.metadata shouldBe FileMetadataValues(Some("checksum"), None, Some(timestamp.toLocalDateTime), None, None, None, None, None, None, None, None, None, None, None, None)
     fileTwo.originalFilePath.isDefined should be(false)
 
     val fileThree = files.find(_.fileId == fileIdThree).get
     fileThree.fileName.get shouldBe "fileThreeName"
     fileThree.uploadMatchId.get shouldBe "3"
-    fileThree.metadata shouldBe FileMetadataValues(None, None, Some(timestamp.toLocalDateTime), None, None, None, None, None, None, None, None, None, None, None)
+    fileThree.metadata shouldBe FileMetadataValues(None, None, Some(timestamp.toLocalDateTime), None, None, None, None, None, None, None, None, None, None, None, None)
     fileThree.originalFilePath.isDefined should be(false)
   }
 
@@ -248,6 +248,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
   "getFileMetadata" should "return the correct metadata with file statuses" in {
     val userId = UUID.randomUUID()
     val fileId = UUID.randomUUID()
+    val assetId = UUID.randomUUID()
     val fileRef = "FILEREF"
     val parentId = UUID.randomUUID()
     val parentRef = "REF1"
@@ -275,7 +276,8 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
         Some(parentId),
         Some(fileRef),
         Some(parentRef),
-        uploadmatchid = Some("1")
+        uploadmatchid = Some("1"),
+        assetid = Some(assetId)
       )
 
     val fileAndMetadataRows = Seq(
@@ -292,7 +294,8 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
       (fileRow, Some(fileMetadataRow(fileId, "ClosureStartDate", closureStartDate.toString))),
       (fileRow, Some(fileMetadataRow(fileId, "FoiExemptionAsserted", foiExemptionAsserted.toString))),
       (fileRow, Some(fileMetadataRow(fileId, "TitleClosed", "true"))),
-      (fileRow, Some(fileMetadataRow(fileId, DescriptionClosed, "true")))
+      (fileRow, Some(fileMetadataRow(fileId, DescriptionClosed, "true"))),
+      (fileRow, Some(fileMetadataRow(fileId, AssetId, assetId.toString)))
     )
 
     val mockAvMetadataResponse = Future(
@@ -344,7 +347,8 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
         Some(closureStartDate.toLocalDateTime),
         Some(foiExemptionAsserted.toLocalDateTime),
         Some(true),
-        Some(true)
+        Some(true),
+        Some(assetId)
       ),
       Some("Success"),
       Some(
@@ -362,7 +366,8 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
       Option(AntivirusMetadata(fileId, "software", "softwareVersion", "databaseVersion", "result", timestamp.getTime)),
       None,
       fileMetadata,
-      mockFileStatuses.map(p => FileStatus(p.fileid, p.statustype, p.value)).toList
+      mockFileStatuses.map(p => FileStatus(p.fileid, p.statustype, p.value)).toList,
+      assetId = Some(assetId)
     )
 
     actualFileMetadata should equal(expectedFileMetadata)
@@ -409,7 +414,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
       None,
       None,
       None,
-      FileMetadataValues(None, None, None, None, None, None, None, None, None, None, None, None, None, None),
+      FileMetadataValues(None, None, None, None, None, None, None, None, None, None, None, None, None, None, None),
       Some("Success"),
       Some(
         FFIDMetadata(
@@ -494,7 +499,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
       row.userid should equal(userId)
     })
 
-    val expectedSize = 71
+    val expectedSize = 76
     metadataRows.size should equal(expectedSize)
 
     defaultMetadataProperties.foreach(prop => {
@@ -571,7 +576,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
     })
     val file = fileRows.find(_.filereference.contains("ref4"))
     file.get.parentreference should equal(Some("ref2"))
-    val expectedSize = 71
+    val expectedSize = 76
     metadataRows.size should equal(expectedSize)
     defaultMetadataProperties.foreach(prop => {
       metadataRows.count(_.propertyname == prop) should equal(5)
@@ -648,7 +653,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
       row.consignmentid should equal(consignmentId)
       row.userid should equal(userId)
     })
-    val expectedSize = 45
+    val expectedSize = 48
     metadataRows.size should equal(expectedSize)
     defaultMetadataProperties.foreach(prop => {
       metadataRows.count(_.propertyname == prop) should equal(3)
@@ -719,7 +724,7 @@ class FileServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers with S
       row.consignmentid should equal(consignmentId)
       row.userid should equal(overrideUserId)
     })
-    val expectedSize = 71
+    val expectedSize = 76
     metadataRows.size should equal(expectedSize)
     defaultMetadataProperties.foreach(prop => {
       metadataRows.count(_.propertyname == prop) should equal(5)

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestUtils.scala
@@ -543,7 +543,7 @@ object TestUtils {
   case class Locations(column: Int, line: Int)
 
   val defaultFileId: UUID = UUID.fromString("07a3a4bd-0281-4a6d-a4c1-8fa3239e1313")
-  val serverSideProperties: List[String] = List(FileUUID, FileReference, ParentReference)
+  val serverSideProperties: List[String] = List(FileUUID, FileReference, ParentReference, AssetId)
   val defaultMetadataProperties: List[String] = List(RightsCopyright, LegalStatus, HeldBy, Language, ClosureType, DescriptionClosed, TitleClosed)
   val defaultCopyright: String = "Crown Copyright"
   val defaultLegalStatus: String = "Public Record"

--- a/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/api/utils/TestUtils.scala
@@ -234,10 +234,11 @@ class TestUtils(db: JdbcBackend#Database) {
       userId: UUID = userId,
       fileRef: Option[String] = None,
       parentRef: Option[String] = None,
-      uploadMatchId: Option[String] = None
+      uploadMatchId: Option[String] = None,
+      assetId: Option[UUID] = None
   ): Unit = {
     val sql =
-      s"""INSERT INTO "File" ("FileId", "ConsignmentId", "UserId", "Datetime", "FileType", "FileName", "ParentId", "FileReference", "ParentReference", "UploadMatchId") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
+      s"""INSERT INTO "File" ("FileId", "ConsignmentId", "UserId", "Datetime", "FileType", "FileName", "ParentId", "FileReference", "ParentReference", "UploadMatchId", "AssetId") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
     val ps: PreparedStatement = connection.prepareStatement(sql)
     ps.setObject(1, fileId, Types.OTHER)
     ps.setObject(2, consignmentId, Types.OTHER)
@@ -249,6 +250,7 @@ class TestUtils(db: JdbcBackend#Database) {
     ps.setString(8, fileRef.orNull)
     ps.setString(9, parentRef.orNull)
     ps.setString(10, uploadMatchId.orNull)
+    ps.setObject(11, assetId.orNull, Types.OTHER)
     ps.executeUpdate()
   }
 


### PR DESCRIPTION
Requires PR: https://github.com/nationalarchives/tdr-consignment-export/pull/1963

DR2 has concept of an asset to support where there are multiple digital objects associated with a single record.

This is modelled using an asset id.

To ensure idempotency TDR should generate and add the asset id when creating entries for uploaded digital objects

Current process on export is to use the TDR 'file id' as the asset id and generate an ephemeral id for the digital object id (file id)

On a re-export this causes DR2 errors because the ephemeral id is re-generated and not persisted